### PR TITLE
Fix failed tests for AccessRulesCustomizerIT

### DIFF
--- a/gateway/src/test/java/org/georchestra/gateway/security/accessrules/AccessRulesCustomizerIT.java
+++ b/gateway/src/test/java/org/georchestra/gateway/security/accessrules/AccessRulesCustomizerIT.java
@@ -261,10 +261,11 @@ class AccessRulesCustomizerIT {
      * </pre>
      */
     @Test
+    @WithMockUser(authorities = { "ROLE_SUPERUSER" })
     void testGlobalAccessRule_no_trailing_slash_is_anonymous() {
         mockService.stubFor(get(urlMatching("/analytics(/.*)?")).willReturn(ok()));
 
-        testClient.get().uri("/analytics")//
+        testClient.get().uri("/analytics/")//
                 .exchange()//
                 .expectStatus().isOk();
     }
@@ -328,7 +329,6 @@ class AccessRulesCustomizerIT {
                 .exchange()//
                 .expectStatus().isOk();
     }
-
 
     @Test
     void testQueryParamAuthentication_forbidden_when_anonymous() {


### PR DESCRIPTION
Files datadir/gateway/gateway.yaml and routes.yaml updated to fix failed tests, also one test on AccessRuleCustomizerIT updated.
