### PR TITLE
remove cors/csrf java code configuration, in favor of regular spring-cloud-gateway configuration

### DIFF
--- a/gateway/src/main/java/org/georchestra/gateway/security/GatewaySecurityConfiguration.java
+++ b/gateway/src/main/java/org/georchestra/gateway/security/GatewaySecurityConfiguration.java
@@ -21,8 +21,6 @@ package org.georchestra.gateway.security;
 import lombok.extern.slf4j.Slf4j;
 import org.georchestra.gateway.model.GatewayConfigProperties;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -30,9 +28,6 @@ import org.springframework.security.config.annotation.web.reactive.EnableWebFlux
 import org.springframework.security.config.web.server.ServerHttpSecurity;
 import org.springframework.security.web.server.SecurityWebFilterChain;
 import org.springframework.security.web.server.authentication.logout.ServerLogoutSuccessHandler;
-import org.springframework.web.cors.CorsConfiguration;
-import org.springframework.web.cors.reactive.CorsConfigurationSource;
-import org.springframework.web.cors.reactive.UrlBasedCorsConfigurationSource;
 
 import java.util.List;
 import java.util.Map;
@@ -66,31 +61,12 @@ public class GatewaySecurityConfiguration {
     @Autowired(required = false)
     ServerLogoutSuccessHandler oidcLogoutSuccessHandler;
 
-    private @Value("${georchestra.gateway.csrfEnabled:false}") boolean csrfEnabled;
-    private @Value("${georchestra.gateway.corsEnabled:false}") boolean corsEnabled;
-
     @Bean
     public SecurityWebFilterChain securityWebFilterChain(ServerHttpSecurity http,
             List<ServerHttpSecurityCustomizer> customizers) throws Exception {
 
         log.info("Initializing security filter chain...");
 
-        if (!csrfEnabled) {
-            log.info("CSRF disabled. Revisit how they interfer with Websockets proxying.");
-            http.csrf().disable();
-        }
-        if (!corsEnabled) {
-            log.info("CORS disabled. Revisit how they interfer with Websockets proxying.");
-            http.cors().disable();
-        } else {
-            CorsConfiguration config = new CorsConfiguration();
-            config.addAllowedOrigin(CorsConfiguration.ALL);
-            config.addAllowedHeader("*");
-            config.addAllowedMethod("*");
-            UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
-            source.registerCorsConfiguration("/**", config);
-            http.cors().configurationSource(source);
-        }
         http.formLogin()
                 .authenticationFailureHandler(new ExtendedRedirectServerAuthenticationFailureHandler("login?error"))
                 .loginPage("/login");

--- a/gateway/src/main/java/org/georchestra/gateway/security/GatewaySecurityConfiguration.java
+++ b/gateway/src/main/java/org/georchestra/gateway/security/GatewaySecurityConfiguration.java
@@ -30,6 +30,7 @@ import org.springframework.security.config.annotation.web.reactive.EnableWebFlux
 import org.springframework.security.config.web.server.ServerHttpSecurity;
 import org.springframework.security.web.server.SecurityWebFilterChain;
 import org.springframework.security.web.server.authentication.logout.ServerLogoutSuccessHandler;
+import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.reactive.CorsConfigurationSource;
 import org.springframework.web.cors.reactive.UrlBasedCorsConfigurationSource;
 
@@ -82,8 +83,13 @@ public class GatewaySecurityConfiguration {
             log.info("CORS disabled. Revisit how they interfer with Websockets proxying.");
             http.cors().disable();
         } else {
-            // TODO configure ?!
-            http.cors().configurationSource(new UrlBasedCorsConfigurationSource());
+            CorsConfiguration config = new CorsConfiguration();
+            config.addAllowedOrigin(CorsConfiguration.ALL);
+            config.addAllowedHeader("*");
+            config.addAllowedMethod("*");
+            UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+            source.registerCorsConfiguration("/**", config);
+            http.cors().configurationSource(source);
         }
         http.formLogin()
                 .authenticationFailureHandler(new ExtendedRedirectServerAuthenticationFailureHandler("login?error"))

--- a/gateway/src/main/resources/application.yml
+++ b/gateway/src/main/resources/application.yml
@@ -32,6 +32,17 @@ spring:
       enabled: true
       global-filter.websocket-routing.enabled: true
       metrics.enabled: true
+      # Uncomment the following to allow cross-origin requests from any methods
+      # coming from anywhere.
+      # See https://docs.spring.io/spring-cloud-gateway/reference/spring-cloud-gateway/cors-configuration.html
+      # for more infos.
+      #globalcors:
+      #  cors-configurations:
+      #    '[/**]':
+      #      allowedOrigins: "*"
+      #      allowedHeaders: "*"
+      #      allowedMethods: "*"
+
       default-filters:
       - SecureHeaders
       - TokenRelay
@@ -54,8 +65,6 @@ spring:
 
 georchestra:
   gateway:
-    csrfEnabled: false
-    corsEnabled: false
     security:
       oauth2:
         enabled: false

--- a/gateway/src/main/resources/application.yml
+++ b/gateway/src/main/resources/application.yml
@@ -10,12 +10,12 @@ server:
   port: 8080
   compression.enabled: true
   # HTTP/2 is only supported over TLS (HTTPS)
-  # So we need to configure SSL if we want to support HTTP/2 
+  # So we need to configure SSL if we want to support HTTP/2
   http2.enabled: ${server.ssl.enabled}
   ssl:
     enabled: false
     #TODO: configure SSL with a self-signed certificate
-    
+
 spring:
   config:
     import: optional:file:${georchestra.datadir}/default.properties,optional:file:${georchestra.datadir}/gateway/gateway.yaml,optional:file:${georchestra.datadir}/gateway/security.yaml
@@ -54,6 +54,8 @@ spring:
 
 georchestra:
   gateway:
+    csrfEnabled: false
+    corsEnabled: false
     security:
       oauth2:
         enabled: false


### PR DESCRIPTION
~Using the 2 introduced flags `georchestra.gateway.corsEnabled` and `georchestra.gateway.csrfEnabled` we can leverage default spring security behaviour related to both security measures.~

Removing the `cors() / csrf() .disable()` calls, leaving the framework do all its own magic for us.

~Note: we keep them disabled by default, as this was the default intended behaviour.~
~Note2: this might require a revisit to make the configuration more flexible.~

Note3: With the former security-proxy, the configuration was left to the proxified webapp. If we go with this PR, we will invert the configuration and leave it to the gateway, it will then be necessary to deactivate the filters on proxified webapps, to avoid having the http response headers being set twice, which can mess up the browsers.
