### PR TITLE
preauth - being able to receive base64-encoded headers

### DIFF
--- a/docs/pre-authentication.adoc
+++ b/docs/pre-authentication.adoc
@@ -31,6 +31,15 @@ The following headers are expected to be received by the Gateway:
 * `preauth-lastname`: the surname of the user (e.g. "Mauduit")
 * `preauth-org`: the organisation identifier (e.g. "geOrchestra")
 
+== Charset considerations & encoded headers
+
+As the framework will consider the received headers as pure `us-ascii`, this can lead to issues when values contain
+accented characters. To circumvent this, it is possible to
+configure the gateway to receive base64-encoded http headers.
+
+If the headers values are prefixed with `{base64}`, then the `gateway` will
+base64-decode the HTTP headers' values  - apart from the `sec-georchestra-preauthenticated` which should still be set to `true` as plaintext - before using them.
+
 == Account creation
 
 In order to be able to administer users who are using the pre-authentication mechanism,
@@ -168,6 +177,9 @@ The following Apache configuration has been used in a setup to interact with the
         RequestHeader set preauth-firstname %{MELLON_GIVEN_NAME}e "expr=-n env('MELLON_GIVEN_NAME')"
         RequestHeader set preauth-lastname %{MELLON_SN}e "expr=-n env('MELLON_SN')"
         RequestHeader set preauth-org %{MELLON_O}e "expr=-n env('MELLON_O')"
+        # If needed to base64-encode the headers because of them containing accented characters, you can
+        # use the following syntax and adapt the other headers above:
+        # RequestHeader set preauth-lastname "expr={base64}%{base64:%{env:MELLON_SN}}"   "expr=-n env('MELLON_SN')"
 
         ProxyPass "http://georchestra-gateway-svc:8080/"
         ProxyPassReverse "http://georchestra-gateway-svc:8080/"

--- a/gateway/src/main/java/org/georchestra/gateway/security/preauth/HeaderPreauthConfigProperties.java
+++ b/gateway/src/main/java/org/georchestra/gateway/security/preauth/HeaderPreauthConfigProperties.java
@@ -45,5 +45,4 @@ public class HeaderPreauthConfigProperties {
      * preauth-lastname, preauth-org, preauth-email, preauth-roles
      */
     private boolean enabled = false;
-
 }

--- a/gateway/src/main/java/org/georchestra/gateway/security/preauth/PreauthAuthenticationManager.java
+++ b/gateway/src/main/java/org/georchestra/gateway/security/preauth/PreauthAuthenticationManager.java
@@ -24,7 +24,10 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import lombok.RequiredArgsConstructor;
+import org.georchestra.commons.security.SecurityHeaders;
 import org.georchestra.security.model.GeorchestraUser;
+import org.ldaptive.io.Base64;
 import org.springframework.http.HttpHeaders;
 import org.springframework.security.authentication.ReactiveAuthenticationManager;
 import org.springframework.security.core.Authentication;
@@ -83,12 +86,12 @@ class PreauthAuthenticationManager implements ReactiveAuthenticationManager, Ser
     }
 
     public static GeorchestraUser map(Map<String, String> requestHeaders) {
-        String username = requestHeaders.get(PREAUTH_USERNAME);
-        String email = requestHeaders.get(PREAUTH_EMAIL);
-        String firstName = requestHeaders.get(PREAUTH_FIRSTNAME);
-        String lastName = requestHeaders.get(PREAUTH_LASTNAME);
-        String org = requestHeaders.get(PREAUTH_ORG);
-        String rolesValue = requestHeaders.get(PREAUTH_ROLES);
+        String username = SecurityHeaders.decode(requestHeaders.get(PREAUTH_USERNAME));
+        String email = SecurityHeaders.decode(requestHeaders.get(PREAUTH_EMAIL));
+        String firstName = SecurityHeaders.decode(requestHeaders.get(PREAUTH_FIRSTNAME));
+        String lastName = SecurityHeaders.decode(requestHeaders.get(PREAUTH_LASTNAME));
+        String org = SecurityHeaders.decode(requestHeaders.get(PREAUTH_ORG));
+        String rolesValue = SecurityHeaders.decode(requestHeaders.get(PREAUTH_ROLES));
         List<String> roleNames = Optional.ofNullable(rolesValue)
                 .map(roles -> Stream
                         .concat(Stream.of("ROLE_USER"), Stream.of(roles.split(";")).filter(StringUtils::hasText))

--- a/gateway/src/main/java/org/georchestra/gateway/security/preauth/PreauthenticatedUserMapperExtension.java
+++ b/gateway/src/main/java/org/georchestra/gateway/security/preauth/PreauthenticatedUserMapperExtension.java
@@ -21,6 +21,7 @@ package org.georchestra.gateway.security.preauth;
 import java.util.Map;
 import java.util.Optional;
 
+import lombok.RequiredArgsConstructor;
 import org.georchestra.gateway.security.GeorchestraUserMapperExtension;
 import org.georchestra.security.model.GeorchestraUser;
 import org.springframework.security.core.Authentication;

--- a/gateway/src/main/resources/application.yml
+++ b/gateway/src/main/resources/application.yml
@@ -70,6 +70,8 @@ georchestra:
   gateway:
     security:
       create-non-existing-users-in-l-d-a-p: false
+      header-authentication:
+        enabled: false
       events:
         rabbitmq:
           # Note usually enableRabbitmqEvents, rabbitmqHost, etc. come from georchestra's default.properties

--- a/gateway/src/test/java/org/georchestra/gateway/accounts/admin/CreateAccountUserCustomizerIT.java
+++ b/gateway/src/test/java/org/georchestra/gateway/accounts/admin/CreateAccountUserCustomizerIT.java
@@ -1,8 +1,10 @@
 package org.georchestra.gateway.accounts.admin;
 
 import org.georchestra.ds.orgs.OrgsDao;
+import org.georchestra.ds.users.Account;
 import org.georchestra.ds.users.AccountDao;
 import org.georchestra.gateway.app.GeorchestraGatewayApplication;
+import org.georchestra.gateway.security.preauth.HeaderPreauthConfigProperties;
 import org.georchestra.testcontainers.ldap.GeorchestraLdapContainer;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.AfterAll;
@@ -18,8 +20,7 @@ import org.springframework.test.web.reactive.server.WebTestClient;
 
 import java.util.Map;
 
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Integration tests for {@link CreateAccountUserCustomizer}.
@@ -31,7 +32,6 @@ public class CreateAccountUserCustomizerIT {
     private @Autowired WebTestClient testClient;
 
     private @Autowired ApplicationContext context;
-
     private @Autowired AccountDao accountDao;
 
     private @Autowired OrgsDao orgsDao;

--- a/gateway/src/test/java/org/georchestra/gateway/accounts/admin/PreauthHttpHeadersBase64EncodedCreateAccountIT.java
+++ b/gateway/src/test/java/org/georchestra/gateway/accounts/admin/PreauthHttpHeadersBase64EncodedCreateAccountIT.java
@@ -1,0 +1,59 @@
+package org.georchestra.gateway.accounts.admin;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.georchestra.ds.users.Account;
+import org.georchestra.ds.users.AccountDao;
+import org.georchestra.gateway.app.GeorchestraGatewayApplication;
+import org.georchestra.testcontainers.ldap.GeorchestraLdapContainer;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.reactive.server.WebTestClient;
+
+@SpringBootTest(classes = GeorchestraGatewayApplication.class)
+@AutoConfigureWebTestClient(timeout = "PT20S")
+@ActiveProfiles({ "createaccount", "preauthbase64encoded" })
+class PreauthHttpHeadersBase64EncodedCreateAccountIT {
+
+    private @Autowired WebTestClient testClient;
+
+    private @Autowired AccountDao accountDao;
+
+    public static GeorchestraLdapContainer ldap = new GeorchestraLdapContainer();
+
+    public static @BeforeAll void startUpContainers() {
+        ldap.start();
+    }
+
+    public static @AfterAll void shutDownContainers() {
+        ldap.stop();
+    }
+
+    @Test
+    void testPreauthenticatedHeaders_AccentedChars() throws Exception {
+        testClient.get().uri("/whoami")//
+                .header("sec-georchestra-preauthenticated", "true")//
+                .header("preauth-username", "{base64}ZnZhbmRlcmJsYWg=")//
+                .header("preauth-email", "{base64}ZnZhbmRlcmJsYWhAZ2VvcmNoZXN0cmEub3Jn")//
+                .header("preauth-firstname", "{base64}RnJhbsOnb2lz")//
+                .header("preauth-lastname", "{base64}VmFuIERlciBBY2NlbnTDqWQgQ2jDoHJhY3TDqHJz")//
+                .header("preauth-org", "{base64}R0VPUkNIRVNUUkE=")//
+                .exchange()//
+                .expectStatus()//
+                .is2xxSuccessful()//
+                .expectBody()//
+                .jsonPath("$.GeorchestraUser").isNotEmpty();
+
+        // Make sure the account has been created and the strings have been correctly
+        // evaluated at creation
+        Account created = accountDao.findByUID("fvanderblah");
+
+        assertThat(created.getSurname()).isEqualTo("Van Der Accentéd Chàractèrs");
+        assertThat(created.getGivenName()).isEqualTo("François");
+    }
+}

--- a/gateway/src/test/resources/application-preauth.yml
+++ b/gateway/src/test/resources/application-preauth.yml
@@ -56,4 +56,3 @@ spring:
         - AddSecHeaders
       httpclient.wiretap: true
       httpserver.wiretap: false
-


### PR DESCRIPTION
As Netty will always consider received headers as US-ASCII encoded strings, this can lead to issues when the values contain accented characters.

With this new feature, it is possible to consider the headers values as base64-encoded, which will be decoded before use.

Tests: IT added.