### PR TITLE
Fix for OAuth2 providers using HS256 token algorithm

### DIFF
--- a/gateway/src/main/java/org/georchestra/gateway/app/GeorchestraGatewayApplication.java
+++ b/gateway/src/main/java/org/georchestra/gateway/app/GeorchestraGatewayApplication.java
@@ -80,7 +80,6 @@ public class GeorchestraGatewayApplication {
         // Mono.just(Map.of(principal.getClass().getCanonicalName(), principal));
     }
 
-
     @GetMapping(path = "/logout", produces = "text/html")
     public Mono<Rendering.Builder<?>> logout(Authentication principal, ServerWebExchange exchange) {
         return Mono.just(Rendering.view("logout"));


### PR DESCRIPTION
Added support for HS256 algorithm using the client-secret as the algorithm secret key. Theses providers do not need nor provide a jwt-set-uri.