### PR TITLE
Fix exception thrown issue when no rabbitmq up

### DIFF
--- a/gateway/src/main/java/org/georchestra/gateway/security/oauth2/OpenIdConnectUserMapper.java
+++ b/gateway/src/main/java/org/georchestra/gateway/security/oauth2/OpenIdConnectUserMapper.java
@@ -207,7 +207,6 @@ public class OpenIdConnectUserMapper extends OAuth2UserMapper {
                 } catch (DataServiceException e) {
                     throw new IllegalStateException(e);
                 } catch (Exception e) {
-                    throw new RuntimeException(e);
                 }
             }
 


### PR DESCRIPTION
Allow gateway to start even if no rabbit mq is up