### PR TITLE
push to docker hub github actions per commit

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -50,6 +50,12 @@ jobs:
       if: github.ref != 'refs/heads/main' && github.repository == 'georchestra/georchestra-gateway'
       run: docker push georchestra/gateway:${{ steps.version.outputs.VERSION }}
 
+    - name: "Push image attached to commit id to docker.io"
+      if: github.ref == 'refs/heads/main' && github.repository == 'georchestra/georchestra-gateway'
+      run: |
+        docker tag georchestra/gateway:latest georchestra/gateway:commit-${{ github.sha }}
+        docker push georchestra/gateway:commit-${{ github.sha }}
+
     - name: "Remove SNAPSHOT jars from repository"
       run: |
         find .m2/repository -name "*SNAPSHOT*" -type d | xargs rm -rf {}


### PR DESCRIPTION
Allow to retain older versions of the master branch of georchestra gateway.

Each new commit will be available under the docker image georchestra/gateway:commit-the_sha_id

We are currently in a fast moving period of the software, and sometimes it breaks the infrastructure. It would be great to be able to easily and rapidly come back to a previous commit of gateway instead of spending the time in building a new docker image locally.

Only downside is that docker hub doesn't really allow setting ourselves an automatic expiration of the docker images. Only quay.io does allow it.
However, it seems like docker hub does it own automatic expiration so we should still be good with that: https://www.docker.com/blog/docker-hub-image-retention-policy-delayed-and-subscription-updates/