### PR TITLE
Updated OAuth2 provider and organization fields in account creation e-mails

### DIFF
--- a/gateway/src/main/java/org/georchestra/gateway/accounts/events/rabbitmq/RabbitmqAccountCreatedEventSender.java
+++ b/gateway/src/main/java/org/georchestra/gateway/accounts/events/rabbitmq/RabbitmqAccountCreatedEventSender.java
@@ -47,19 +47,28 @@ public class RabbitmqAccountCreatedEventSender {
         final String oAuth2ProviderId = user.getOAuth2ProviderId();
         if (null != oAuth2ProviderId) {
             String fullName = user.getFirstName() + " " + user.getLastName();
+            String localUid = user.getUsername();
             String email = user.getEmail();
             String organization = user.getOrganization();
             String[] providerFields = oAuth2ProviderId.split(";");
-            sendNewOAuthAccountMessage(fullName, email, organization, providerFields[0], providerFields[1]);
+            String providerName = "";
+            String providerUid = "";
+            if(providerFields.length == 2)
+            {
+                providerName = providerFields[0];
+                providerUid = providerFields[1];
+            }
+            sendNewOAuthAccountMessage(fullName, localUid, email, organization, providerName, providerUid);
         }
     }
 
-    public void sendNewOAuthAccountMessage(String fullName, String email, String organization, String providerName,
-            String providerUid) {
+    public void sendNewOAuthAccountMessage(String fullName, String localUid, String email, String organization,
+            String providerName, String providerUid) {
         JSONObject jsonObj = new JSONObject();
         jsonObj.put("uid", UUID.randomUUID());
         jsonObj.put("subject", OAUTH2_ACCOUNT_CREATION);
-        jsonObj.put("username", fullName);
+        jsonObj.put("fullName", fullName);
+        jsonObj.put("localUid", localUid);
         jsonObj.put("email", email);
         jsonObj.put("organization", organization);
         jsonObj.put("providerName", providerName);

--- a/gateway/src/main/java/org/georchestra/gateway/accounts/events/rabbitmq/RabbitmqAccountCreatedEventSender.java
+++ b/gateway/src/main/java/org/georchestra/gateway/accounts/events/rabbitmq/RabbitmqAccountCreatedEventSender.java
@@ -48,19 +48,22 @@ public class RabbitmqAccountCreatedEventSender {
         if (null != oAuth2ProviderId) {
             String fullName = user.getFirstName() + " " + user.getLastName();
             String email = user.getEmail();
-            String provider = oAuth2ProviderId;
-            sendNewOAuthAccountMessage(fullName, email, provider);
+            String organization = user.getOrganization();
+            String[] providerFields = oAuth2ProviderId.split(";");
+            sendNewOAuthAccountMessage(fullName, email, organization, providerFields[0], providerFields[1]);
         }
     }
 
-    public void sendNewOAuthAccountMessage(String fullName, String email, String provider) {
-        // beans getting a reference to the sender
+    public void sendNewOAuthAccountMessage(String fullName, String email, String organization, String providerName,
+            String providerUid) {
         JSONObject jsonObj = new JSONObject();
         jsonObj.put("uid", UUID.randomUUID());
         jsonObj.put("subject", OAUTH2_ACCOUNT_CREATION);
-        jsonObj.put("username", fullName); // bean
-        jsonObj.put("email", email); // bean
-        jsonObj.put("provider", provider); // bean
+        jsonObj.put("username", fullName);
+        jsonObj.put("email", email);
+        jsonObj.put("organization", organization);
+        jsonObj.put("providerName", providerName);
+        jsonObj.put("providerUid", providerUid);
         eventTemplate.convertAndSend("routing-gateway", jsonObj.toString());// send
     }
 }


### PR DESCRIPTION
Sending User Details including provider name and provider Uid and organization to console when creating a new OAuth2 account.