### PR TITLE
preauth - making sure the authenticated flag on the token is set to true

### DIFF
--- a/gateway/src/main/java/org/georchestra/gateway/security/preauth/PreauthAuthenticationManager.java
+++ b/gateway/src/main/java/org/georchestra/gateway/security/preauth/PreauthAuthenticationManager.java
@@ -59,7 +59,7 @@ class PreauthAuthenticationManager implements ReactiveAuthenticationManager, Ser
                 throw new IllegalStateException("Pre-authenticated user headers not provided");
             }
             PreAuthenticatedAuthenticationToken authentication = new PreAuthenticatedAuthenticationToken(username,
-                    credentials);
+                    credentials, List.of());
             return Mono.just(authentication);
         }
         return Mono.empty();

--- a/gateway/src/test/java/org/georchestra/gateway/security/preauth/HeaderPreAuthenticationConfigurationIT.java
+++ b/gateway/src/test/java/org/georchestra/gateway/security/preauth/HeaderPreAuthenticationConfigurationIT.java
@@ -54,4 +54,16 @@ public class HeaderPreAuthenticationConfigurationIT {
                 .isNotEmpty();
     }
 
+    public @Test void test_preauthenticatedHeadersAccess_isAuthenticated() {
+        assertNotNull(context.getBean(PreauthGatewaySecurityCustomizer.class));
+        assertNotNull(context.getBean(PreauthenticatedUserMapperExtension.class));
+
+        ResponseSpec exchange = prepareWebTestClientHeaders(testClient.get(), ADMIN_HEADERS).uri("/whoami").exchange();
+        BodyContentSpec body = exchange.expectStatus().is2xxSuccessful().expectBody();
+        body.jsonPath("$.['GeorchestraUser']").isNotEmpty();
+        body.jsonPath(
+                "$.['org.springframework.security.web.authentication.preauth.PreAuthenticatedAuthenticationToken'].authenticated")
+                .isEqualTo(true);
+    }
+
 }


### PR DESCRIPTION
Calling the constructor for `PreAuthenticatedAuthenticationToken` with 3 args, which sets the `authenticated` flag to `true`. This fixes issues with targets requiring that the user logged in but with no specific roles.

Without the modification,we can end up in the following situation:

![image](https://github.com/georchestra/georchestra-gateway/assets/594335/c8a449d5-9e4c-4253-b98b-cb89e16718e6)


tests: adding an IT, `make test` OK
