### PR TITLE
local account creation for user connected with external identity provider

### DIFF
--- a/gateway/src/main/java/org/georchestra/gateway/filter/headers/providers/GeorchestraUserHeadersContributor.java
+++ b/gateway/src/main/java/org/georchestra/gateway/filter/headers/providers/GeorchestraUserHeadersContributor.java
@@ -61,7 +61,8 @@ public class GeorchestraUserHeadersContributor extends HeaderContributor {
                         add(headers, "sec-address", mappings.getAddress(), user.map(GeorchestraUser::getPostalAddress));
                         add(headers, "sec-title", mappings.getTitle(), user.map(GeorchestraUser::getTitle));
                         add(headers, "sec-notes", mappings.getNotes(), user.map(GeorchestraUser::getNotes));
-                        add(headers, "sec-ldap-remaining-days", user.map(GeorchestraUser::getLdapWarn),
+                        add(headers, "sec-ldap-remaining-days", Optional
+                                .of(user.isPresent() && user.get().getLdapWarn() != null && user.get().getLdapWarn()),
                                 user.map(GeorchestraUser::getLdapRemainingDays));
                     });
         };

--- a/gateway/src/main/java/org/georchestra/gateway/security/GatewaySecurityConfiguration.java
+++ b/gateway/src/main/java/org/georchestra/gateway/security/GatewaySecurityConfiguration.java
@@ -20,16 +20,14 @@ package org.georchestra.gateway.security;
 
 import lombok.extern.slf4j.Slf4j;
 import org.georchestra.gateway.model.GatewayConfigProperties;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.reactive.EnableWebFluxSecurity;
 import org.springframework.security.config.web.server.ServerHttpSecurity;
 import org.springframework.security.web.server.SecurityWebFilterChain;
-import org.springframework.security.web.server.authentication.RedirectServerAuthenticationFailureHandler;
-import org.springframework.security.web.server.util.matcher.ServerWebExchangeMatcher;
-import org.springframework.web.server.ServerWebExchange;
-import reactor.core.publisher.Mono;
+import org.springframework.security.web.server.authentication.logout.ServerLogoutSuccessHandler;
 
 import java.util.List;
 import java.util.Map;
@@ -50,7 +48,7 @@ import java.util.stream.Stream;
  */
 @Configuration(proxyBeanMethods = false)
 @EnableWebFluxSecurity
-@EnableConfigurationProperties(GatewayConfigProperties.class)
+@EnableConfigurationProperties({ GatewayConfigProperties.class })
 @Slf4j(topic = "org.georchestra.gateway.security")
 public class GatewaySecurityConfiguration {
 
@@ -59,6 +57,10 @@ public class GatewaySecurityConfiguration {
      * configure the different aspects of the {@link ServerHttpSecurity} used to
      * {@link ServerHttpSecurity#build build} the {@link SecurityWebFilterChain}.
      */
+
+    @Autowired
+    ServerLogoutSuccessHandler oidcLogoutSuccessHandler;
+
     @Bean
     public SecurityWebFilterChain securityWebFilterChain(ServerHttpSecurity http,
             List<ServerHttpSecurityCustomizer> customizers) throws Exception {
@@ -80,7 +82,8 @@ public class GatewaySecurityConfiguration {
 
         log.info("Security filter chain initialized");
 
-        return http.formLogin().loginPage("/login").and().logout().logoutUrl("/logout").and().build();
+        return http.formLogin().loginPage("/login").and().logout().logoutUrl("/logout")
+                .logoutSuccessHandler(oidcLogoutSuccessHandler).and().build();
     }
 
     private Stream<ServerHttpSecurityCustomizer> sortedCustomizers(List<ServerHttpSecurityCustomizer> customizers) {

--- a/gateway/src/main/java/org/georchestra/gateway/security/ldap/LdapConfigProperties.java
+++ b/gateway/src/main/java/org/georchestra/gateway/security/ldap/LdapConfigProperties.java
@@ -63,6 +63,8 @@ import lombok.experimental.Accessors;
 @ConfigurationProperties(prefix = "georchestra.gateway.security")
 public class LdapConfigProperties implements Validator {
 
+    private boolean createNonExistingUsersInLDAP = true;
+
     @Valid
     private Map<String, Server> ldap = Map.of();
 

--- a/gateway/src/main/java/org/georchestra/gateway/security/oauth2/ExtendedOAuth2ClientProperties.java
+++ b/gateway/src/main/java/org/georchestra/gateway/security/oauth2/ExtendedOAuth2ClientProperties.java
@@ -1,0 +1,34 @@
+package org.georchestra.gateway.security.oauth2;
+
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.boot.autoconfigure.security.oauth2.client.OAuth2ClientProperties;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@ConfigurationProperties(prefix = "spring.security.oauth2.client")
+public class ExtendedOAuth2ClientProperties implements InitializingBean {
+
+    private final Map<String, Provider> provider = new HashMap<>();
+
+    public Map<String, Provider> getProvider() {
+        return this.provider;
+    }
+
+    public static class Provider extends OAuth2ClientProperties.Provider {
+        private String endSessionUri;
+
+        public String getEndSessionUri() {
+            return this.endSessionUri;
+        }
+
+        public void setEndSessionUri(String endSessionUri) {
+            this.endSessionUri = endSessionUri;
+        }
+    }
+
+    @Override
+    public void afterPropertiesSet() {
+    }
+}

--- a/gateway/src/main/java/org/georchestra/gateway/security/oauth2/OpenIdConnectUserMapper.java
+++ b/gateway/src/main/java/org/georchestra/gateway/security/oauth2/OpenIdConnectUserMapper.java
@@ -19,16 +19,27 @@
 
 package org.georchestra.gateway.security.oauth2;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.georchestra.ds.DataServiceException;
+import org.georchestra.ds.roles.Role;
+import org.georchestra.ds.roles.RoleDao;
+import org.georchestra.ds.security.UserMapperImpl;
+import org.georchestra.ds.security.UsersApiImpl;
+import org.georchestra.ds.users.*;
+import org.georchestra.gateway.security.ldap.LdapConfigProperties;
 import org.georchestra.security.model.GeorchestraUser;
 import org.slf4j.Logger;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.core.Ordered;
 import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
 import org.springframework.security.oauth2.core.oidc.AddressStandardClaim;
@@ -129,8 +140,18 @@ import lombok.extern.slf4j.Slf4j;
  * </ul>
  */
 @RequiredArgsConstructor
+@EnableConfigurationProperties({ LdapConfigProperties.class })
 @Slf4j(topic = "org.georchestra.gateway.security.oauth2")
 public class OpenIdConnectUserMapper extends OAuth2UserMapper {
+
+    @Autowired
+    LdapConfigProperties config;
+
+    @Autowired(required = false)
+    private AccountDao accountDao;
+
+    @Autowired(required = false)
+    private RoleDao roleDao;
 
     private final @NonNull OpenIdConnectCustomClaimsConfigProperties nonStandardClaimsConfig;
 
@@ -144,18 +165,56 @@ public class OpenIdConnectUserMapper extends OAuth2UserMapper {
     }
 
     protected @Override Optional<GeorchestraUser> map(OAuth2AuthenticationToken token) {
+        if (config.isCreateNonExistingUsersInLDAP()) {
+            String oAuth2ProviderId = String.format("%s;%s", token.getAuthorizedClientRegistrationId(),
+                    token.getName());
 
-        GeorchestraUser user = super.map(token).orElseGet(GeorchestraUser::new);
+            UserMapperImpl mapper = new UserMapperImpl();
+            mapper.setRoleDao(roleDao);
+            List<String> protectedUsers = Collections.emptyList();
+            UserRule rule = new UserRule();
+            rule.setListOfprotectedUsers(protectedUsers.toArray(String[]::new));
+            UsersApiImpl usersApi = new UsersApiImpl();
+            usersApi.setAccountsDao(accountDao);
+            usersApi.setMapper(mapper);
+            usersApi.setUserRule(rule);
 
-        OidcUser oidcUser = (OidcUser) token.getPrincipal();
-        try {
-            applyStandardClaims((StandardClaimAccessor) oidcUser, user);
-            applyNonStandardClaims(oidcUser.getClaims(), user);
-        } catch (Exception e) {
-            log.error("Error mapping non-standard OIDC claims for authenticated user", e);
-            throw new IllegalStateException(e);
+            Optional<GeorchestraUser> userOpt = usersApi.findByOAuth2ProviderId(oAuth2ProviderId);
+
+            if (userOpt.isEmpty()) {
+                try {
+                    OidcUser oidcUser = (OidcUser) token.getPrincipal();
+                    Account newAccount = AccountFactory.createBrief(oidcUser.getEmail(), null, oidcUser.getGivenName(),
+                            oidcUser.getFamilyName(), oidcUser.getEmail(), "", "", "", oAuth2ProviderId);
+                    newAccount.setPending(false);
+                    accountDao.insert(newAccount);
+                    roleDao.addUser(Role.USER, newAccount);
+                    userOpt = usersApi.findByOAuth2ProviderId(oAuth2ProviderId);
+                } catch (DuplicatedUidException e) {
+                    throw new IllegalStateException(e);
+                } catch (DuplicatedEmailException e) {
+                    throw new IllegalStateException(e);
+                } catch (DataServiceException e) {
+                    throw new IllegalStateException(e);
+                }
+            }
+
+            List<String> roles = userOpt.get().getRoles().stream().map(r -> r.contains("ROLE_") ? r : "ROLE_" + r)
+                    .collect(Collectors.toList());
+            userOpt.get().setRoles(roles);
+            return userOpt;
+        } else {
+            GeorchestraUser user = super.map(token).orElseGet(GeorchestraUser::new);
+            OidcUser oidcUser = (OidcUser) token.getPrincipal();
+            try {
+                applyStandardClaims(oidcUser, user);
+                applyNonStandardClaims(oidcUser.getClaims(), user);
+            } catch (Exception e) {
+                log.error("Error mapping non-standard OIDC claims for authenticated user", e);
+                throw new IllegalStateException(e);
+            }
+            return Optional.of(user);
         }
-        return Optional.of(user);
     }
 
     /**

--- a/gateway/src/main/resources/application.yml
+++ b/gateway/src/main/resources/application.yml
@@ -18,7 +18,7 @@ server:
     
 spring:
   config:
-    import: optional:file:${georchestra.datadir}/default.properties,optional:file:${georchestra.datadir}/gateway/gateway.yaml
+    import: optional:file:${georchestra.datadir}/default.properties,optional:file:${georchestra.datadir}/gateway/gateway.yaml,optional:file:${georchestra.datadir}/gateway/security.yaml
   main:
     banner-mode: off
     web-application-type: reactive
@@ -136,4 +136,4 @@ logging:
 
 ---
 spring.config.activate.on-profile: dev
-spring.config.import: file:../datadir/default.properties,file:../datadir/gateway/gateway.yaml
+spring.config.import: file:../datadir/default.properties,file:../datadir/gateway/gateway.yaml,file:../datadir/gateway/security.yaml

--- a/gateway/src/test/java/org/georchestra/gateway/app/GeorchestraGatewayApplicationTests.java
+++ b/gateway/src/test/java/org/georchestra/gateway/app/GeorchestraGatewayApplicationTests.java
@@ -46,7 +46,7 @@ class GeorchestraGatewayApplicationTests {
         assertEquals("src/test/resources/test-datadir", env.getProperty("georchestra.datadir"));
 
         assertEquals(
-                "optional:file:src/test/resources/test-datadir/default.properties,optional:file:src/test/resources/test-datadir/gateway/gateway.yaml",
+                "optional:file:src/test/resources/test-datadir/default.properties,optional:file:src/test/resources/test-datadir/gateway/gateway.yaml,optional:file:src/test/resources/test-datadir/gateway/security.yaml",
                 env.getProperty("spring.config.import"));
 
         Boolean propertyFromTestDatadir = env.getProperty("georchestra.test-datadir", Boolean.class);

--- a/gateway/src/test/java/org/georchestra/gateway/autoconfigure/security/OAuth2SecurityAutoConfigurationTest.java
+++ b/gateway/src/test/java/org/georchestra/gateway/autoconfigure/security/OAuth2SecurityAutoConfigurationTest.java
@@ -20,16 +20,22 @@
 package org.georchestra.gateway.autoconfigure.security;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
+import java.util.HashMap;
 import java.util.List;
 
+import org.georchestra.ds.users.AccountDaoImpl;
 import org.georchestra.gateway.security.oauth2.OAuth2Configuration.OAuth2AuthenticationCustomizer;
 import org.georchestra.gateway.security.oauth2.OAuth2ProxyConfigProperties;
 import org.georchestra.gateway.security.oauth2.OpenIdConnectCustomClaimsConfigProperties;
 import org.georchestra.gateway.security.oauth2.OpenIdConnectCustomClaimsConfigProperties.RolesMapping;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.ldap.core.LdapTemplate;
+import org.springframework.security.ldap.DefaultSpringSecurityContextSource;
 import org.springframework.security.oauth2.client.endpoint.ReactiveOAuth2AccessTokenResponseClient;
 import org.springframework.security.oauth2.client.oidc.userinfo.OidcReactiveOAuth2UserService;
 import org.springframework.security.oauth2.client.userinfo.DefaultReactiveOAuth2UserService;
@@ -42,6 +48,27 @@ import org.springframework.security.oauth2.client.userinfo.ReactiveOAuth2UserSer
 class OAuth2SecurityAutoConfigurationTest {
     private ApplicationContextRunner runner = new ApplicationContextRunner()
             .withConfiguration(AutoConfigurations.of(OAuth2SecurityAutoConfiguration.class));
+
+    @BeforeEach
+    void setUp() throws Exception {
+        assumeTrue(System.getProperty("console.test.openldap.ldapurl") != null
+                && System.getProperty("console.test.openldap.basedn") != null);
+
+        String ldapUrl = System.getProperty("console.test.openldap.ldapurl");
+        String baseDn = System.getProperty("console.test.openldap.basedn");
+
+        DefaultSpringSecurityContextSource contextSource = new DefaultSpringSecurityContextSource(ldapUrl + baseDn);
+        contextSource.setBase(baseDn);
+        contextSource.setUrl(ldapUrl);
+        contextSource.setBaseEnvironmentProperties(new HashMap<String, Object>());
+        contextSource.setAnonymousReadOnly(true);
+        contextSource.setCacheEnvironmentProperties(false);
+
+        LdapTemplate ldapTemplate = new LdapTemplate(contextSource);
+
+        AccountDaoImpl accountDaoImpl = new AccountDaoImpl(ldapTemplate);
+        accountDaoImpl.setUserSearchBaseDN("ou=users");
+    }
 
     @Test
     void testDisabledByDefault() {

--- a/gateway/src/test/java/org/georchestra/gateway/security/oauth2/OpenIdConnectUserMapperTest.java
+++ b/gateway/src/test/java/org/georchestra/gateway/security/oauth2/OpenIdConnectUserMapperTest.java
@@ -21,15 +21,20 @@ package org.georchestra.gateway.security.oauth2;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.georchestra.ds.users.AccountDaoImpl;
 import org.georchestra.security.model.GeorchestraUser;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.ldap.core.LdapTemplate;
+import org.springframework.security.ldap.DefaultSpringSecurityContextSource;
 import org.springframework.security.oauth2.core.oidc.AddressStandardClaim;
 import org.springframework.security.oauth2.core.oidc.StandardClaimAccessor;
 
@@ -49,6 +54,24 @@ class OpenIdConnectUserMapperTest {
      */
     @BeforeEach
     void setUp() throws Exception {
+        assumeTrue(System.getProperty("console.test.openldap.ldapurl") != null
+                && System.getProperty("console.test.openldap.basedn") != null);
+
+        String ldapUrl = System.getProperty("console.test.openldap.ldapurl");
+        String baseDn = System.getProperty("console.test.openldap.basedn");
+
+        DefaultSpringSecurityContextSource contextSource = new DefaultSpringSecurityContextSource(ldapUrl + baseDn);
+        contextSource.setBase(baseDn);
+        contextSource.setUrl(ldapUrl);
+        contextSource.setBaseEnvironmentProperties(new HashMap<String, Object>());
+        contextSource.setAnonymousReadOnly(true);
+        contextSource.setCacheEnvironmentProperties(false);
+
+        LdapTemplate ldapTemplate = new LdapTemplate(contextSource);
+
+        AccountDaoImpl accountDaoImpl = new AccountDaoImpl(ldapTemplate);
+        accountDaoImpl.setUserSearchBaseDN("ou=users");
+
         nonStandardClaimsConfig = new OpenIdConnectCustomClaimsConfigProperties();
         mapper = new OpenIdConnectUserMapper(nonStandardClaimsConfig);
     }

--- a/gateway/src/test/resources/application-it.yml
+++ b/gateway/src/test/resources/application-it.yml
@@ -1,6 +1,8 @@
 # if in need of debugging what's going on with the proxied requests and the wiremock server,
 # set wiretap to true and logging levels to trace
 spring:
+  config:
+    import: optional:file:src/test/resources/test-datadir/gateway/security.yaml
   cloud:
     gateway:
       httpclient:

--- a/gateway/src/test/resources/test-datadir/gateway/security.yaml
+++ b/gateway/src/test/resources/test-datadir/gateway/security.yaml
@@ -1,0 +1,33 @@
+georchestra:
+  gateway:
+    security:
+      oauth2:
+        enabled: true
+      ldap:
+        openldap:
+          enabled: true
+          extended: true
+          url: ldap://ldap:389
+          baseDn: ${ldapBaseDn:dc=georchestra,dc=org}
+          adminDn: ${ldapAdminDn:cn=admin,dc=georchestra,dc=org"}
+          adminPassword: ${ldapAdminPassword:secret}
+          users:
+            rdn: ${ldapUsersRdn:ou=users}
+            searchFilter: ${ldapUserSearchFilter:(uid={0})}
+            pendingUsersSearchBaseDN: ou=pendingusers
+            protectedUsers: geoserver_privileged_user
+          roles:
+            rdn: ${ldapRolesRdn:ou=roles}
+            searchFilter: ${ldapRolesSearchFilter:(member={0})}
+          orgs:
+            rdn: ${ldapOrgsRdn:ou=orgs}
+            protectedRoles: ADMINISTRATOR, GN_.*, ORGADMIN, REFERENT, USER, SUPERUSER
+spring:
+  security:
+    oauth2:
+      client:
+        registration:
+          google:
+            clientId: client_id
+            clientSecret: client_secret
+            scope: openid, email, profile


### PR DESCRIPTION
On this PR, we are creating a new LDAP account for user connected using external IDP (Google, Mel,  FranceConnect).
When user connect for first time, a new LDAP account is created. After that, user information (firstname, lastname...) will be read from user LDAP account.
External IDP users can modify password and connect using login/password page.
For FranceConnect, an EndSessionURL is added to perform correct logout process.
Create e new LDAP account is optional depending on property "georchestra.gateway.security.createNonExistingUsersInLDAP" 