### PR TITLE
Package refactoring, load and apply service access rules

### DIFF
--- a/src/main/java/org/georchestra/gateway/autoconfigure/app/HeaderFiltersAutoConfiguration.java
+++ b/src/main/java/org/georchestra/gateway/autoconfigure/app/HeaderFiltersAutoConfiguration.java
@@ -16,12 +16,13 @@
  * You should have received a copy of the GNU General Public License along with
  * geOrchestra.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.georchestra.gateway.config;
+package org.georchestra.gateway.autoconfigure.app;
 
 import org.georchestra.gateway.filter.headers.AddSecHeadersGatewayFilterFactory;
 import org.georchestra.gateway.filter.headers.RemoveHeadersGatewayFilterFactory;
 import org.georchestra.gateway.filter.headers.RemoveSecurityHeadersGatewayFilterFactory;
 import org.georchestra.gateway.filter.headers.StandardSecurityHeadersProvider;
+import org.georchestra.gateway.model.GatewayConfigProperties;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.gateway.config.GatewayAutoConfiguration;
@@ -30,8 +31,8 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
-@EnableConfigurationProperties(GatewayConfigProperties.class)
 @AutoConfigureBefore(GatewayAutoConfiguration.class)
+@EnableConfigurationProperties(GatewayConfigProperties.class)
 public class HeaderFiltersAutoConfiguration {
 
     /**

--- a/src/main/java/org/georchestra/gateway/autoconfigure/app/RoutePredicateFactoriesAutoConfiguration.java
+++ b/src/main/java/org/georchestra/gateway/autoconfigure/app/RoutePredicateFactoriesAutoConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 by the geOrchestra PSC
+ * Copyright (C) 2021 by the geOrchestra PSC
  *
  * This file is part of geOrchestra.
  *
@@ -16,28 +16,19 @@
  * You should have received a copy of the GNU General Public License along with
  * geOrchestra.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.georchestra.gateway.filter.headers;
+package org.georchestra.gateway.autoconfigure.app;
 
-import java.net.URI;
-import java.util.function.Consumer;
-
+import org.georchestra.gateway.handler.predicate.QueryParamRoutePredicateFactory;
 import org.georchestra.gateway.model.GatewayConfigProperties;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.HttpHeaders;
-import org.springframework.web.server.ServerWebExchange;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 
-public class StandardSecurityHeadersProvider implements HeaderProvider {
+@Configuration
+@EnableConfigurationProperties(GatewayConfigProperties.class)
+public class RoutePredicateFactoriesAutoConfiguration {
 
-    private @Autowired GatewayConfigProperties config;
-
-    @Override
-    public Consumer<HttpHeaders> prepare(ServerWebExchange exchange) {
-        return headers -> {
-            URI uri = exchange.getRequest().getURI();
-            String path = uri.getPath();
-            GatewayConfigProperties c = config;
-            System.err.println(uri);
-        };
+    public @Bean QueryParamRoutePredicateFactory queryParamRoutePredicateFactory() {
+        return new QueryParamRoutePredicateFactory();
     }
-
 }

--- a/src/main/java/org/georchestra/gateway/autoconfigure/security/LdapSecurityAutoConfiguration.java
+++ b/src/main/java/org/georchestra/gateway/autoconfigure/security/LdapSecurityAutoConfiguration.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2022 by the geOrchestra PSC
+ *
+ * This file is part of geOrchestra.
+ *
+ * geOrchestra is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * geOrchestra is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * geOrchestra.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.georchestra.gateway.autoconfigure.security;
+
+import javax.annotation.PostConstruct;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.ldap.core.LdapTemplate;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Configuration(proxyBeanMethods = false)
+@ConditionalOnClass(LdapTemplate.class)
+@Import({ LdapSecurityAutoConfiguration.Enabled.class, LdapSecurityAutoConfiguration.Disabled.class })
+@Slf4j(topic = "org.georchestra.gateway.autoconfigure.security.ldap")
+public class LdapSecurityAutoConfiguration {
+
+    private static final String ENABLED_PROP = "georchestra.gateway.security.ldap.enabled";
+
+    @Configuration(proxyBeanMethods = false)
+    @ConditionalOnProperty(name = ENABLED_PROP, havingValue = "true", matchIfMissing = false)
+    @Import(org.georchestra.gateway.security.ldap.LdapSecurityConfiguration.class)
+    static class Enabled {
+
+        public @PostConstruct void log() {
+            log.info("georchestra LDAP security enabled");
+        }
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    @ConditionalOnProperty(name = ENABLED_PROP, havingValue = "false", matchIfMissing = true)
+    static class Disabled {
+
+        public @PostConstruct void log() {
+            log.info("georchestra LDAP security disabled");
+        }
+    }
+}

--- a/src/main/java/org/georchestra/gateway/autoconfigure/security/OAuth2SecurityAutoConfiguration.java
+++ b/src/main/java/org/georchestra/gateway/autoconfigure/security/OAuth2SecurityAutoConfiguration.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2021 by the geOrchestra PSC
+ *
+ * This file is part of geOrchestra.
+ *
+ * geOrchestra is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * geOrchestra is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * geOrchestra.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.georchestra.gateway.autoconfigure.security;
+
+import javax.annotation.PostConstruct;
+
+import org.georchestra.gateway.security.oauth2.OAuth2Configuration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Configuration(proxyBeanMethods = false)
+@Slf4j(topic = "org.georchestra.gateway.autoconfigure.security.ldap")
+@Import({ OAuth2SecurityAutoConfiguration.Enabled.class, OAuth2SecurityAutoConfiguration.Disabled.class })
+public class OAuth2SecurityAutoConfiguration {
+    private static final String ENABLED_PROP = "georchestra.gateway.security.oauth2.enabled";
+
+    @Import(OAuth2Configuration.class)
+    @ConditionalOnProperty(name = ENABLED_PROP, havingValue = "true", matchIfMissing = false)
+    static @Configuration class Enabled {
+        public @PostConstruct void log() {
+            log.info("georchestra OAuth2 security enabled");
+        }
+    }
+
+    @ConditionalOnProperty(name = ENABLED_PROP, havingValue = "false", matchIfMissing = true)
+    static @Configuration class Disabled {
+        public @PostConstruct void log() {
+            log.info("georchestra OAuth2 security disabled");
+        }
+    }
+}

--- a/src/main/java/org/georchestra/gateway/autoconfigure/security/WebSecurityAutoConfiguration.java
+++ b/src/main/java/org/georchestra/gateway/autoconfigure/security/WebSecurityAutoConfiguration.java
@@ -16,24 +16,16 @@
  * You should have received a copy of the GNU General Public License along with
  * geOrchestra.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.georchestra.gateway.config;
+package org.georchestra.gateway.autoconfigure.security;
 
-import java.net.URL;
-import java.util.List;
+import org.georchestra.gateway.security.GatewaySecurityConfiguration;
+import org.georchestra.gateway.security.accessrules.AccessRulesConfiguration;
+import org.springframework.boot.autoconfigure.security.ConditionalOnDefaultWebSecurity;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
 
-import lombok.Data;
-
-@Data
-public class Service {
-    /**
-     * Back end service URL
-     */
-    private URL target;
-
-    /**
-     * Service-specific security headers configuration
-     */
-    private HeaderMappings headers;
-
-    private List<RoleBasedAccessRule> accessRules;
+@Configuration(proxyBeanMethods = false)
+@ConditionalOnDefaultWebSecurity
+@Import({ GatewaySecurityConfiguration.class, AccessRulesConfiguration.class })
+public class WebSecurityAutoConfiguration {
 }

--- a/src/main/java/org/georchestra/gateway/filter/headers/AddSecHeadersGatewayFilterFactory.java
+++ b/src/main/java/org/georchestra/gateway/filter/headers/AddSecHeadersGatewayFilterFactory.java
@@ -26,7 +26,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-import org.georchestra.gateway.config.GatewayConfigProperties;
+import org.georchestra.gateway.model.GatewayConfigProperties;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cloud.gateway.filter.GatewayFilter;
 import org.springframework.cloud.gateway.filter.GatewayFilterChain;

--- a/src/main/java/org/georchestra/gateway/model/GatewayConfigProperties.java
+++ b/src/main/java/org/georchestra/gateway/model/GatewayConfigProperties.java
@@ -16,7 +16,7 @@
  * You should have received a copy of the GNU General Public License along with
  * geOrchestra.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.georchestra.gateway.config;
+package org.georchestra.gateway.model;
 
 import java.util.Collections;
 import java.util.List;

--- a/src/main/java/org/georchestra/gateway/model/HeaderMappings.java
+++ b/src/main/java/org/georchestra/gateway/model/HeaderMappings.java
@@ -16,7 +16,7 @@
  * You should have received a copy of the GNU General Public License along with
  * geOrchestra.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.georchestra.gateway.config;
+package org.georchestra.gateway.model;
 
 import java.util.Optional;
 

--- a/src/main/java/org/georchestra/gateway/model/RoleBasedAccessRule.java
+++ b/src/main/java/org/georchestra/gateway/model/RoleBasedAccessRule.java
@@ -16,15 +16,16 @@
  * You should have received a copy of the GNU General Public License along with
  * geOrchestra.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.georchestra.gateway.handler.predicate;
+package org.georchestra.gateway.model;
 
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
+import java.util.List;
 
-@Configuration
-public class RoutePredicateFactoriesAutoConfiguration {
+import lombok.Data;
 
-    public @Bean QueryParamRoutePredicateFactory queryParamRoutePredicateFactory() {
-        return new QueryParamRoutePredicateFactory();
-    }
+@Data
+public class RoleBasedAccessRule {
+
+    private List<String> interceptUrl;
+    private boolean anonymous;
+    private List<String> allowedRoles = List.of();
 }

--- a/src/main/java/org/georchestra/gateway/model/Service.java
+++ b/src/main/java/org/georchestra/gateway/model/Service.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 by the geOrchestra PSC
+ * Copyright (C) 2021 by the geOrchestra PSC
  *
  * This file is part of geOrchestra.
  *
@@ -16,17 +16,24 @@
  * You should have received a copy of the GNU General Public License along with
  * geOrchestra.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.georchestra.gateway.security;
+package org.georchestra.gateway.model;
 
-import org.springframework.boot.context.properties.ConfigurationProperties;
+import java.net.URL;
+import java.util.List;
 
 import lombok.Data;
 
-@ConfigurationProperties(prefix = "georchestra.gateway.security.oauth2.proxy")
-public @Data class OAuth2ProxyConfigProperties {
-    private boolean enabled;
-    private String host;
-    private Integer port;
-    private String username;
-    private String password;
+@Data
+public class Service {
+    /**
+     * Back end service URL
+     */
+    private URL target;
+
+    /**
+     * Service-specific security headers configuration
+     */
+    private HeaderMappings headers;
+
+    private List<RoleBasedAccessRule> accessRules;
 }

--- a/src/main/java/org/georchestra/gateway/security/GatewaySecurityConfiguration.java
+++ b/src/main/java/org/georchestra/gateway/security/GatewaySecurityConfiguration.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2021 by the geOrchestra PSC
+ *
+ * This file is part of geOrchestra.
+ *
+ * geOrchestra is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * geOrchestra is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * geOrchestra.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.georchestra.gateway.security;
+
+import java.util.List;
+
+import org.georchestra.gateway.model.GatewayConfigProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.reactive.EnableWebFluxSecurity;
+import org.springframework.security.config.web.server.ServerHttpSecurity;
+import org.springframework.security.web.server.SecurityWebFilterChain;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Configuration(proxyBeanMethods = false)
+@EnableWebFluxSecurity
+@EnableConfigurationProperties(GatewayConfigProperties.class)
+@Slf4j(topic = "org.georchestra.gateway.security")
+public class GatewaySecurityConfiguration {
+
+    @Bean
+    public SecurityWebFilterChain securityWebFilterChain(ServerHttpSecurity http, GatewayConfigProperties config,
+            List<ServerHttpSecurityCustomizer> customizers) throws Exception {
+
+        // disable csrf and cors or the websocket connection gets a 403 Forbidden.
+        // Revisit.
+        http.csrf().disable().cors().disable();
+
+        customizers.forEach(customizer -> {
+            log.debug("Applying security customizer " + customizer.getName());
+            customizer.customize(http);
+        });
+
+//		http.authorizeExchange()//
+//				.pathMatchers("/", "/header/**").permitAll()//
+//				.pathMatchers("/ws/**").permitAll()//
+//				.pathMatchers("/**").authenticated();
+
+        return http.build();
+    }
+}

--- a/src/main/java/org/georchestra/gateway/security/ServerHttpSecurityCustomizer.java
+++ b/src/main/java/org/georchestra/gateway/security/ServerHttpSecurityCustomizer.java
@@ -1,0 +1,11 @@
+package org.georchestra.gateway.security;
+
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.web.server.ServerHttpSecurity;
+
+public interface ServerHttpSecurityCustomizer extends Customizer<ServerHttpSecurity> {
+
+    default String getName() {
+        return getClass().getCanonicalName();
+    }
+}

--- a/src/main/java/org/georchestra/gateway/security/accessrules/AccessRulesConfiguration.java
+++ b/src/main/java/org/georchestra/gateway/security/accessrules/AccessRulesConfiguration.java
@@ -16,28 +16,19 @@
  * You should have received a copy of the GNU General Public License along with
  * geOrchestra.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.georchestra.gateway.filter.headers;
-
-import java.net.URI;
-import java.util.function.Consumer;
+package org.georchestra.gateway.security.accessrules;
 
 import org.georchestra.gateway.model.GatewayConfigProperties;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.HttpHeaders;
-import org.springframework.web.server.ServerWebExchange;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 
-public class StandardSecurityHeadersProvider implements HeaderProvider {
+@Configuration
+@EnableConfigurationProperties(GatewayConfigProperties.class)
+public class AccessRulesConfiguration {
 
-    private @Autowired GatewayConfigProperties config;
-
-    @Override
-    public Consumer<HttpHeaders> prepare(ServerWebExchange exchange) {
-        return headers -> {
-            URI uri = exchange.getRequest().getURI();
-            String path = uri.getPath();
-            GatewayConfigProperties c = config;
-            System.err.println(uri);
-        };
+    @Bean
+    AccessRulesCustomizer georchestraAccessRulesCustomizer(GatewayConfigProperties config) {
+        return new AccessRulesCustomizer(config);
     }
-
 }

--- a/src/main/java/org/georchestra/gateway/security/accessrules/AccessRulesCustomizer.java
+++ b/src/main/java/org/georchestra/gateway/security/accessrules/AccessRulesCustomizer.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2022 by the geOrchestra PSC
+ *
+ * This file is part of geOrchestra.
+ *
+ * geOrchestra is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * geOrchestra is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * geOrchestra.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.georchestra.gateway.security.accessrules;
+
+import java.util.List;
+
+import org.georchestra.gateway.model.GatewayConfigProperties;
+import org.georchestra.gateway.model.RoleBasedAccessRule;
+import org.georchestra.gateway.security.ServerHttpSecurityCustomizer;
+import org.springframework.security.config.web.server.ServerHttpSecurity;
+import org.springframework.security.config.web.server.ServerHttpSecurity.AuthorizeExchangeSpec;
+import org.springframework.security.config.web.server.ServerHttpSecurity.AuthorizeExchangeSpec.Access;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@RequiredArgsConstructor
+@Slf4j(topic = "org.georchestra.gateway.config.security.accessrules")
+public class AccessRulesCustomizer implements ServerHttpSecurityCustomizer {
+
+    private final GatewayConfigProperties config;
+
+    @Override
+    public void customize(ServerHttpSecurity http) {
+        log.info("Configuring proxied applications access rules...");
+
+        AuthorizeExchangeSpec authorizeExchange = http.authorizeExchange();
+
+        log.info("Applying global access rules...");
+        apply(authorizeExchange, config.getGlobalAccessRules());
+
+        config.getServices().forEach((name, service) -> {
+            log.info("Applying access rules for backend service '{}'", name);
+            apply(authorizeExchange, service.getAccessRules());
+        });
+    }
+
+    private void apply(AuthorizeExchangeSpec authorizeExchange, List<RoleBasedAccessRule> accessRules) {
+        if (accessRules == null || accessRules.isEmpty()) {
+            log.info("No access rules found.");
+            return;
+        }
+        for (RoleBasedAccessRule rule : accessRules) {
+            apply(authorizeExchange, rule);
+        }
+    }
+
+    private void apply(AuthorizeExchangeSpec authorizeExchange, RoleBasedAccessRule rule) {
+        List<String> antPatterns = rule.getInterceptUrl();
+        boolean anonymous = rule.isAnonymous();
+        List<String> allowedRoles = rule.getAllowedRoles();
+        Access access = authorizeExchange.pathMatchers(antPatterns.toArray(String[]::new));
+        if (anonymous) {
+            log.info("Access rule: {} anonymous", antPatterns);
+            access.permitAll();
+        } else if (null != allowedRoles) {
+            log.info("Access rule: {} has any role: {}", antPatterns, allowedRoles);
+            access.hasAnyAuthority(allowedRoles.toArray(String[]::new));
+        }
+    }
+}

--- a/src/main/java/org/georchestra/gateway/security/ldap/LdapConfigProperties.java
+++ b/src/main/java/org/georchestra/gateway/security/ldap/LdapConfigProperties.java
@@ -18,6 +18,8 @@
  */
 package org.georchestra.gateway.security.ldap;
 
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
 import lombok.Data;
 
 /**
@@ -38,6 +40,7 @@ import lombok.Data;
  * </pre>
  */
 @Data
+@ConfigurationProperties(prefix = "georchestra.gateway.security.ldap")
 public class LdapConfigProperties {
 
     private String url;

--- a/src/main/java/org/georchestra/gateway/security/oauth2/OAuth2ProxyConfigProperties.java
+++ b/src/main/java/org/georchestra/gateway/security/oauth2/OAuth2ProxyConfigProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 by the geOrchestra PSC
+ * Copyright (C) 2022 by the geOrchestra PSC
  *
  * This file is part of geOrchestra.
  *
@@ -16,16 +16,17 @@
  * You should have received a copy of the GNU General Public License along with
  * geOrchestra.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.georchestra.gateway.config;
+package org.georchestra.gateway.security.oauth2;
 
-import java.util.List;
+import org.springframework.boot.context.properties.ConfigurationProperties;
 
 import lombok.Data;
 
-@Data
-public class RoleBasedAccessRule {
-
-    private List<String> interceptUrl;
-    private boolean anonymous;
-    private List<String> allowedRoles = List.of();
+@ConfigurationProperties(prefix = "georchestra.gateway.security.oauth2.proxy")
+public @Data class OAuth2ProxyConfigProperties {
+    private boolean enabled;
+    private String host;
+    private Integer port;
+    private String username;
+    private String password;
 }

--- a/src/main/resources/META-INF/spring.factories
+++ b/src/main/resources/META-INF/spring.factories
@@ -1,6 +1,7 @@
 # Auto Configure
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-org.georchestra.gateway.security.GatewaySecurityAutoconfiguration,\
-org.georchestra.gateway.security.ldap.LdapSecurityAutoConfiguration,\
-org.georchestra.gateway.handler.predicate.RoutePredicateFactoriesAutoConfiguration,\
-org.georchestra.gateway.config.HeaderFiltersAutoConfiguration
+org.georchestra.gateway.autoconfigure.security.WebSecurityAutoConfiguration,\
+org.georchestra.gateway.autoconfigure.security.LdapSecurityAutoConfiguration,\
+org.georchestra.gateway.autoconfigure.security.OAuth2SecurityAutoConfiguration,\
+org.georchestra.gateway.autoconfigure.app.HeaderFiltersAutoConfiguration,\
+org.georchestra.gateway.autoconfigure.app.RoutePredicateFactoriesAutoConfiguration

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -16,6 +16,7 @@ georchestra:
   gateway:
     security:
       oauth2:
+        enabled: true
         proxy:
           enabled: false
           host: localhost
@@ -23,7 +24,7 @@ georchestra:
           username: jack
           password: insecure
       ldap:
-        enabled: true
+        enabled: false
         url: ${ldapScheme}://${ldapHost}:${ldapPort}
         baseDn: ${ldapBaseDn:dc=georchestra,dc=org}
         usersRdn: ${ldapUsersRdn:ou=users}

--- a/src/main/resources/gateway.yml
+++ b/src/main/resources/gateway.yml
@@ -89,12 +89,11 @@ georchestra:
         access-rules:
         - intercept-url: /geoserver/**
           anonymous: true
-          allowed-roles: ADMINISTRATOR
       geofence:
         target: http://geofence:8080/geofence/
         access-rules:
         - intercept-url: /geofence/**
-          allowed-roles: ROLE_ADMINISTRATOR
+          allowed-roles: ADMINISTRATOR
       header: 
         target: http://header:8080/header/
         access-rules:

--- a/src/main/resources/gateway.yml
+++ b/src/main/resources/gateway.yml
@@ -19,6 +19,7 @@ georchestra:
     - intercept-url: .*(\?|&amp;)login.*
       allowed-roles: USER,GN_EDITOR,GN_REVIEWER,GN_ADMIN,ADMINISTRATOR,SUPERUSER,ORGADMIN
     - intercept-url:
+      - /
       - .*
       - /proxy/\?url=.*
       anonymous: true
@@ -85,13 +86,20 @@ georchestra:
           json-user: true
       geoserver: 
         target: http://geoserver:8080/geoserver/
+        access-rules:
+        - intercept-url: /geoserver/**
+          anonymous: true
+          allowed-roles: ADMINISTRATOR
       geofence:
         target: http://geofence:8080/geofence/
         access-rules:
-        - intercept-url: /geofence/.*
-          allowed-roles: ADMINISTRATOR
+        - intercept-url: /geofence/**
+          allowed-roles: ROLE_ADMINISTRATOR
       header: 
         target: http://header:8080/header/
+        access-rules:
+        - intercept-url: /header/**
+          anonymous: true
       mapfishapp: 
         target: http://mapfishapp:8080/mapfishapp/
       geowebcache: 
@@ -122,9 +130,10 @@ georchestra:
 # to debug this app directly from the IDE
 spring.config.activate.on-profile: dev
 georchestra.gateway:
-  security.ldap:
-    enabled: true
-    url: ldap://localhost:3891
+  security:
+    ldap:
+      enabled: true
+      url: ldap://localhost:3891
   services:
     header.target: http://localhost:10003/header/
     mapfishapp.target: http://localhost:10004/mapfishapp/

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -1,0 +1,12 @@
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n
+            </pattern>
+        </encoder>
+    </appender>
+    <root level="error">
+        <appender-ref ref="STDOUT"/>
+    </root>
+    <logger name="org.georchestra" level="info"/>
+</configuration>


### PR DESCRIPTION
Refactor auto-configuration and business packages.

Load access rules defines for services, only global rules were defined.

TODO: all `intercept-url` attributes in `gateway.yaml` need to
be converted to Ant patterns.