### PR TITLE
Add filters used by GeoServer Cloud

### DIFF
--- a/gateway/src/main/java/org/georchestra/gateway/autoconfigure/app/FiltersAutoConfiguration.java
+++ b/gateway/src/main/java/org/georchestra/gateway/autoconfigure/app/FiltersAutoConfiguration.java
@@ -22,6 +22,9 @@ import org.georchestra.gateway.filter.global.ResolveTargetGlobalFilter;
 import org.georchestra.gateway.filter.headers.HeaderFiltersConfiguration;
 import org.georchestra.gateway.model.GatewayConfigProperties;
 import org.georchestra.gateway.model.GeorchestraTargetConfig;
+import org.geoserver.cloud.gateway.filter.RouteProfileGatewayFilterFactory;
+import org.geoserver.cloud.gateway.filter.StripBasePathGatewayFilterFactory;
+import org.geoserver.cloud.gateway.predicate.RegExpQueryRoutePredicateFactory;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.gateway.config.GatewayAutoConfiguration;
@@ -44,4 +47,22 @@ public class FiltersAutoConfiguration {
     public @Bean ResolveTargetGlobalFilter resolveTargetWebFilter(GatewayConfigProperties config) {
         return new ResolveTargetGlobalFilter(config);
     }
+
+    /**
+     * Custom gateway predicate factory to support matching by regular expressions
+     * on both name and value of query parameters
+     */
+    public @Bean RegExpQueryRoutePredicateFactory regExpQueryRoutePredicateFactory() {
+        return new RegExpQueryRoutePredicateFactory();
+    }
+
+    /** Allows to enable routes only if a given spring profile is enabled */
+    public @Bean RouteProfileGatewayFilterFactory routeProfileGatewayFilterFactory() {
+        return new RouteProfileGatewayFilterFactory();
+    }
+
+    public @Bean StripBasePathGatewayFilterFactory stripBasePathGatewayFilterFactory() {
+        return new StripBasePathGatewayFilterFactory();
+    }
+
 }

--- a/gateway/src/main/java/org/geoserver/cloud/gateway/filter/GlobalUriFilter.java
+++ b/gateway/src/main/java/org/geoserver/cloud/gateway/filter/GlobalUriFilter.java
@@ -1,0 +1,70 @@
+/*
+ * (c) 2022 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
+ * GPL 2.0 license, available at the root application directory.
+ */
+package org.geoserver.cloud.gateway.filter;
+
+import static org.springframework.cloud.gateway.support.ServerWebExchangeUtils.GATEWAY_REQUEST_URL_ATTR;
+import static org.springframework.cloud.gateway.support.ServerWebExchangeUtils.GATEWAY_ROUTE_ATTR;
+
+import org.springframework.cloud.gateway.filter.GatewayFilterChain;
+import org.springframework.cloud.gateway.filter.GlobalFilter;
+import org.springframework.cloud.gateway.filter.ReactiveLoadBalancerClientFilter;
+import org.springframework.cloud.gateway.route.Route;
+import org.springframework.core.Ordered;
+import org.springframework.stereotype.Component;
+import org.springframework.web.server.ServerWebExchange;
+
+import reactor.core.publisher.Mono;
+
+import java.net.URI;
+
+/**
+ * See gateway's issue <a href=
+ * "https://github.com/spring-cloud/spring-cloud-gateway/issues/2065">#2065</a>
+ * "Double Encoded URLs"
+ */
+@Component
+public class GlobalUriFilter implements GlobalFilter, Ordered {
+
+    @Override
+    public Mono<Void> filter(ServerWebExchange exchange, GatewayFilterChain chain) {
+
+        URI incomingUri = exchange.getRequest().getURI();
+        if (isUriEncoded(incomingUri)) {
+            // Get the original Gateway route (contains the service's original host)
+            Route route = exchange.getAttribute(GATEWAY_ROUTE_ATTR);
+            if (route == null) {
+                return chain.filter(exchange);
+            }
+
+            // Save it as the outgoing URI to call the service, and override the "wrongly"
+            // double encoded URI in ReactiveLoadBalancerClientFilter
+            // LoadBalancerUriTools::containsEncodedParts
+            // double encoded URI again
+            URI balanceUrl = exchange.getRequiredAttribute(GATEWAY_REQUEST_URL_ATTR);
+            URI mergedUri = createUri(incomingUri, balanceUrl);
+            exchange.getAttributes().put(GATEWAY_REQUEST_URL_ATTR, mergedUri);
+        }
+
+        return chain.filter(exchange);
+    }
+
+    private URI createUri(URI incomingUri, URI balanceUrl) {
+        final var port = balanceUrl.getPort() != -1 ? ":" + balanceUrl.getPort() : "";
+        final var rawPath = balanceUrl.getRawPath() != null ? balanceUrl.getRawPath() : "";
+        final var query = incomingUri.getRawQuery() != null ? "?" + incomingUri.getRawQuery() : "";
+        return URI.create(balanceUrl.getScheme() + "://" + balanceUrl.getHost() + port + rawPath + query);
+    }
+
+    private static boolean isUriEncoded(URI uri) {
+        return (uri.getRawQuery() != null && uri.getRawQuery().contains("%"))
+                || (uri.getRawPath() != null && uri.getRawPath().contains("%"));
+    }
+
+    // order after ReactiveLoadBalancerClientFilter
+    @Override
+    public int getOrder() {
+        return ReactiveLoadBalancerClientFilter.LOAD_BALANCER_CLIENT_FILTER_ORDER + 1;
+    }
+}

--- a/gateway/src/main/java/org/geoserver/cloud/gateway/filter/RouteProfileGatewayFilterFactory.java
+++ b/gateway/src/main/java/org/geoserver/cloud/gateway/filter/RouteProfileGatewayFilterFactory.java
@@ -1,0 +1,112 @@
+/*
+ * (c) 2021 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
+ * GPL 2.0 license, available at the root application directory.
+ */
+package org.geoserver.cloud.gateway.filter;
+
+import static org.springframework.cloud.gateway.support.GatewayToStringStyler.filterToStringCreator;
+
+import lombok.Data;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.experimental.Accessors;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cloud.gateway.filter.GatewayFilter;
+import org.springframework.cloud.gateway.filter.GatewayFilterChain;
+import org.springframework.cloud.gateway.filter.factory.AbstractGatewayFilterFactory;
+import org.springframework.core.env.Environment;
+import org.springframework.http.HttpStatus;
+import org.springframework.util.StringUtils;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.server.ServerWebExchange;
+
+import reactor.core.publisher.Mono;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import javax.validation.constraints.NotEmpty;
+
+/** Allows to enable routes only if a given spring profile is enabled */
+public class RouteProfileGatewayFilterFactory
+        extends AbstractGatewayFilterFactory<RouteProfileGatewayFilterFactory.Config> {
+
+    private static final List<String> SHORTCUT_FIELD_ORDER = Collections
+            .unmodifiableList(Arrays.asList(Config.PROFILE_KEY, Config.HTTPSTATUS_KEY));
+
+    @Autowired
+    private Environment environment;
+
+    public RouteProfileGatewayFilterFactory() {
+        super(Config.class);
+    }
+
+    @Override
+    public List<String> shortcutFieldOrder() {
+        return SHORTCUT_FIELD_ORDER;
+    }
+
+    @Override
+    public GatewayFilter apply(Config config) {
+        return new RouteProfileGatewayFilter(environment, config);
+    }
+
+    @RequiredArgsConstructor
+    private static class RouteProfileGatewayFilter implements GatewayFilter {
+
+        private final @NonNull Environment environment;
+        private final @NonNull Config config;
+
+        @Override
+        public Mono<Void> filter(ServerWebExchange exchange, GatewayFilterChain chain) {
+            final List<String> activeProfiles = Arrays.asList(environment.getActiveProfiles());
+            String profile = config.getProfile();
+            if (StringUtils.hasText(profile)) {
+                final boolean exclude = profile.startsWith("!");
+                profile = exclude ? profile.substring(1) : profile;
+
+                boolean profileMatch = activeProfiles.contains(profile);
+                boolean proceed = (profileMatch && !exclude) || (!profileMatch && exclude);
+                if (proceed) {
+                    // continue...
+                    return chain.filter(exchange);
+                }
+            }
+
+            int status = config.getStatusCode();
+            exchange.getResponse().setRawStatusCode(status);
+            return exchange.getResponse().setComplete();
+        }
+
+        @Override
+        public String toString() {
+            return filterToStringCreator(this).append(Config.PROFILE_KEY, config.getProfile())
+                    .append(Config.HTTPSTATUS_KEY, config.getStatusCode()).toString();
+        }
+    }
+
+    @Data
+    @Accessors(chain = true)
+    @Validated
+    public static class Config {
+
+        /**
+         * Profiles key, indicates which profiles must be enabled to allow the request
+         * to proceed
+         */
+        public static final String PROFILE_KEY = "profile";
+
+        /**
+         * Status code key. HTTP status code to return when the request is not allowed
+         * to proceed because the required profiles are not active
+         */
+        public static final String HTTPSTATUS_KEY = "statusCode";
+
+        @NotEmpty
+        private String profile;
+
+        private int statusCode = HttpStatus.NOT_FOUND.value();
+    }
+}

--- a/gateway/src/main/java/org/geoserver/cloud/gateway/filter/StripBasePathGatewayFilterFactory.java
+++ b/gateway/src/main/java/org/geoserver/cloud/gateway/filter/StripBasePathGatewayFilterFactory.java
@@ -1,0 +1,91 @@
+/*
+ * (c) 2021 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
+ * GPL 2.0 license, available at the root application directory.
+ */
+package org.geoserver.cloud.gateway.filter;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import lombok.Data;
+
+import org.springframework.cloud.gateway.filter.GatewayFilter;
+import org.springframework.cloud.gateway.filter.factory.AbstractGatewayFilterFactory;
+import org.springframework.cloud.gateway.filter.factory.StripPrefixGatewayFilterFactory;
+import org.springframework.cloud.gateway.filter.factory.StripPrefixGatewayFilterFactory.Config;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.util.StringUtils;
+
+import java.util.List;
+
+/**
+ * See gateway's issue <a href=
+ * "https://github.com/spring-cloud/spring-cloud-gateway/issues/1759">#1759</a>
+ * "Webflux base path does not work with Path predicates"
+ */
+public class StripBasePathGatewayFilterFactory
+        extends AbstractGatewayFilterFactory<StripBasePathGatewayFilterFactory.PrefixConfig> {
+
+    private StripPrefixGatewayFilterFactory stripPrefix = new StripPrefixGatewayFilterFactory();
+
+    public StripBasePathGatewayFilterFactory() {
+        super(PrefixConfig.class);
+    }
+
+    @Override
+    public List<String> shortcutFieldOrder() {
+        return List.of("prefix");
+    }
+
+    @Override
+    public GatewayFilter apply(PrefixConfig config) {
+        config.checkPreconditions();
+        return (exchange, chain) -> {
+            final ServerHttpRequest request = exchange.getRequest();
+
+            final String basePath = config.getPrefix();
+            final String path = request.getURI().getRawPath();
+            // if (basePath.equals(path)) {
+            // return chain.filter(exchange);
+            // }
+
+            final int partsToRemove = resolvePartsToStrip(basePath, path);
+            if (partsToRemove == 0) {
+                return chain.filter(exchange);
+            }
+            GatewayFilter stripFilter = stripPrefix.apply(newStripPrefixConfig(partsToRemove));
+            return stripFilter.filter(exchange, chain);
+        };
+    }
+
+    private Config newStripPrefixConfig(int partsToRemove) {
+        Config config = stripPrefix.newConfig();
+        config.setParts(partsToRemove);
+        return config;
+    }
+
+    private int resolvePartsToStrip(String basePath, String requestPath) {
+        if (null == basePath)
+            return 0;
+        if (!requestPath.startsWith(basePath)) {
+            return 0;
+        }
+        final int basePathSteps = StringUtils.countOccurrencesOf(basePath, "/");
+        boolean isRoot = basePath.equals(requestPath);
+        return isRoot ? basePathSteps - 1 : basePathSteps;
+    }
+
+    public static @Data class PrefixConfig {
+        private String prefix;
+
+        public void checkPreconditions() {
+            final String prefix = getPrefix();
+
+            // requireNonNull(prefix, "StripBasePath prefix can't be null");
+            if (prefix != null) {
+                checkArgument(prefix.startsWith("/"), "StripBasePath prefix must start with /");
+
+                checkArgument("/".equals(prefix) || !prefix.endsWith("/"), "StripBasePath prefix must not end with /");
+            }
+        }
+    }
+}

--- a/gateway/src/main/java/org/geoserver/cloud/gateway/predicate/RegExpQueryRoutePredicateFactory.java
+++ b/gateway/src/main/java/org/geoserver/cloud/gateway/predicate/RegExpQueryRoutePredicateFactory.java
@@ -1,0 +1,128 @@
+/*
+ * (c) 2020 Open Source Geospatial Foundation - all rights reserved This code is licensed under the
+ * GPL 2.0 license, available at the root application directory.
+ */
+package org.geoserver.cloud.gateway.predicate;
+
+import lombok.Data;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.experimental.Accessors;
+
+import org.springframework.cloud.gateway.handler.predicate.AbstractRoutePredicateFactory;
+import org.springframework.cloud.gateway.handler.predicate.GatewayPredicate;
+import org.springframework.cloud.gateway.handler.predicate.QueryRoutePredicateFactory;
+import org.springframework.util.StringUtils;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.server.ServerWebExchange;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Predicate;
+import java.util.regex.Pattern;
+
+import javax.validation.constraints.NotEmpty;
+
+/**
+ * Gateway predicate factory that allows matching by HTTP request query string
+ * parameters using {@link Pattern Java regular expressions} for both parameter
+ * name and value.
+ *
+ * <p>
+ * This predicate factory is similar to the {@link QueryRoutePredicateFactory}
+ * but besides allowing regular expressions to match a parameter value, also
+ * allows to match the parameter name through a regex.
+ *
+ * <p>
+ * Just like with {@link QueryRoutePredicateFactory}, the "value" regular
+ * expression is optional. If not given, the test will be performed only against
+ * the query parameter names. If a value regular expression is present, though,
+ * the evaluation will be performed against the values of the first parameter
+ * that matches the name regex.
+ *
+ * <p>
+ * Sample usage: the following route configuration example uses a
+ * {@code RegExpQuery} predicate to match the {@code service} query parameter
+ * name and {@code wfs} value in a case insensitive fashion.
+ *
+ * <pre>
+ * <code>
+ * spring:
+ *  cloud:
+ *   gateway:
+ *    routes:
+ *     - id: wfs_ows
+ *       uri: lb://wfs-service
+ *       predicates:
+ *       - RegExpQuery=(?i:service),(?i:wfs)
+ * </code>
+ * </pre>
+ */
+public class RegExpQueryRoutePredicateFactory
+        extends AbstractRoutePredicateFactory<RegExpQueryRoutePredicateFactory.Config> {
+
+    /** HTTP request query parameter regexp key. */
+    public static final String PARAM_KEY = "paramRegexp";
+
+    /** HTTP request query parameter value regexp key. */
+    public static final String VALUE_KEY = "valueRegexp";
+
+    public RegExpQueryRoutePredicateFactory() {
+        super(Config.class);
+    }
+
+    public @Override List<String> shortcutFieldOrder() {
+        return Arrays.asList(PARAM_KEY, VALUE_KEY);
+    }
+
+    public @Override Predicate<ServerWebExchange> apply(Config config) {
+        return new RegExpQueryRoutePredicate(config);
+    }
+
+    @RequiredArgsConstructor
+    private static class RegExpQueryRoutePredicate implements GatewayPredicate {
+        private final @NonNull Config config;
+
+        public @Override boolean test(ServerWebExchange exchange) {
+            final String paramRegexp = config.getParamRegexp();
+            final String valueRegexp = config.getValueRegexp();
+
+            boolean matchNameOnly = !StringUtils.hasText(config.getValueRegexp());
+            Optional<String> paramName = findParameterName(paramRegexp, exchange);
+            boolean paramNameMatches = paramName.isPresent();
+            if (matchNameOnly) {
+                return paramNameMatches;
+            }
+            return paramNameMatches && paramValueMatches(paramName.get(), valueRegexp, exchange);
+        }
+
+        public @Override String toString() {
+            return String.format("Query: param regexp='%s' value regexp='%s'", config.getParamRegexp(),
+                    config.getValueRegexp());
+        }
+    }
+
+    static Optional<String> findParameterName(@NonNull String regex, ServerWebExchange exchange) {
+        Set<String> parameterNames = exchange.getRequest().getQueryParams().keySet();
+        return parameterNames.stream().filter(name -> name.matches(regex)).findFirst();
+    }
+
+    static boolean paramValueMatches(@NonNull String paramName, @NonNull String valueRegEx,
+            ServerWebExchange exchange) {
+        List<String> values = exchange.getRequest().getQueryParams().get(paramName);
+        return values != null && values.stream().anyMatch(v -> v != null && v.matches(valueRegEx));
+    }
+
+    @Data
+    @Accessors(chain = true)
+    @Validated
+    public static class Config {
+
+        @NotEmpty
+        private String paramRegexp;
+
+        private String valueRegexp;
+    }
+}


### PR DESCRIPTION
In a process to ditch gscloud's own gateway, and use georchestra's gateway instead, incorporate some
custom gateway filters.