### PR TITLE
Added customizable login and logout pages

### DIFF
--- a/gateway/pom.xml
+++ b/gateway/pom.xml
@@ -35,6 +35,10 @@
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-thymeleaf</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-oauth2-client</artifactId>
     </dependency>
     <dependency>

--- a/gateway/src/main/java/org/georchestra/gateway/app/GeorchestraGatewayApplication.java
+++ b/gateway/src/main/java/org/georchestra/gateway/app/GeorchestraGatewayApplication.java
@@ -37,6 +37,7 @@ import org.springframework.stereotype.Controller;
 import org.springframework.util.unit.DataSize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.reactive.result.view.Rendering;
 import org.springframework.web.server.ServerWebExchange;
 
 import lombok.extern.slf4j.Slf4j;
@@ -68,6 +69,16 @@ public class GeorchestraGatewayApplication {
         return Mono.just(ret);
         // return principal == null ? Mono.empty() :
         // Mono.just(Map.of(principal.getClass().getCanonicalName(), principal));
+    }
+
+    @GetMapping(path = "/login", produces = "text/html")
+    public Mono<Rendering.Builder<?>> login(Authentication principal, ServerWebExchange exchange) {
+        return Mono.just(Rendering.view("login"));
+    }
+
+    @GetMapping(path = "/logout", produces = "text/html")
+    public Mono<Rendering.Builder<?>> logout(Authentication principal, ServerWebExchange exchange) {
+        return Mono.just(Rendering.view("logout"));
     }
 
     @EventListener(ApplicationReadyEvent.class)

--- a/gateway/src/main/java/org/georchestra/gateway/security/GatewaySecurityConfiguration.java
+++ b/gateway/src/main/java/org/georchestra/gateway/security/GatewaySecurityConfiguration.java
@@ -72,7 +72,8 @@ public class GatewaySecurityConfiguration {
         });
 
         log.info("Security filter chain initialized");
-        return http.build();
+
+        return http.formLogin().loginPage("/login").and().logout().logoutUrl("/logout").and().build();
     }
 
     private Stream<ServerHttpSecurityCustomizer> sortedCustomizers(List<ServerHttpSecurityCustomizer> customizers) {

--- a/gateway/src/main/resources/templates/login.html
+++ b/gateway/src/main/resources/templates/login.html
@@ -1,28 +1,28 @@
-<div>
-    <h2>Please Login</h2>
-    <br/>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <meta name="description" content="">
+    <meta name="author" content="">
+    <title>Please sign in</title>
+    <link href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-beta/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-/Y6pD6FV/Vv2HJnA6t+vslU6fwYXjCFtcEpHbNJ0lyAFsXTsjBbfaDjzALeQsN6M" crossorigin="anonymous">
+    <link href="https://getbootstrap.com/docs/4.0/examples/signin/signin.css" rel="stylesheet" crossorigin="anonymous"/>
+</head>
+<body>
+<div class="container">
+    <form class="form-signin" method="post" action="/login">
+        <h2 class="form-signin-heading">Please sign in</h2>
+        <p>
+            <label for="username" class="sr-only">Username</label>
+            <input type="text" id="username" name="username" class="form-control" placeholder="Username" required autofocus>
+        </p>
+        <p>
+            <label for="password" class="sr-only">Password</label>
+            <input type="password" id="password" name="password" class="form-control" placeholder="Password" required>
+        </p>
+        <button class="btn btn-lg btn-primary btn-block" type="submit">Sign in</button>
+    </form>
 </div>
-<div>
-    <h4><a th:href="/@{/oauth2/authorization/google}">Login with Google</a></h4>   
-</div>
-<div><p>OR</p></div>
-     
-<form th:action="@{/login}" method="post" style="max-width: 400px; margin: 0 auto;">
-<div class="border border-secondary rounded p-3">
-    <div th:if="${param.error}">
-        <p class="text-danger">Invalid username or password.</p>
-    </div>
-    <div th:if="${param.logout}">
-        <p class="text-warning">You have been logged out.</p>
-    </div>
-    <div>
-        <p><input type="email" name="email" required class="form-control" placeholder="E-mail" /></p>
-    </div>
-    <div>
-        <p><input type="password" name="pass" required class="form-control" placeholder="Password" /></p>
-    </div>
-    <div>
-        <p><input type="submit" value="Login" class="btn btn-primary" /></p>
-    </div>
-</div>
-</form>
+</body>
+</html>

--- a/gateway/src/main/resources/templates/logout.html
+++ b/gateway/src/main/resources/templates/logout.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <meta name="description" content="">
+    <meta name="author" content="">
+    <title>Confirm Log Out?</title>
+    <link href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-beta/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-/Y6pD6FV/Vv2HJnA6t+vslU6fwYXjCFtcEpHbNJ0lyAFsXTsjBbfaDjzALeQsN6M" crossorigin="anonymous">
+    <link href="https://getbootstrap.com/docs/4.0/examples/signin/signin.css" rel="stylesheet" crossorigin="anonymous"/>
+  </head>
+  <body>
+     <div class="container">
+      <form class="form-signin" method="post" action="/logout">
+        <h2 class="form-signin-heading">Are you sure you want to log out?</h2>
+        <button class="btn btn-lg btn-primary btn-block" type="submit">Log Out</button>
+      </form>
+    </div>
+  </body>
+</html>

--- a/gateway/src/test/java/org/georchestra/gateway/security/accessrules/AccessRulesCustomizerIT.java
+++ b/gateway/src/test/java/org/georchestra/gateway/security/accessrules/AccessRulesCustomizerIT.java
@@ -157,11 +157,11 @@ class AccessRulesCustomizerIT {
 
         testClient.get().uri("/mapfishapp/ogcproxy")//
                 .exchange()//
-                .expectStatus().isUnauthorized();
+                .expectStatus().isFound();
 
         testClient.get().uri("/mapfishapp/ogcproxy/somethingprivate")//
                 .exchange()//
-                .expectStatus().isUnauthorized();
+                .expectStatus().isFound();
 
         testClient.get().uri("/mapfishapp/somethingpublic")//
                 .exchange()//
@@ -211,11 +211,11 @@ class AccessRulesCustomizerIT {
 
         testClient.get().uri("/import")//
                 .exchange()//
-                .expectStatus().isUnauthorized();
+                .expectStatus().isFound();
 
         testClient.get().uri("/import/any/thing")//
                 .exchange()//
-                .expectStatus().isUnauthorized();
+                .expectStatus().isFound();
     }
 
     /**
@@ -298,11 +298,11 @@ class AccessRulesCustomizerIT {
 
         testClient.get().uri("/analytics")//
                 .exchange()//
-                .expectStatus().isUnauthorized();
+                .expectStatus().isFound();
 
         testClient.get().uri("/analytics/any/thing")//
                 .exchange()//
-                .expectStatus().isUnauthorized();
+                .expectStatus().isFound();
     }
 
     /**


### PR DESCRIPTION
Default HTML template for LDAP login is embedded in gateway source code

Custom Thymeleaf templates can be provided in a directory reachable by the gateway and specified using the Spring configuration key `spring.thymeleaf.prefix` which can be added in `gateway/security.yml` of datadir like this : 
`spring.thymeleaf.prefix: file:///path/to/templates/`
Trailing slash is important.

Some tests were expecting a 401 error when accessing resources unauthenticated. Code changes to allow customizable login page changed this behaviour, no longer returning 401 error but a 302 redirect to login page. After some research, it is not clear which behaviour is better, so for now I accepted the error code change and modified the tests in this way, but it may not be the right way.