### PR TITLE
LdapAccountsManager - skip organization creation of org is empty

### DIFF
--- a/gateway/src/main/java/org/georchestra/gateway/accounts/admin/ldap/LdapAccountsManager.java
+++ b/gateway/src/main/java/org/georchestra/gateway/accounts/admin/ldap/LdapAccountsManager.java
@@ -25,6 +25,7 @@ import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
+import org.apache.commons.lang3.StringUtils;
 import org.georchestra.ds.DataServiceException;
 import org.georchestra.ds.DuplicatedCommonNameException;
 import org.georchestra.ds.orgs.Org;
@@ -153,7 +154,7 @@ class LdapAccountsManager extends AbstractAccountsManager {
 
     private void ensureOrgExists(@NonNull Account newAccount) {
         String orgId = newAccount.getOrg();
-        if (null == orgId)
+        if (StringUtils.isEmpty(orgId))
             return;
         try { // account created, add org
             Org org;

--- a/gateway/src/test/java/org/georchestra/gateway/accounts/admin/CreateAccountUserCustomizerIT.java
+++ b/gateway/src/test/java/org/georchestra/gateway/accounts/admin/CreateAccountUserCustomizerIT.java
@@ -77,6 +77,14 @@ public class CreateAccountUserCustomizerIT {
             "preauth-lastname", "Test", //
             "preauth-org", "GEORCHESTRA");
 
+    private static final Map<String, String> NON_EXISTING_USER_WITH_ORG_EMPTY_HEADERS = Map.of( //
+            "sec-georchestra-preauthenticated", "true", //
+            "preauth-username", "jmflup", //
+            "preauth-email", "jmflup@georchestra.org", //
+            "preauth-firstname", "Jean-Marc", //
+            "preauth-lastname", "Flup", //
+            "preauth-org", "");
+
     private WebTestClient.RequestHeadersUriSpec<?> prepareWebTestClientHeaders(
             WebTestClient.RequestHeadersUriSpec<?> spec, Map<String, String> headers) {
         headers.forEach((k, v) -> {
@@ -145,5 +153,15 @@ public class CreateAccountUserCustomizerIT {
                         "ROLE_USER", //
                         "ROLE_MAPSTORE_ADMIN", //
                         "ROLE_EMAILPROXY"));
+    }
+
+    public @Test void testPreauthenticatedHeadersWithOrgNotNullButEmpty() throws Exception {
+        prepareWebTestClientHeaders(testClient.get(), NON_EXISTING_USER_WITH_ORG_EMPTY_HEADERS).uri("/whoami")//
+                .exchange()//
+                .expectStatus()//
+                .is2xxSuccessful()//
+                .expectBody()//
+                .jsonPath("$.GeorchestraUser").isNotEmpty()
+                .jsonPath("$.GeorchestraUser.organization").isEqualTo(null);
     }
 }


### PR DESCRIPTION
This one supersedes #79, takes back my previous one (#78), but since the preauthentication PR has now been merged, it allows me to add an integration test to reveal the bug it attempts to fix.

some IdP (e.g. FranceConnect) seem to return a blank ("") organization, we cannot rely on the `try {} catch (NameNotFoundException)` here, but at least we can just skip the org creation if we don't have at least a name to create it.

We don't handle the case "put the user into a default organization" on purpose, as I don't think this has been specified.

Tests: updated testsuite to take into account blank org.