### PR TITLE
Disable CSRF protections

### DIFF
--- a/gateway/src/main/java/org/georchestra/gateway/security/GatewaySecurityConfiguration.java
+++ b/gateway/src/main/java/org/georchestra/gateway/security/GatewaySecurityConfiguration.java
@@ -74,6 +74,10 @@ public class GatewaySecurityConfiguration {
 
         log.info("Initializing security filter chain...");
 
+        // disable CSRF protection, considering it will be managed
+        // by proxified webapps, not the gateway.
+        http.csrf().disable();
+
         http.formLogin()
                 .authenticationFailureHandler(new ExtendedRedirectServerAuthenticationFailureHandler("login?error"))
                 .loginPage("/login");


### PR DESCRIPTION
Partially reverts https://github.com/georchestra/georchestra-gateway/pull/59: CORS is configurable via yaml config files, CSRF is not.

From my understanding, CSRF protection has to be managed separately by the underlying webapps being proxified by the gateway.