### PR TITLE
Allow to disable the georchestra header

### DIFF
--- a/gateway/src/main/java/org/georchestra/gateway/app/GeorchestraGatewayApplication.java
+++ b/gateway/src/main/java/org/georchestra/gateway/app/GeorchestraGatewayApplication.java
@@ -61,8 +61,7 @@ public class GeorchestraGatewayApplication {
     private boolean ldapEnabled = false;
 
     private @Autowired(required = false) OAuth2ClientProperties oauth2ClientConfig;
-    private @Value("${georchestra.gateway.headerUrl:/header/}") String georchestraHeaderUrl;
-    private @Value("${georchestra.gateway.headerHeight:90}") String georchestraHeaderHeight;
+    private @Value("${georchestra.gateway.headerEnabled:true}") boolean headerEnabled;
     private @Value("${georchestra.gateway.footerUrl:#{null}}") String georchestraFooterUrl;
 
     public static void main(String[] args) {
@@ -92,9 +91,10 @@ public class GeorchestraGatewayApplication {
         // Mono.just(Map.of(principal.getClass().getCanonicalName(), principal));
     }
 
-    @GetMapping(path = "/logout", produces = "text/html")
-    public Mono<Rendering.Builder<?>> logout(Authentication principal, ServerWebExchange exchange) {
-        return Mono.just(Rendering.view("logout"));
+    @GetMapping(path = "/logout")
+    public String logout(Model mdl) {
+        mdl.addAttribute("header_enabled", headerEnabled);
+        return "logout";
     }
 
     @GetMapping(path = "/login")
@@ -106,8 +106,7 @@ public class GeorchestraGatewayApplication {
                 oauth2LoginLinks.put("/oauth2/authorization/" + k, clientName);
             });
         }
-        mdl.addAttribute("header_url", georchestraHeaderUrl);
-        mdl.addAttribute("header_height", georchestraHeaderHeight);
+        mdl.addAttribute("header_enabled", headerEnabled);
         mdl.addAttribute("footer_url", georchestraFooterUrl);
         mdl.addAttribute("ldapEnabled", ldapEnabled);
         mdl.addAttribute("oauth2LoginLinks", oauth2LoginLinks);

--- a/gateway/src/main/resources/templates/login.html
+++ b/gateway/src/main/resources/templates/login.html
@@ -11,15 +11,9 @@
     <link href="login/signin.css" rel="stylesheet"/>
 </head>
 <body>
-<!--
-<header th:if="${header_url != null}">
-    <iframe id="header" title="Header" th:src="${header_url}" th:style="'width:100%;height:'+${header_height}+'px;border:none;overflow:hidden;transition: all 0.3s ease 0s;'" scrolling="no"
-            frameborder="0"></iframe>
-</header>
--->
-<header>
+  <header th:if="${header_enabled}">
     <geor-header></geor-header>
-</header>
+  </header>
 <div class="container">
     <form class="form-signin" method="post" action="/login" th:if="${ldapEnabled}">
         <h2 class="form-signin-heading">Please sign in</h2>

--- a/gateway/src/main/resources/templates/logout.html
+++ b/gateway/src/main/resources/templates/logout.html
@@ -10,7 +10,9 @@
     <link href="login/bootstrap.min.css" rel="stylesheet">
     <link href="login/signin.css" rel="stylesheet"/>
   </head>
-  <geor-header></geor-header>
+  <header th:if="${header_enabled}">
+    <geor-header></geor-header>
+  </header>
   <body>
      <div class="container mt-5">
       <form class="form-signin" method="post" action="/logout">


### PR DESCRIPTION
In some situations (e.g. acting as proxy only for geoserver cloud), the header in the login and logout pages is not required, and even off-topic.

Make it possible to disable it through the
`georchestra.gateway.headerEnabled` property, defaulting to `true`.