### PR TITLE
Documentation custom error pages

### DIFF
--- a/docs/custom-error-pages.adoc
+++ b/docs/custom-error-pages.adoc
@@ -1,0 +1,31 @@
+= Customize error pages
+:toc:
+:toc-placement!:
+
+This documentation page is for configuring the error pages to custom ones using some HTML files.
+
+toc::[]
+
+== Customize error pages
+
+1. Go to application.yaml and add these new lines:
+  
+[source,yaml]
+----
+server:
+  error:
+    whitelabel:
+      enabled: false
+----    
+          
+2. In security.yaml or application.yaml check if these lines are added so that you can configure the error pages from the datadir:
+[source,yaml]
+----
+spring:
+  thymeleaf:
+    prefix: file:${georchestra.datadir}/gateway/templates/
+---- 
+
+3. In the datadir create a folder from the root directory: "gateway/templates/error"
+4. Place your error page files named as per the status code. For example for 404: 404.html
+5. Restart georchestra gateway.


### PR DESCRIPTION
This PR is for explaining how to configure custom error pages. As per following this tutorial: https://attacomsian.com/blog/spring-boot-custom-error-page

I don't really know how AsciiDoc format, so please suggest me if something is wrong. (I prefer markdown way easier to understand and use)