### PR TITLE
Proxy to external URLs

### DIFF
--- a/gateway/src/main/java/org/georchestra/gateway/filter/headers/HeaderFiltersConfiguration.java
+++ b/gateway/src/main/java/org/georchestra/gateway/filter/headers/HeaderFiltersConfiguration.java
@@ -53,6 +53,10 @@ public class HeaderFiltersConfiguration {
         return new CookieAffinityGatewayFilterFactory();
     }
 
+    public @Bean ProxyGatewayFilterFactory proxyGatewayFilterFactory() {
+        return new ProxyGatewayFilterFactory();
+    }
+
     public @Bean GeorchestraUserHeadersContributor userSecurityHeadersProvider() {
         return new GeorchestraUserHeadersContributor();
     }

--- a/gateway/src/main/java/org/georchestra/gateway/filter/headers/ProxyGatewayFilterFactory.java
+++ b/gateway/src/main/java/org/georchestra/gateway/filter/headers/ProxyGatewayFilterFactory.java
@@ -1,0 +1,40 @@
+package org.georchestra.gateway.filter.headers;
+
+import org.springframework.cloud.gateway.filter.GatewayFilter;
+import org.springframework.cloud.gateway.filter.factory.AbstractGatewayFilterFactory;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.cloud.gateway.route.Route;
+import org.springframework.cloud.gateway.support.ServerWebExchangeUtils;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.List;
+
+public class ProxyGatewayFilterFactory extends AbstractGatewayFilterFactory<Object> {
+    public ProxyGatewayFilterFactory() {
+        super(Object.class);
+    }
+
+    @Override
+    public GatewayFilter apply(final Object config) {
+        return (exchange, chain) -> {
+            Route route = exchange.getAttribute(ServerWebExchangeUtils.GATEWAY_ROUTE_ATTR);
+            ServerHttpRequest request = exchange.getRequest();
+            List<String> urls = request.getQueryParams().get("url");
+            if ((urls != null) && (urls.size() == 1)) {
+                try {
+                    request = exchange.getRequest().mutate().uri(new URI(urls.get(0))).build();
+
+                    Route newRoute = Route.async().id(route.getId()).uri(new URI(urls.get(0))).order(route.getOrder())
+                            .asyncPredicate(route.getPredicate()).build();
+
+                    exchange.getAttributes().put(AddSecHeadersGatewayFilterFactory.DISABLE_SECURITY_HEADERS, "true");
+                    exchange.getAttributes().put(ServerWebExchangeUtils.GATEWAY_ROUTE_ATTR, newRoute);
+                    return chain.filter(exchange.mutate().request(request).build());
+                } catch (URISyntaxException e) {
+                }
+            }
+            return chain.filter(exchange);
+        };
+    }
+}


### PR DESCRIPTION
First attempt to add a proxy to external URLs, see [issue #39](https://github.com/georchestra/georchestra-gateway/issues/39)
As of discussed in the issue and in some meetings, it may be a bad idea to add a such proxy to the gateway and it is yet to be decided, but for reference here is a working attempt without any security, compatible with the one at `/proxy` in security-proxy.

Example of proxy route declaration :
```
      - id: proxy
        uri: no://op
        predicates:
        - Path=/proxy/**
        filters:
        - Proxy
```