### PR TITLE
Prototype applying georchestra access rules

### DIFF
--- a/src/main/java/org/georchestra/gateway/config/RoleBasedAccessRule.java
+++ b/src/main/java/org/georchestra/gateway/config/RoleBasedAccessRule.java
@@ -19,14 +19,13 @@
 package org.georchestra.gateway.config;
 
 import java.util.List;
-import java.util.regex.Pattern;
 
 import lombok.Data;
 
 @Data
 public class RoleBasedAccessRule {
 
-    private List<Pattern> interceptUrl;
+    private List<String> interceptUrl;
     private boolean anonymous;
-    private List<String> allowedRoles;
+    private List<String> allowedRoles = List.of();
 }


### PR DESCRIPTION
Note the patterns changed from Pattern to String
to use Ant patterns instead of Java regex.

Rule uri's should be updated accordingly.