### PR TITLE
Use the OAuth2 registration name if client name is not provided for the login page

### DIFF
--- a/gateway/src/main/java/org/georchestra/gateway/app/GeorchestraGatewayApplication.java
+++ b/gateway/src/main/java/org/georchestra/gateway/app/GeorchestraGatewayApplication.java
@@ -102,7 +102,8 @@ public class GeorchestraGatewayApplication {
         Map<String, String> oauth2LoginLinks = new HashMap<String, String>();
         if (oauth2ClientConfig != null) {
             oauth2ClientConfig.getRegistration().forEach((k, v) -> {
-                oauth2LoginLinks.put("/oauth2/authorization/" + k, v.getClientName());
+                String clientName = Optional.ofNullable(v.getClientName()).orElse(k);
+                oauth2LoginLinks.put("/oauth2/authorization/" + k, clientName);
             });
         }
         mdl.addAttribute("header_url", georchestraHeaderUrl);


### PR DESCRIPTION
Use the OAuth2 registration name if client name is not provided for the login page.
Before:
![image](https://github.com/georchestra/georchestra-gateway/assets/207423/f27156f1-5644-45b3-a765-0daec5796fb6)

After:
![image](https://github.com/georchestra/georchestra-gateway/assets/207423/8d3d6b3a-3b5d-471a-8b5b-8f4d420e2a31)
