### PR TITLE
skip org creation of org is empty

### DIFF
--- a/gateway/src/main/java/org/georchestra/gateway/accounts/admin/ldap/LdapAccountsManager.java
+++ b/gateway/src/main/java/org/georchestra/gateway/accounts/admin/ldap/LdapAccountsManager.java
@@ -25,6 +25,7 @@ import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
+import org.apache.commons.lang3.StringUtils;
 import org.georchestra.ds.DataServiceException;
 import org.georchestra.ds.DuplicatedCommonNameException;
 import org.georchestra.ds.orgs.Org;
@@ -153,7 +154,7 @@ class LdapAccountsManager extends AbstractAccountsManager {
 
     private void ensureOrgExists(@NonNull Account newAccount) {
         String orgId = newAccount.getOrg();
-        if (null == orgId)
+        if (StringUtils.isEmpty(orgId))
             return;
         try { // account created, add org
             Org org;


### PR DESCRIPTION
some IdP (e.g. FranceConnect) seem to return a blank ("") organization, we cannot rely on the `try {} catch (NameNotFoundException)` here, but at least we can just skip the org creation if we don't have at least a name to create it.

Tests: tried with the IT testsuite from the branch still in review from PR #63, but which does not exist yet ... A simple case where `preauth-org: ''` is sufficient to reproduce the issue.