### PR TITLE
Allow to specify LDAP's user search returned attributes

### DIFF
--- a/docs/authzn.adoc
+++ b/docs/authzn.adoc
@@ -88,6 +88,11 @@ is `ou=users,dc=georchestra,dc=org`, the RDN is `ou=users`.
 |Optional if `activeDirectory` is `true`, mandatory otherwise. Users search filter,
 e.g. `(uid={0})`.
 
+|`georchestra.gateway.security.ldap.[name].users.returningAttributes`
+|null
+|Specifies the attributes that will be returned as part of the search. null indicates
+that all attributes will be returned. An empty array indicates no attributes are returned.
+
 |`georchestra.gateway.security.ldap.[name].roles.rdn`
 |
 |Ignored for Active Directory, mandatory otherwise. Relative Distinguished Name of the "roles" LDAP organization unit. E.g. if the complete name (or DN) is `ou=roles,dc=georchestra,dc=org`,
@@ -128,6 +133,7 @@ georchestra:
           users:
             rdn: ${ldapUsersRdn:ou=users}
             searchFilter: ${ldapUserSearchFilter:(uid={0})}
+            returningAttributes: custom_id,isMemberOf
           roles:
             rdn: ${ldapRolesRdn:ou=roles}
             searchFilter: ${ldapRolesSearchFilter:(member={0})}

--- a/gateway/src/main/java/org/georchestra/gateway/security/ldap/LdapConfigBuilder.java
+++ b/gateway/src/main/java/org/georchestra/gateway/security/ldap/LdapConfigBuilder.java
@@ -44,6 +44,7 @@ class LdapConfigBuilder {
                 .baseDn(config.getBaseDn())//
                 .usersRdn(config.getUsers().getRdn())//
                 .usersSearchFilter(searchFilter)//
+                .returningAttributes(config.getUsers().getReturningAttributes())//
                 .rolesRdn(config.getRoles().getRdn())//
                 .rolesSearchFilter(config.getRoles().getSearchFilter())//
                 .adminDn(toOptional(config.getAdminDn()))//
@@ -59,6 +60,7 @@ class LdapConfigBuilder {
                 .baseDn(config.getBaseDn())//
                 .usersRdn(config.getUsers().getRdn())//
                 .usersSearchFilter(searchFilter)//
+                .returningAttributes(config.getUsers().getReturningAttributes())//
                 .rolesRdn(config.getRoles().getRdn())//
                 .rolesSearchFilter(config.getRoles().getSearchFilter())//
                 .orgsRdn(config.getOrgs().getRdn())//

--- a/gateway/src/main/java/org/georchestra/gateway/security/ldap/LdapConfigProperties.java
+++ b/gateway/src/main/java/org/georchestra/gateway/security/ldap/LdapConfigProperties.java
@@ -35,6 +35,7 @@ import org.springframework.validation.annotation.Validated;
 
 import lombok.Data;
 import lombok.Generated;
+import lombok.Setter;
 import lombok.experimental.Accessors;
 
 /**
@@ -139,6 +140,14 @@ public class LdapConfigProperties implements Validator {
          * (&(objectClass=user)(userPrincipalName={0})) for ActiveDirectory
          */
         private String searchFilter;
+
+        /**
+         * Specifies the attributes that will be returned as part of the search.
+         * <p>
+         * null indicates that all attributes will be returned. An empty array indicates
+         * no attributes are returned.
+         */
+        private @Setter String[] returningAttributes;
     }
 
     @Generated

--- a/gateway/src/main/java/org/georchestra/gateway/security/ldap/basic/BasicLdapAuthenticationConfiguration.java
+++ b/gateway/src/main/java/org/georchestra/gateway/security/ldap/basic/BasicLdapAuthenticationConfiguration.java
@@ -96,7 +96,7 @@ public class BasicLdapAuthenticationConfiguration {
                     .rolesSearchFilter(config.getRolesSearchFilter())//
                     .adminDn(config.getAdminDn().orElse(null))//
                     .adminPassword(config.getAdminPassword().orElse(null))//
-                    .build();
+                    .returningAttributes(config.getReturningAttributes()).build();
             return new BasicLdapAuthenticationProvider(config.getName(), provider);
         } catch (RuntimeException e) {
             throw new BeanCreationException(

--- a/gateway/src/main/java/org/georchestra/gateway/security/ldap/basic/LdapAuthenticatorProviderBuilder.java
+++ b/gateway/src/main/java/org/georchestra/gateway/security/ldap/basic/LdapAuthenticatorProviderBuilder.java
@@ -49,6 +49,9 @@ public class LdapAuthenticatorProviderBuilder {
     private @Setter String adminDn;
     private @Setter String adminPassword;
 
+    // null = all atts, empty == none
+    private @Setter String[] returningAttributes = null;
+
     public LdapAuthenticationProvider build() {
         requireNonNull(url, "url is not set");
         requireNonNull(baseDn, "baseDn is not set");
@@ -71,6 +74,8 @@ public class LdapAuthenticatorProviderBuilder {
     private BindAuthenticator ldapAuthenticator(BaseLdapPathContextSource contextSource) {
         FilterBasedLdapUserSearch search = new FilterBasedLdapUserSearch(userSearchBase, userSearchFilter,
                 contextSource);
+
+        search.setReturningAttributes(returningAttributes);
 
         BindAuthenticator authenticator = new BindAuthenticator(contextSource);
         authenticator.setUserSearch(search);

--- a/gateway/src/main/java/org/georchestra/gateway/security/ldap/basic/LdapServerConfig.java
+++ b/gateway/src/main/java/org/georchestra/gateway/security/ldap/basic/LdapServerConfig.java
@@ -43,6 +43,8 @@ public class LdapServerConfig {
     private @NonNull String usersSearchFilter;
     private @NonNull String rolesRdn;
     private @NonNull String rolesSearchFilter;
+    // null = all atts, empty == none
+    private String[] returningAttributes;
 
     private @NonNull Optional<String> adminDn;
     private @NonNull Optional<String> adminPassword;

--- a/gateway/src/main/java/org/georchestra/gateway/security/ldap/extended/ExtendedLdapAuthenticationConfiguration.java
+++ b/gateway/src/main/java/org/georchestra/gateway/security/ldap/extended/ExtendedLdapAuthenticationConfiguration.java
@@ -95,7 +95,7 @@ public class ExtendedLdapAuthenticationConfiguration {
                 .rolesSearchFilter(config.getRolesSearchFilter())//
                 .adminDn(config.getAdminDn().orElse(null))//
                 .adminPassword(config.getAdminPassword().orElse(null))//
-                .build();
+                .returningAttributes(config.getReturningAttributes()).build();
 
         return new GeorchestraLdapAuthenticationProvider(config.getName(), delegate);
     }

--- a/gateway/src/main/java/org/georchestra/gateway/security/ldap/extended/ExtendedLdapConfig.java
+++ b/gateway/src/main/java/org/georchestra/gateway/security/ldap/extended/ExtendedLdapConfig.java
@@ -39,6 +39,8 @@ public class ExtendedLdapConfig {
     private @NonNull String usersSearchFilter;
     private @NonNull String rolesRdn;
     private @NonNull String rolesSearchFilter;
+    // null = all atts, empty == none
+    private String[] returningAttributes;
 
     private @NonNull Optional<String> adminDn;
     private @NonNull Optional<String> adminPassword;


### PR DESCRIPTION
`users.returnedAttributes` specifies the attributes that
will be returned as part of the search.

`null` indicates that all attributes will be returned. An
empty array indicates no attributes are returned.