### PR TITLE
Fix rabbitHealthIndicator issue when rabbitmq is disabled

### DIFF
--- a/gateway/src/main/java/org/georchestra/gateway/autoconfigure/app/FiltersAutoConfiguration.java
+++ b/gateway/src/main/java/org/georchestra/gateway/autoconfigure/app/FiltersAutoConfiguration.java
@@ -68,7 +68,7 @@ public class FiltersAutoConfiguration {
         return new StripBasePathGatewayFilterFactory();
     }
 
-    @ConditionalOnProperty(name = "enableRabbitmqEvents", havingValue = "true", matchIfMissing = false)
+    @ConditionalOnProperty(name = "enableRabbitmqEvents", havingValue = "false", matchIfMissing = true)
     public @Bean HealthIndicator rabbitHealthIndicator() {
         return () -> Health.up().withDetail("version", "mock").build();
     }


### PR DESCRIPTION
rabbitHealthIndicator mock bean is created when rabbitmq is disabled to fix issue generated by rabbitmq dependencies