### PR TITLE
whoami - avoid revealing sensitive info (password) in the output

### DIFF
--- a/gateway/src/main/java/org/georchestra/gateway/security/ldap/extended/GeorchestraUserNamePasswordAuthenticationToken.java
+++ b/gateway/src/main/java/org/georchestra/gateway/security/ldap/extended/GeorchestraUserNamePasswordAuthenticationToken.java
@@ -35,7 +35,7 @@ import lombok.RequiredArgsConstructor;
  * can be used to fetch additional user identity information.
  */
 @RequiredArgsConstructor
-class GeorchestraUserNamePasswordAuthenticationToken implements Authentication {
+public class GeorchestraUserNamePasswordAuthenticationToken implements Authentication {
 
     private static final long serialVersionUID = 1L;
 
@@ -54,7 +54,7 @@ class GeorchestraUserNamePasswordAuthenticationToken implements Authentication {
 
     @Override
     public Object getCredentials() {
-        return orig.getCredentials();
+        return null;
     }
 
     @Override


### PR DESCRIPTION
do not pass the `getCredentials()` call to the delegated `Authentication` object on  a `GeorchestraUserNamePasswordAuthenticationToken`, returning `null` instead.

Tests: added a utest, make test OK, runtime test on the default docker composition at the root of the repository.

Note: I am not sure if we need to check other Authentication objects that the configuration could allow. In case of preauthentication via headers or oauth2, we won't have the information anyway, but what about other pure spring security objects ?


