### PR TITLE
fix: geOrchestra json headers - organization as json payload is not transmitted

### DIFF
--- a/gateway/src/main/java/org/georchestra/gateway/security/ldap/extended/ExtendedGeorchestraUser.java
+++ b/gateway/src/main/java/org/georchestra/gateway/security/ldap/extended/ExtendedGeorchestraUser.java
@@ -1,0 +1,40 @@
+package org.georchestra.gateway.security.ldap.extended;
+
+import org.georchestra.security.model.GeorchestraUser;
+import org.georchestra.security.model.Organization;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.Accessors;
+import lombok.experimental.Delegate;
+
+/**
+ * {@link GeorchestraUser} with resolved {@link #getOrg() Organization}
+ */
+@SuppressWarnings("serial")
+@RequiredArgsConstructor
+@Accessors(chain = true)
+public class ExtendedGeorchestraUser extends GeorchestraUser {
+
+    @JsonIgnore
+    private final @NonNull @Delegate GeorchestraUser user;
+
+    @JsonIgnore
+    private @Getter @Setter Organization org;
+
+    public @Override boolean equals(Object o) {
+        if (!(o instanceof GeorchestraUser)) {
+            return false;
+        }
+        return super.equals(o);
+    }
+
+    public @Override int hashCode() {
+        return super.hashCode();
+    }
+}

--- a/gateway/src/main/java/org/georchestra/gateway/security/ldap/extended/GeorchestraLdapAuthenticatedUserMapper.java
+++ b/gateway/src/main/java/org/georchestra/gateway/security/ldap/extended/GeorchestraLdapAuthenticatedUserMapper.java
@@ -67,7 +67,7 @@ class GeorchestraLdapAuthenticatedUserMapper implements GeorchestraUserMapperExt
         final String ldapConfigName = token.getConfigName();
         final String username = principal.getUsername();
 
-        Optional<GeorchestraUser> user = users.findByUsername(ldapConfigName, username);
+        Optional<ExtendedGeorchestraUser> user = users.findByUsername(ldapConfigName, username);
         if (user.isEmpty()) {
             user = users.findByEmail(ldapConfigName, username);
         }

--- a/gateway/src/main/resources/application.yml
+++ b/gateway/src/main/resources/application.yml
@@ -50,7 +50,7 @@ spring:
       - SecureHeaders
       - TokenRelay
       - RemoveSecurityHeaders
-      # AddSecHeaders appends sec-* headers to proxied requests based on the
+      # AddSecHeaders appends sec-* headers to proxied requests based on the currently authenticated user
       - AddSecHeaders
       global-filter:
         websocket-routing:

--- a/gateway/src/test/java/org/georchestra/gateway/accounts/admin/CreateAccountUserCustomizerIT.java
+++ b/gateway/src/test/java/org/georchestra/gateway/accounts/admin/CreateAccountUserCustomizerIT.java
@@ -161,7 +161,6 @@ public class CreateAccountUserCustomizerIT {
                 .expectStatus()//
                 .is2xxSuccessful()//
                 .expectBody()//
-                .jsonPath("$.GeorchestraUser").isNotEmpty()
-                .jsonPath("$.GeorchestraUser.organization").isEqualTo(null);
+                .jsonPath("$.GeorchestraUser").isNotEmpty().jsonPath("$.GeorchestraUser.organization").isEqualTo(null);
     }
 }

--- a/gateway/src/test/java/org/georchestra/gateway/security/ResolveGeorchestraUserGlobalFilterIT.java
+++ b/gateway/src/test/java/org/georchestra/gateway/security/ResolveGeorchestraUserGlobalFilterIT.java
@@ -1,0 +1,104 @@
+package org.georchestra.gateway.security;
+
+import org.georchestra.gateway.app.GeorchestraGatewayApplication;
+import org.georchestra.gateway.filter.headers.providers.JsonPayloadHeadersContributor;
+import org.georchestra.gateway.model.GatewayConfigProperties;
+import org.georchestra.gateway.model.HeaderMappings;
+import org.georchestra.testcontainers.ldap.GeorchestraLdapContainer;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ApplicationContext;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.reactive.server.WebTestClient;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.utility.DockerImageName;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@SpringBootTest(classes = GeorchestraGatewayApplication.class)
+@AutoConfigureWebTestClient(timeout = "PT20S")
+@ActiveProfiles("georheaders")
+public class ResolveGeorchestraUserGlobalFilterIT {
+
+    public static GeorchestraLdapContainer ldap = new GeorchestraLdapContainer();
+
+    private @Autowired WebTestClient testClient;
+
+    private @Autowired GatewayConfigProperties gatewayConfig;
+
+    private @Autowired ApplicationContext context;
+
+    public static GenericContainer httpEcho = new GenericContainer(DockerImageName.parse("ealen/echo-server")) {
+        @Override
+        protected void doStart() {
+            super.doStart();
+            Integer mappedPort = this.getMappedPort(80);
+            System.setProperty("httpEchoHost", this.getHost());
+            System.setProperty("httpEchoPort", mappedPort.toString());
+            System.out.println("Automatically set system property httpEchoHost=" + this.getHost());
+            System.out.println("Automatically set system property httpEchoPort=" + mappedPort);
+        }
+    };
+
+    public static @BeforeAll void startUpContainers() {
+        httpEcho.setExposedPorts(Arrays.asList(new Integer[] { 80 }));
+        httpEcho.start();
+        ldap.start();
+    }
+
+    public static @AfterAll void shutDownContainers() {
+        ldap.stop();
+        httpEcho.stop();
+    }
+
+    public @Test void testReceivedHeadersAsJson() {
+        gatewayConfig.getDefaultHeaders().setJsonUser(Optional.of(true));
+        gatewayConfig.getDefaultHeaders().setJsonOrganization(Optional.of(true));
+        assertNotNull(context.getBean(JsonPayloadHeadersContributor.class));
+
+        testClient.get().uri("/echo/")//
+                .header("Authorization", "Basic dGVzdGFkbWluOnRlc3RhZG1pbg==") // testadmin:testadmin
+                .exchange()//
+                .expectStatus()//
+                .is2xxSuccessful()//
+                .expectBody()//
+                .jsonPath(".request.headers.sec-user").exists().jsonPath(".request.headers.sec-organization").exists();
+    }
+
+    public @Test void testJsonUserNoOrganization() {
+        gatewayConfig.getDefaultHeaders().setJsonUser(Optional.of(true));
+        gatewayConfig.getDefaultHeaders().setJsonOrganization(Optional.of(false));
+
+        testClient.get().uri("/echo/")//
+                .header("Authorization", "Basic dGVzdGFkbWluOnRlc3RhZG1pbg==") // testadmin:testadmin
+                .exchange()//
+                .expectStatus()//
+                .is2xxSuccessful()//
+                .expectBody()//
+                .jsonPath(".request.headers.sec-user").exists()//
+                .jsonPath(".request.headers.sec-organization").doesNotHaveJsonPath();
+
+    }
+
+    public @Test void testNoJsonUserJsonOrganization() {
+        gatewayConfig.getDefaultHeaders().setJsonUser(Optional.of(false));
+        gatewayConfig.getDefaultHeaders().setJsonOrganization(Optional.of(true));
+
+        testClient.get().uri("/echo/")//
+                .header("Authorization", "Basic dGVzdGFkbWluOnRlc3RhZG1pbg==") // testadmin:testadmin
+                .exchange()//
+                .expectStatus()//
+                .is2xxSuccessful()//
+                .expectBody()//
+                .jsonPath(".request.headers.sec-user").doesNotHaveJsonPath()//
+                .jsonPath(".request.headers.sec-organization").exists();
+
+    }
+}

--- a/gateway/src/test/resources/application-georheaders.yml
+++ b/gateway/src/test/resources/application-georheaders.yml
@@ -1,0 +1,47 @@
+georchestra:
+  gateway:
+    default-headers:
+      # Default security headers to append to proxied requests
+      proxy: true
+      username: true
+      roles: true
+      org: true
+      orgname: true
+      #jsonUser: true
+      jsonOrganization: true
+    security:
+      ldap:
+        default:
+          enabled: true
+          extended: true
+          url: ldap://${ldapHost}:${ldapPort}/
+          baseDn: dc=georchestra,dc=org
+          adminDn: cn=admin,dc=georchestra,dc=org
+          adminPassword: secret
+          users:
+            rdn: ou=users
+            searchFilter: (uid={0})
+            pendingUsersSearchBaseDN: ou=pendingusers
+            protectedUsers: geoserver_privileged_user
+          roles:
+            rdn: ou=roles
+            searchFilter: (member={0})
+            protectedRoles: ADMINISTRATOR, EXTRACTORAPP, GN_.*, ORGADMIN, REFERENT, USER, SUPERUSER
+          orgs:
+            rdn: ou=orgs
+            orgTypes: Association,Company,NGO,Individual,Other
+            pendingOrgSearchBaseDN: ou=pendingorgs
+    services:
+      echo:
+        target: http://${httpEchoHost}:${httpEchoPort}
+        access-rules:
+          - intercept-url: /echo/**
+            anonymous: false
+spring:
+  cloud:
+    gateway:
+      routes:
+        - id: echo
+          uri: http://${httpEchoHost}:${httpEchoPort}
+          predicates:
+            - Path=/echo/


### PR DESCRIPTION
When the following configuration is set:

```yaml
georchestra:
  gateway:
    default-headers:
      proxy: true
      username: true
      roles: true
      org: true
      orgname: true
      jsonUser: true
      jsonOrganization: true
```

The `sec-organization` base64-encoded JSON header is actually not provided. It looks like the organization is not fetched from the geOrchestra LDAP, hence the code not able to serialize it as expected.