### PR TITLE
Allowing users to login with email in addition of UID

### DIFF
--- a/gateway/src/main/java/org/georchestra/gateway/security/ldap/basic/LdapAuthenticatorProviderBuilder.java
+++ b/gateway/src/main/java/org/georchestra/gateway/security/ldap/basic/LdapAuthenticatorProviderBuilder.java
@@ -20,12 +20,14 @@ package org.georchestra.gateway.security.ldap.basic;
 
 import static java.util.Objects.requireNonNull;
 
+import org.georchestra.ds.users.AccountDao;
+import org.georchestra.gateway.security.ldap.extended.ExtendedLdapAuthenticationProvider;
 import org.georchestra.gateway.security.ldap.extended.ExtendedPasswordPolicyAwareContextSource;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.ldap.core.support.BaseLdapPathContextSource;
 import org.springframework.security.core.authority.mapping.GrantedAuthoritiesMapper;
 import org.springframework.security.core.authority.mapping.SimpleAuthorityMapper;
 import org.springframework.security.ldap.authentication.BindAuthenticator;
-import org.springframework.security.ldap.authentication.LdapAuthenticationProvider;
 import org.springframework.security.ldap.search.FilterBasedLdapUserSearch;
 import org.springframework.security.ldap.userdetails.DefaultLdapAuthoritiesPopulator;
 
@@ -50,10 +52,12 @@ public class LdapAuthenticatorProviderBuilder {
     private @Setter String adminDn;
     private @Setter String adminPassword;
 
+    private @Setter AccountDao accountDao;
+
     // null = all atts, empty == none
     private @Setter String[] returningAttributes = null;
 
-    public LdapAuthenticationProvider build() {
+    public ExtendedLdapAuthenticationProvider build() {
         requireNonNull(url, "url is not set");
         requireNonNull(baseDn, "baseDn is not set");
         requireNonNull(userSearchBase, "userSearchBase is not set");
@@ -64,12 +68,13 @@ public class LdapAuthenticatorProviderBuilder {
         final ExtendedPasswordPolicyAwareContextSource source = contextSource();
         final BindAuthenticator authenticator = ldapAuthenticator(source);
         final DefaultLdapAuthoritiesPopulator rolesPopulator = ldapAuthoritiesPopulator(source);
-
-        LdapAuthenticationProvider provider = new LdapAuthenticationProvider(authenticator, rolesPopulator);
+        ExtendedLdapAuthenticationProvider provider = new ExtendedLdapAuthenticationProvider(authenticator,
+                rolesPopulator);
 
         final GrantedAuthoritiesMapper rolesMapper = ldapAuthoritiesMapper();
         provider.setAuthoritiesMapper(rolesMapper);
         provider.setUserDetailsContextMapper(new LdapUserDetailsMapper());
+        provider.setAccountDao(accountDao);
         return provider;
     }
 

--- a/gateway/src/main/java/org/georchestra/gateway/security/ldap/extended/DemultiplexingUsersApi.java
+++ b/gateway/src/main/java/org/georchestra/gateway/security/ldap/extended/DemultiplexingUsersApi.java
@@ -69,4 +69,10 @@ class DemultiplexingUsersApi {
         Objects.requireNonNull(target, () -> "No UsersApi found for config named " + serviceName);
         return target.findByUsername(username);
     }
+
+    public Optional<GeorchestraUser> findByEmail(@NonNull String serviceName, @NonNull String email) {
+        UsersApi target = targets.get(serviceName);
+        Objects.requireNonNull(target, () -> "No UsersApi found for config named " + serviceName);
+        return target.findByEmail(email);
+    }
 }

--- a/gateway/src/main/java/org/georchestra/gateway/security/ldap/extended/ExtendedLdapAuthenticationConfiguration.java
+++ b/gateway/src/main/java/org/georchestra/gateway/security/ldap/extended/ExtendedLdapAuthenticationConfiguration.java
@@ -86,18 +86,24 @@ public class ExtendedLdapAuthenticationConfiguration {
     private GeorchestraLdapAuthenticationProvider createLdapProvider(ExtendedLdapConfig config) {
         log.info("Creating extended LDAP AuthenticationProvider {} at {}", config.getName(), config.getUrl());
 
-        LdapAuthenticationProvider delegate = new LdapAuthenticatorProviderBuilder()//
-                .url(config.getUrl())//
-                .baseDn(config.getBaseDn())//
-                .userSearchBase(config.getUsersRdn())//
-                .userSearchFilter(config.getUsersSearchFilter())//
-                .rolesSearchBase(config.getRolesRdn())//
-                .rolesSearchFilter(config.getRolesSearchFilter())//
-                .adminDn(config.getAdminDn().orElse(null))//
-                .adminPassword(config.getAdminPassword().orElse(null))//
-                .returningAttributes(config.getReturningAttributes()).build();
-
-        return new GeorchestraLdapAuthenticationProvider(config.getName(), delegate);
+        final LdapTemplate ldapTemplate;
+        try {
+            ldapTemplate = ldapTemplate(config);
+            final AccountDao accountsDao = accountsDao(ldapTemplate, config);
+            ExtendedLdapAuthenticationProvider delegate = new LdapAuthenticatorProviderBuilder()//
+                    .url(config.getUrl())//
+                    .baseDn(config.getBaseDn())//
+                    .userSearchBase(config.getUsersRdn())//
+                    .userSearchFilter(config.getUsersSearchFilter())//
+                    .rolesSearchBase(config.getRolesRdn())//
+                    .rolesSearchFilter(config.getRolesSearchFilter())//
+                    .adminDn(config.getAdminDn().orElse(null))//
+                    .adminPassword(config.getAdminPassword().orElse(null))//
+                    .returningAttributes(config.getReturningAttributes()).accountDao(accountsDao).build();
+            return new GeorchestraLdapAuthenticationProvider(config.getName(), delegate);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
     }
 
     @Bean

--- a/gateway/src/main/java/org/georchestra/gateway/security/ldap/extended/ExtendedLdapAuthenticationProvider.java
+++ b/gateway/src/main/java/org/georchestra/gateway/security/ldap/extended/ExtendedLdapAuthenticationProvider.java
@@ -1,0 +1,66 @@
+package org.georchestra.gateway.security.ldap.extended;
+
+import org.georchestra.ds.DataServiceException;
+import org.georchestra.ds.users.Account;
+import org.georchestra.ds.users.AccountDao;
+import org.springframework.ldap.NameNotFoundException;
+import org.springframework.ldap.core.DirContextOperations;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.ldap.authentication.LdapAuthenticationProvider;
+import org.springframework.security.ldap.authentication.LdapAuthenticator;
+import org.springframework.security.ldap.userdetails.LdapAuthoritiesPopulator;
+import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
+
+public class ExtendedLdapAuthenticationProvider extends LdapAuthenticationProvider {
+
+    private AccountDao accountDao;
+
+    public ExtendedLdapAuthenticationProvider(LdapAuthenticator authenticator,
+            LdapAuthoritiesPopulator authoritiesPopulator) {
+        super(authenticator, authoritiesPopulator);
+    }
+
+    public void setAccountDao(AccountDao accountDao) {
+        this.accountDao = accountDao;
+    }
+
+    @Override
+    public Authentication authenticate(Authentication authentication) throws AuthenticationException {
+        Assert.isInstanceOf(UsernamePasswordAuthenticationToken.class, authentication,
+                () -> this.messages.getMessage("LdapAuthenticationProvider.onlySupports",
+                        "Only UsernamePasswordAuthenticationToken is supported"));
+        UsernamePasswordAuthenticationToken userToken = (UsernamePasswordAuthenticationToken) authentication;
+        Account account = null;
+        try {
+            account = accountDao.findByEmail(userToken.getName());
+        } catch (DataServiceException e) {
+        } catch (NameNotFoundException e) {
+        }
+        if (account != null) {
+            userToken = new UsernamePasswordAuthenticationToken(account.getUid(), userToken.getCredentials());
+        }
+
+        String username = userToken.getName();
+        String password = (String) authentication.getCredentials();
+
+        if (!StringUtils.hasLength(username)) {
+            throw new BadCredentialsException(
+                    this.messages.getMessage("LdapAuthenticationProvider.emptyUsername", "Empty Username"));
+        }
+        if (!StringUtils.hasLength(password)) {
+            throw new BadCredentialsException(
+                    this.messages.getMessage("AbstractLdapAuthenticationProvider.emptyPassword", "Empty Password"));
+        }
+        Assert.notNull(password, "Null password was supplied in authentication token");
+        DirContextOperations userData = doAuthentication(userToken);
+        UserDetails user = this.userDetailsContextMapper.mapUserFromContext(userData, authentication.getName(),
+                loadUserAuthorities(userData, authentication.getName(), (String) authentication.getCredentials()));
+
+        return createSuccessfulAuthentication(userToken, user);
+    }
+}

--- a/gateway/src/main/java/org/georchestra/gateway/security/ldap/extended/GeorchestraLdapAuthenticatedUserMapper.java
+++ b/gateway/src/main/java/org/georchestra/gateway/security/ldap/extended/GeorchestraLdapAuthenticatedUserMapper.java
@@ -67,6 +67,10 @@ class GeorchestraLdapAuthenticatedUserMapper implements GeorchestraUserMapperExt
         final String username = principal.getUsername();
 
         Optional<GeorchestraUser> user = users.findByUsername(ldapConfigName, username);
+        if (user.isEmpty()) {
+            user = users.findByEmail(ldapConfigName, username);
+        }
+
         return user.map(u -> fixPrefixedRoleNames(u, token));
     }
 


### PR DESCRIPTION
This PR includes changes required to allow all users, including IDP users (Franceconnect, Mel, Google), to login using their email after first successful login with IDP.

Need geOrchestra code changes from [PR#4002](https://github.com/georchestra/georchestra/pull/4002/files) to work.