### PR TITLE
Fix access rules order and add integration tests

### DIFF
--- a/gateway/pom.xml
+++ b/gateway/pom.xml
@@ -14,6 +14,16 @@
     <imageTag>${project.version}</imageTag>
     <spring-boot.build-image.imageName>georchestra/gateway:${imageTag}</spring-boot.build-image.imageName>
   </properties>
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>com.github.tomakehurst</groupId>
+        <artifactId>wiremock-jre8</artifactId>
+        <!-- override provided version 2.26.3 -->
+        <version>2.33.1</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
   <dependencies>
     <dependency>
       <groupId>org.georchestra</groupId>
@@ -70,13 +80,33 @@
       <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>
     </dependency>
-    <!-- <dependency> -->
-    <!-- <groupId>org.springframework.security</groupId> -->
-    <!-- <artifactId>spring-security-test</artifactId> -->
-    <!-- <scope>test</scope> -->
-    <!-- </dependency> -->
+    <dependency>
+      <groupId>com.github.tomakehurst</groupId>
+      <artifactId>wiremock-jre8</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.security</groupId>
+      <artifactId>spring-security-test</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-failsafe-plugin</artifactId>
+          <!-- override provided version 2.22.2 -->
+          <version>3.0.0-M6</version>
+        </plugin>
+        <plugin>
+          <groupId>org.jacoco</groupId>
+          <artifactId>jacoco-maven-plugin</artifactId>
+          <version>0.8.8</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
     <plugins>
       <plugin>
         <groupId>net.revelc.code.formatter</groupId>
@@ -175,6 +205,18 @@
         </configuration>
       </plugin>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <executions>
+          <execution>
+            <goals>
+              <goal>integration-test</goal>
+              <goal>verify</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>
         <executions>
@@ -189,7 +231,6 @@
       <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
-        <version>0.8.8</version>
         <executions>
           <execution>
             <id>prepare-agent</id>

--- a/gateway/src/main/java/org/georchestra/gateway/filter/headers/HeaderContributor.java
+++ b/gateway/src/main/java/org/georchestra/gateway/filter/headers/HeaderContributor.java
@@ -31,6 +31,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.security.config.web.server.ServerHttpSecurity;
 import org.springframework.web.server.ServerWebExchange;
 
+import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 
 /**
@@ -44,7 +45,7 @@ import lombok.extern.slf4j.Slf4j;
  * @see GeorchestraUserHeadersContributor
  * @see GeorchestraOrganizationHeadersContributor
  */
-@Slf4j
+@Slf4j(topic = "org.georchestra.gateway.filter.headers")
 public abstract class HeaderContributor implements Ordered {
 
     /**
@@ -69,25 +70,37 @@ public abstract class HeaderContributor implements Ordered {
         return 0;
     }
 
-    protected void add(HttpHeaders target, String header, Optional<Boolean> enabled, Optional<String> value) {
+    protected void add(@NonNull HttpHeaders target, @NonNull String header, @NonNull Optional<Boolean> enabled,
+            @NonNull Optional<String> value) {
         add(target, header, enabled, value.orElse(null));
     }
 
-    protected void add(HttpHeaders target, String header, Optional<Boolean> enabled, List<String> values) {
-        add(target, header, enabled, values.stream().collect(Collectors.joining(";")));
+    protected void add(@NonNull HttpHeaders target, @NonNull String header, @NonNull Optional<Boolean> enabled,
+            @NonNull List<String> values) {
+        String val = values.isEmpty() ? null : values.stream().collect(Collectors.joining(";"));
+        add(target, header, enabled, val);
     }
 
-    protected void add(HttpHeaders target, String header, Optional<Boolean> enabled, String value) {
+    protected void add(@NonNull HttpHeaders target, @NonNull String header, @NonNull Optional<Boolean> enabled,
+            String value) {
         if (enabled.orElse(Boolean.FALSE).booleanValue()) {
             if (null == value) {
-                log.debug("Value for header {} is not present", header);
+                log.trace("Value for header {} is not present", header);
             } else {
                 log.debug("Appending header {}: {}", header, value);
                 target.add(header, value);
             }
         } else {
-            log.debug("Header {} is not enabled", header);
+            log.trace("Header {} is not enabled", header);
         }
     }
 
+    protected void add(@NonNull HttpHeaders target, @NonNull String header, String value) {
+        if (null == value) {
+            log.trace("Value for header {} is not present", header);
+        } else {
+            log.debug("Appending header {}: {}", header, value);
+            target.add(header, value);
+        }
+    }
 }

--- a/gateway/src/main/java/org/georchestra/gateway/filter/headers/HeaderContributor.java
+++ b/gateway/src/main/java/org/georchestra/gateway/filter/headers/HeaderContributor.java
@@ -82,7 +82,7 @@ public abstract class HeaderContributor implements Ordered {
             if (null == value) {
                 log.debug("Value for header {} is not present", header);
             } else {
-                log.info("Appending header {}: {}", header, value);
+                log.debug("Appending header {}: {}", header, value);
                 target.add(header, value);
             }
         } else {

--- a/gateway/src/main/java/org/georchestra/gateway/filter/headers/HeaderFiltersConfiguration.java
+++ b/gateway/src/main/java/org/georchestra/gateway/filter/headers/HeaderFiltersConfiguration.java
@@ -19,11 +19,13 @@
 package org.georchestra.gateway.filter.headers;
 
 import java.util.List;
+import java.util.function.BooleanSupplier;
 
 import org.georchestra.gateway.filter.headers.providers.GeorchestraOrganizationHeadersContributor;
 import org.georchestra.gateway.filter.headers.providers.GeorchestraUserHeadersContributor;
 import org.georchestra.gateway.filter.headers.providers.JsonPayloadHeadersContributor;
 import org.georchestra.gateway.filter.headers.providers.SecProxyHeaderContributor;
+import org.georchestra.gateway.model.GatewayConfigProperties;
 import org.springframework.cloud.gateway.filter.factory.GatewayFilterFactory;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
@@ -51,8 +53,9 @@ public class HeaderFiltersConfiguration {
         return new GeorchestraUserHeadersContributor();
     }
 
-    public @Bean SecProxyHeaderContributor secProxyHeaderProvider() {
-        return new SecProxyHeaderContributor();
+    public @Bean SecProxyHeaderContributor secProxyHeaderProvider(GatewayConfigProperties configProps) {
+        BooleanSupplier secProxyEnabledSupplier = () -> configProps.getDefaultHeaders().getProxy().orElse(false);
+        return new SecProxyHeaderContributor(secProxyEnabledSupplier);
     }
 
     public @Bean GeorchestraOrganizationHeadersContributor organizationSecurityHeadersProvider() {

--- a/gateway/src/main/java/org/georchestra/gateway/filter/headers/RemoveHeadersGatewayFilterFactory.java
+++ b/gateway/src/main/java/org/georchestra/gateway/filter/headers/RemoveHeadersGatewayFilterFactory.java
@@ -60,7 +60,7 @@ import lombok.extern.slf4j.Slf4j;
  * </pre>
  * 
  */
-@Slf4j(topic = "org.georchestra.gateway.headers")
+@Slf4j(topic = "org.georchestra.gateway.filter.headers")
 public class RemoveHeadersGatewayFilterFactory extends AbstractGatewayFilterFactory<RegExConfig> {
 
     public RemoveHeadersGatewayFilterFactory() {
@@ -119,7 +119,7 @@ public class RemoveHeadersGatewayFilterFactory extends AbstractGatewayFilterFact
         void removeMatching(@NonNull HttpHeaders headers) {
             new HashSet<>(headers.keySet()).stream()//
                     .filter(this::matches)//
-                    .peek(name -> log.debug("Removing header {}", name))//
+                    .peek(name -> log.trace("Removing header {}", name))//
                     .forEach(headers::remove);
         }
     }

--- a/gateway/src/main/java/org/georchestra/gateway/filter/headers/providers/SecProxyHeaderContributor.java
+++ b/gateway/src/main/java/org/georchestra/gateway/filter/headers/providers/SecProxyHeaderContributor.java
@@ -18,22 +18,30 @@
  */
 package org.georchestra.gateway.filter.headers.providers;
 
+import java.util.function.BooleanSupplier;
 import java.util.function.Consumer;
 
 import org.georchestra.gateway.filter.headers.HeaderContributor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.web.server.ServerWebExchange;
 
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+
 /**
- * Unconditionally contributes the {@literal sec-proxy: true} request header,
- * which is required by all backend services as a flag indicating the request is
- * authenticated.
+ * Contributes the {@literal sec-proxy: true} request header based on the value
+ * returned by the provided {@link BooleanSupplier}, which is required by all
+ * backend services as a flag indicating the request is authenticated.
  */
+@RequiredArgsConstructor
 public class SecProxyHeaderContributor extends HeaderContributor {
+
+    private final @NonNull BooleanSupplier secProxyHeaderEnabled;
 
     public @Override Consumer<HttpHeaders> prepare(ServerWebExchange exchange) {
         return headers -> {
-            headers.add("sec-proxy", "true");
+            if (secProxyHeaderEnabled.getAsBoolean())
+                add(headers, "sec-proxy", "true");
         };
     }
 }

--- a/gateway/src/main/java/org/georchestra/gateway/model/RoleBasedAccessRule.java
+++ b/gateway/src/main/java/org/georchestra/gateway/model/RoleBasedAccessRule.java
@@ -46,6 +46,12 @@ public class RoleBasedAccessRule {
     private List<String> interceptUrl = List.of();
 
     /**
+     * Highest precedence rule, if {@code true}, forbids access to the intercepted
+     * URLs
+     */
+    private boolean forbidden = false;
+
+    /**
      * Whether anonymous (unauthenticated) access is to be granted to the
      * intercepted URIs. If {@code true}, no further specification is applied to the
      * intercepted urls (i.e. if set, {@link #allowedRoles} are ignored). If

--- a/gateway/src/main/java/org/georchestra/gateway/security/ResolveGeorchestraUserGlobalFilter.java
+++ b/gateway/src/main/java/org/georchestra/gateway/security/ResolveGeorchestraUserGlobalFilter.java
@@ -47,7 +47,7 @@ import reactor.core.publisher.Mono;
  * @see GeorchestraUserMapper
  */
 @RequiredArgsConstructor
-@Slf4j
+@Slf4j(topic = "org.georchestra.gateway.security")
 public class ResolveGeorchestraUserGlobalFilter implements GlobalFilter, Ordered {
 
     public static final int ORDER = RouteToRequestUrlFilter.ROUTE_TO_URL_FILTER_ORDER + 1;

--- a/gateway/src/main/java/org/georchestra/gateway/security/oauth2/OAuth2AuthenticationTokenOpenIDUserMapper.java
+++ b/gateway/src/main/java/org/georchestra/gateway/security/oauth2/OAuth2AuthenticationTokenOpenIDUserMapper.java
@@ -39,7 +39,7 @@ import lombok.extern.slf4j.Slf4j;
  * @author groldan
  *
  */
-@Slf4j
+@Slf4j(topic = "org.georchestra.gateway.security.oauth2")
 public class OAuth2AuthenticationTokenOpenIDUserMapper extends OAuth2AuthenticationTokenUserMapper {
 
     @Override

--- a/gateway/src/main/java/org/georchestra/gateway/security/oauth2/OAuth2AuthenticationTokenUserMapper.java
+++ b/gateway/src/main/java/org/georchestra/gateway/security/oauth2/OAuth2AuthenticationTokenUserMapper.java
@@ -26,7 +26,6 @@ import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
-import org.georchestra.gateway.model.GeorchestraUsers;
 import org.georchestra.gateway.security.GeorchestraUserMapperExtension;
 import org.georchestra.security.model.GeorchestraUser;
 import org.slf4j.Logger;

--- a/gateway/src/main/java/org/georchestra/gateway/security/oauth2/OAuth2AuthenticationTokenUserMapper.java
+++ b/gateway/src/main/java/org/georchestra/gateway/security/oauth2/OAuth2AuthenticationTokenUserMapper.java
@@ -41,7 +41,7 @@ import lombok.extern.slf4j.Slf4j;
  * @author groldan
  *
  */
-@Slf4j
+@Slf4j(topic = "org.georchestra.gateway.security.oauth2")
 public class OAuth2AuthenticationTokenUserMapper implements GeorchestraUserMapperExtension {
 
     @Override

--- a/gateway/src/main/resources/application.yml
+++ b/gateway/src/main/resources/application.yml
@@ -191,8 +191,8 @@ logging:
     root: warn
     '[org.springframework]': info
     '[org.springframework.cloud.gateway]': info
-    '[org.springframework.security]': debug
+    '[org.springframework.security]': info
     '[org.springframework.security.oauth2]': debug
     '[reactor.netty.http ]': debug
-    '[org.georchestra.gateway]': debug
+    '[org.georchestra.gateway]': info
     

--- a/gateway/src/main/resources/application.yml
+++ b/gateway/src/main/resources/application.yml
@@ -195,4 +195,10 @@ logging:
     '[org.springframework.security.oauth2]': debug
     '[reactor.netty.http ]': debug
     '[org.georchestra.gateway]': info
+    '[org.georchestra.gateway.filter.headers]': debug
+    '[org.georchestra.gateway.config.security]': debug
+    '[org.georchestra.gateway.config.security.accessrules]': debug
+    '[org.georchestra.gateway.security.ldap]': debug
+    '[org.georchestra.gateway.security.oauth2]': debug
+    
     

--- a/gateway/src/main/resources/gateway.yml
+++ b/gateway/src/main/resources/gateway.yml
@@ -12,16 +12,10 @@ georchestra:
       org: true
       orgname: true
     global-access-rules:
-    - intercept-url: .*/ogcproxy/.*
-      allowed-roles: NO_ONE
-    - intercept-url: /testPage
-      anonymous: false
-    - intercept-url: .*(\?|&amp;)login.*
-      allowed-roles: USER,GN_EDITOR,GN_REVIEWER,GN_ADMIN,ADMINISTRATOR,SUPERUSER,ORGADMIN
     - intercept-url:
-      - /
       - /**
-      - /proxy/\?url=.*
+      #TODO: implement proxy in gateaway, mirroring security-proxy's behavior
+      #- /proxy/\?url=.*
       anonymous: true
       # wonder what's the purpose of having several roles defined in security-proxy's security-mappings.xml
       # if anonymous access is granted:
@@ -68,7 +62,7 @@ georchestra:
         access-rules:
         - intercept-url: /extractorapp/admin*
           allowed-roles: ADMINISTRATOR
-        - intercept-url: /extractorapp/jobs/**)
+        - intercept-url: /extractorapp/jobs/**
           allowed-roles: ADMINISTRATOR
         - intercept-url: /extractorapp/**
           allowed-roles: EXTRACTORAPP
@@ -101,6 +95,11 @@ georchestra:
           anonymous: true
       mapfishapp: 
         target: http://mapfishapp:8080/mapfishapp/
+        access-rules:
+        - intercept-url: /mapfishapp/ogcproxy/**
+          forbidden: true
+        - intercept-url: /mapfishapp/**
+          anonymous: true
       geowebcache: 
         target: http://geowebcache:8080/geowebcache/
       mapstore: 

--- a/gateway/src/test/java/org/georchestra/gateway/filter/headers/providers/JsonPayloadHeadersContributorTest.java
+++ b/gateway/src/test/java/org/georchestra/gateway/filter/headers/providers/JsonPayloadHeadersContributorTest.java
@@ -105,7 +105,7 @@ class JsonPayloadHeadersContributorTest {
         org.setDescription("desc");
         org.setLastUpdated("123");
         org.setLinkage("http://test.com");
-        org.setMembers(List.of("homer", "march", "lisa", "bart", "maggie"));
+        org.setMembers(List.of("homer", "marge", "lisa", "bart", "maggie"));
         org.setNotes("notes");
         org.setPostalAddress("123 springfield");
 

--- a/gateway/src/test/java/org/georchestra/gateway/filter/headers/providers/SecProxyHeaderContributorTest.java
+++ b/gateway/src/test/java/org/georchestra/gateway/filter/headers/providers/SecProxyHeaderContributorTest.java
@@ -21,6 +21,7 @@ package org.georchestra.gateway.filter.headers.providers;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.Mockito.mock;
 
 import java.util.List;
@@ -39,11 +40,17 @@ class SecProxyHeaderContributorTest {
     @Test
     void test() {
         ServerWebExchange exchange = mock(ServerWebExchange.class);
-        Consumer<HttpHeaders> consumer = new SecProxyHeaderContributor().prepare(exchange);
+        Consumer<HttpHeaders> consumer = new SecProxyHeaderContributor(() -> true).prepare(exchange);
         assertNotNull(consumer);
         HttpHeaders headers = new HttpHeaders();
         consumer.accept(headers);
         assertEquals(List.of("true"), headers.get("sec-proxy"));
+
+        consumer = new SecProxyHeaderContributor(() -> false).prepare(exchange);
+        assertNotNull(consumer);
+        headers = new HttpHeaders();
+        consumer.accept(headers);
+        assertNull(headers.get("sec-proxy"));
     }
 
 }

--- a/gateway/src/test/java/org/georchestra/gateway/security/ResolveGeorchestraUserGlobalFilterTest.java
+++ b/gateway/src/test/java/org/georchestra/gateway/security/ResolveGeorchestraUserGlobalFilterTest.java
@@ -20,7 +20,6 @@
 package org.georchestra.gateway.security;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;

--- a/gateway/src/test/java/org/georchestra/gateway/security/accessrules/AccessRulesCustomizerIT.java
+++ b/gateway/src/test/java/org/georchestra/gateway/security/accessrules/AccessRulesCustomizerIT.java
@@ -1,0 +1,330 @@
+/*
+ * Copyright (C) 2022 by the geOrchestra PSC
+ *
+ * This file is part of geOrchestra.
+ *
+ * geOrchestra is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * geOrchestra is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * geOrchestra.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.georchestra.gateway.security.accessrules;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.noContent;
+import static com.github.tomakehurst.wiremock.client.WireMock.ok;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching;
+
+import java.net.URI;
+
+import org.georchestra.gateway.app.GeorchestraGatewayApplication;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.web.reactive.server.WebTestClient;
+
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
+
+/**
+ * Integration tests for {@link AccessRulesCustomizer} for the access rules in
+ * the default {@literal gateway.yml} config file.
+ *
+ */
+@SpringBootTest(classes = GeorchestraGatewayApplication.class, webEnvironment = WebEnvironment.MOCK)
+@AutoConfigureWebTestClient(timeout = "PT20S")
+@ActiveProfiles("it")
+class AccessRulesCustomizerIT {
+
+    @RegisterExtension
+    static WireMockExtension mockService = WireMockExtension.newInstance()
+            .options(new WireMockConfiguration().dynamicPort().dynamicHttpsPort()).build();
+
+    /**
+     * Configure the target service mappings to call the {@link #mockService} at its
+     * dynamically allocated port
+     * 
+     * @see #mockServiceTarget
+     */
+    @DynamicPropertySource
+    static void registerPgProperties(DynamicPropertyRegistry registry) {
+        mockServiceTarget(registry, "header", "/header");
+        mockServiceTarget(registry, "mapfishapp", "/mapfishapp");
+        mockServiceTarget(registry, "geoserver", "/geoserver");
+        mockServiceTarget(registry, "console", "/console");
+        mockServiceTarget(registry, "analytics", "/analytics");
+        mockServiceTarget(registry, "datafeeder", "/datafeeder");
+        mockServiceTarget(registry, "import", "/import");
+        mockServiceTarget(registry, "atlas", "/atlas");
+        mockServiceTarget(registry, "geowebcache", "/geowebcache");
+    }
+
+    /**
+     * Sets a {@literal georchestra.gateway.services.<service>.target} configuration
+     * property for the given {@code serviceName} to be mapped to the Wiremock
+     * server at the {@code targetBaseURI} uri.
+     * <p>
+     * For example, if the Wiremock service is at port 7654, for the
+     * {@literal header} service with {@literal /header} target URI, the config
+     * property would be:
+     * 
+     * <pre>
+     * {@code georchestra.gateway.services.header.target=http://localhost:7654/header}
+     * </pre>
+     * 
+     * @param registry      the dynamic property source to contribute to the
+     *                      application context's environment
+     * @param serviceName   the name of the service for a
+     *                      {@literal georchestra.gateway.services.<service>.target}
+     *                      property
+     * @param targetBaseURI the target URI to map the service target to the Wiremock
+     *                      instance
+     */
+    private static void mockServiceTarget(DynamicPropertyRegistry registry, String serviceName, String targetBaseURI) {
+        WireMockRuntimeInfo runtimeInfo = mockService.getRuntimeInfo();
+        String httpBaseUrl = runtimeInfo.getHttpBaseUrl();
+        String proxiedURI = URI.create(httpBaseUrl + "/" + targetBaseURI).normalize().toString();
+        String propertyName = String.format("georchestra.gateway.services.%s.target", serviceName);
+        registry.add(propertyName, () -> proxiedURI);
+    }
+
+    private @Autowired WebTestClient testClient;
+
+    /**
+     * <pre>
+     * {@code
+     * georchestra.gateway.services.header:
+     *  access-rules:
+     *  - intercept-url: /header/**
+     *    anonymous: true
+     * }
+     * </pre>
+     */
+    public @Test void testSimpleMapping_anonymous() {
+        mockService.stubFor(get(urlMatching("/header(/.*)?"))//
+                .withHeader("sec-proxy", equalTo("true"))//
+                .willReturn(ok()));
+
+        testClient.get().uri("/header").exchange().expectStatus().isOk();
+        testClient.get().uri("/header/img/logo.png").exchange().expectStatus().isOk();
+    }
+
+    /**
+     * Revisit: not sure how to force a 403 (Forbidden) instead of a redirect to the
+     * login page when not yet authenticated
+     * 
+     * <pre>
+     * {@code
+     * georchestra.gateway.services.mapfishapp: 
+     *   access-rules:
+     *   - intercept-url: /mapfishapp/ogcproxy/**
+     *     forbidden: true
+     *   - intercept-url: /**
+     *     anonymous: true
+     * }
+     */
+    public @Test void testMapfishApp_ogproxy_access_denied_to_anonymoys() {
+        mockService.stubFor(get(urlMatching("/mapfishapp/ogcproxy(/.*)?")).willReturn(ok()));
+        mockService.stubFor(get(urlMatching("/mapfishapp(/.*)?")).willReturn(ok()));
+
+        testClient.get().uri("/mapfishapp/ogcproxy")//
+                .exchange()//
+                .expectStatus().isFound()//
+                .expectHeader().location("/login");
+
+        testClient.get().uri("/mapfishapp/ogcproxy/test")//
+                .exchange()//
+                .expectStatus().isFound()//
+                .expectHeader().location("/login");
+
+        testClient.get().uri("/mapfishapp/should_be_ok")//
+                .exchange()//
+                .expectStatus().isOk();
+    }
+
+    /**
+     * <pre>
+     * {@code
+     * georchestra.gateway.services.mapfishapp: 
+     *   access-rules:
+     *   - intercept-url: /mapfishapp/ogcproxy/**
+     *     forbidden: true
+     *   - intercept-url: /**
+     *     anonymous: true
+     * }
+     */
+    @WithMockUser(authorities = { "ROLE_USER" })
+    public @Test void testMapfishApp_ogproxy_access_denied_to_authenticated_user() {
+        mockService.stubFor(get(urlMatching("/mapfishapp/ogcproxy(/.*)?")).willReturn(ok()));
+        mockService.stubFor(get(urlMatching("/mapfishapp(/.*)?")).willReturn(ok()));
+
+        testClient.get().uri("/mapfishapp/ogcproxy")//
+                .exchange()//
+                .expectStatus().isForbidden();
+
+        testClient.get().uri("/mapfishapp/ogcproxy/test")//
+                .exchange()//
+                .expectStatus().isForbidden();
+
+        testClient.get().uri("/mapfishapp/should_be_ok")//
+                .exchange()//
+                .expectStatus().isOk();
+    }
+
+    /**
+     * <pre>
+     * {@code
+     * georchestra.gateway.services.import: 
+     *   access-rules:
+     *   - intercept-url: /import/**
+     *     anonymous: false
+     * }
+     */
+    public @Test void testService_requires_authenticated_user_redirects_to_login_page() {
+        mockService.stubFor(get(urlMatching("/import(/.*)?")).willReturn(noContent()));
+
+        testClient.get().uri("/import")//
+                .exchange()//
+                .expectStatus().isFound()//
+                .expectHeader().location("/login");
+
+        testClient.get().uri("/import/any/thing")//
+                .exchange()//
+                .expectStatus().isFound()//
+                .expectHeader().location("/login");
+    }
+
+    /**
+     * <pre>
+     * {@code
+     * georchestra.gateway.services.import: 
+     *   access-rules:
+     *   - intercept-url: /import/**
+     *     anonymous: false
+     * }
+     */
+    @WithMockUser(authorities = { "ROLE_DOESNTMATTER" })
+    public @Test void testService_requires_any_authenticated_user() {
+        mockService.stubFor(get(urlMatching("/import(/.*)?")).willReturn(ok()));
+
+        testClient.get().uri("/import")//
+                .exchange()//
+                .expectStatus().isOk();
+
+        testClient.get().uri("/import/any/thing")//
+                .exchange()//
+                .expectStatus().isOk();
+    }
+
+    /**
+     * <pre>
+     * {@code
+     * georchestra.gateway.services.analytics: 
+     *   access-rules:
+     *   - intercept-url: /analytics/**
+     *     allowed-roles: SUPERUSER,ORGADMIN
+     * }
+     */
+    @WithMockUser(authorities = { "ROLE_USER", "ROLE_EDITOR" })
+    public @Test void testService_requires_specific_role_forbidden_for_non_matching_roles() {
+        mockService.stubFor(get(urlMatching("/analytics(/.*)?")).willReturn(ok()));
+
+        testClient.get().uri("/analytics")//
+                .exchange()//
+                .expectStatus().isForbidden();
+
+        testClient.get().uri("/analytics/any/thing")//
+                .exchange()//
+                .expectStatus().isForbidden();
+    }
+
+    /**
+     * <pre>
+     * {@code
+     * georchestra.gateway.services.analytics: 
+     *   access-rules:
+     *   - intercept-url: /analytics/**
+     *     allowed-roles: SUPERUSER,ORGADMIN
+     * }
+     */
+    @WithMockUser(authorities = { "ROLE_USER", "ROLE_ORGADMIN" })
+    public @Test void testService_requires_specific_role_allowed_for_matching_roles() {
+        mockService.stubFor(get(urlMatching("/analytics(/.*)?")).willReturn(ok()));
+
+        testClient.get().uri("/analytics")//
+                .exchange()//
+                .expectStatus().isOk();
+
+        testClient.get().uri("/analytics/any/thing")//
+                .exchange()//
+                .expectStatus().isOk();
+    }
+
+    /**
+     * <pre>
+     * {@code
+     * georchestra.gateway.services.analytics: 
+     *   access-rules:
+     *   - intercept-url: /analytics/**
+     *     allowed-roles: SUPERUSER,ORGADMIN
+     * }
+     */
+    public @Test void testService_requires_specific_roles_redirects_unauthenticated_to_login() {
+        mockService.stubFor(get(urlMatching("/analytics(/.*)?")).willReturn(ok()));
+
+        testClient.get().uri("/analytics")//
+                .exchange()//
+                .expectStatus().isFound()//
+                .expectHeader().location("/login");
+
+        testClient.get().uri("/analytics/any/thing")//
+                .exchange()//
+                .expectStatus().isFound()//
+                .expectHeader().location("/login");
+    }
+
+    /**
+     * <pre>
+     * {@code
+     *     georchestra.gateway:
+     * 	    global-access-rules:
+     * 	    - intercept-url:
+     * 	      - /**
+     * 	      anonymous: true
+     * 	    services:
+     * 	      atlas: 
+     * 	        target: http://atlas:8080/atlas/
+     * }
+     * </pre>
+     */
+    @Test
+    void testGlobalAccessRule() {
+        mockService.stubFor(get(urlMatching("/atlas(/.*)?")).willReturn(ok()));
+
+        testClient.get().uri("/atlas")//
+                .exchange()//
+                .expectStatus().isOk();
+
+        testClient.get().uri("/atlas/any/thing")//
+                .exchange()//
+                .expectStatus().isOk();
+    }
+}

--- a/gateway/src/test/resources/application-it.yml
+++ b/gateway/src/test/resources/application-it.yml
@@ -1,0 +1,15 @@
+# if in need of debugging what's going on with the proxied requests and the wiremock server,
+# set wiretap to true and logging levels to trace
+spring:
+  cloud:
+    gateway:
+      httpclient:
+        wiretap: false
+      httpserver:
+        wiretap: false
+
+logging:
+  level:
+    reactor.netty: info
+    org.springframework.cloud.gateway: info
+    org.georchestra.gateway.config.security.accessrules: info


### PR DESCRIPTION
Access rules were being applied in the wrong order,
global rules first and service rules after, leading
to the global `/**` rule matching service URLs that
it shouldn't.

Adds integration tests using WireMock.