### PR TITLE
simplify configuration override from the georchestra datadir

### DIFF
--- a/gateway/src/main/resources/application.yml
+++ b/gateway/src/main/resources/application.yml
@@ -18,7 +18,8 @@ server:
 
 spring:
   config:
-    import: optional:file:${georchestra.datadir}/default.properties,optional:file:${georchestra.datadir}/gateway/gateway.yaml,optional:file:${georchestra.datadir}/gateway/security.yaml
+    # See https://github.com/georchestra/datadir/tree/master/gateway for a configuration override example
+    import: optional:file:${georchestra.datadir}/default.properties,optional:file:${georchestra.datadir}/gateway/gateway.yaml
   main:
     banner-mode: off
     web-application-type: reactive

--- a/gateway/src/test/java/org/georchestra/gateway/app/GeorchestraGatewayApplicationTests.java
+++ b/gateway/src/test/java/org/georchestra/gateway/app/GeorchestraGatewayApplicationTests.java
@@ -46,7 +46,7 @@ class GeorchestraGatewayApplicationTests {
         assertEquals("src/test/resources/test-datadir", env.getProperty("georchestra.datadir"));
 
         assertEquals(
-                "optional:file:src/test/resources/test-datadir/default.properties,optional:file:src/test/resources/test-datadir/gateway/gateway.yaml,optional:file:src/test/resources/test-datadir/gateway/security.yaml",
+                "optional:file:src/test/resources/test-datadir/default.properties,optional:file:src/test/resources/test-datadir/gateway/gateway.yaml",
                 env.getProperty("spring.config.import"));
 
         Boolean propertyFromTestDatadir = env.getProperty("georchestra.test-datadir", Boolean.class);


### PR DESCRIPTION
We don't need to source the security.yaml file from the datadir, as it will already be sourced by the datadir/gateway.yaml ; one file for override is probably enough, see:
https://github.com/georchestra/datadir/blob/master/gateway/gateway.yaml#L5


