### PR TITLE
Allow building with a Java 21 JDK

### DIFF
--- a/gateway/pom.xml
+++ b/gateway/pom.xml
@@ -188,7 +188,7 @@
             <configuration>
               <rules>
                 <requireJavaVersion>
-                  <version>11</version>
+                  <version>[11,)</version>
                 </requireJavaVersion>
                 <requireMavenVersion>
                   <version>[3.6.3,)</version>

--- a/gateway/pom.xml
+++ b/gateway/pom.xml
@@ -318,7 +318,7 @@
             <path>
               <groupId>org.projectlombok</groupId>
               <artifactId>lombok</artifactId>
-              <version>1.18.22</version>
+              <version>${lombok.version}</version>
             </path>
           </annotationProcessorPaths>
         </configuration>

--- a/gateway/pom.xml
+++ b/gateway/pom.xml
@@ -313,7 +313,7 @@
             <path>
               <groupId>org.springframework.boot</groupId>
               <artifactId>spring-boot-configuration-processor</artifactId>
-              <version>2.6.6</version>
+              <version>2.7.12</version>
             </path>
             <path>
               <groupId>org.projectlombok</groupId>

--- a/gateway/pom.xml
+++ b/gateway/pom.xml
@@ -143,7 +143,7 @@
         <plugin>
           <groupId>org.jacoco</groupId>
           <artifactId>jacoco-maven-plugin</artifactId>
-          <version>0.8.8</version>
+          <version>0.8.11</version>
         </plugin>
       </plugins>
     </pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,7 @@
   </modules>
   <properties>
     <revision>23.1-SNAPSHOT</revision>
+    <georchestra.version>${project.version}</georchestra.version>
     <spring-cloud.version>2021.0.7</spring-cloud.version>
     <formatter-maven-plugin.version>2.10.0</formatter-maven-plugin.version>
     <fmt.skip>false</fmt.skip>
@@ -40,12 +41,12 @@
       <dependency>
         <groupId>org.georchestra</groupId>
         <artifactId>georchestra-ldap-account-management</artifactId>
-	<version>${project.version}</version>
+	<version>${georchestra.version}</version>
       </dependency>
       <dependency>
         <groupId>org.georchestra</groupId>
         <artifactId>georchestra-testcontainers</artifactId>
-	<version>${project.version}</version>
+	<version>${georchestra.version}</version>
         <scope>test</scope>
       </dependency>
       <!--spring-security-oauth2 dependencies version forced to 5.6.2

--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,7 @@
     <pom.fmt.skip>${fmt.skip}</pom.fmt.skip>
     <imageTag>${project.version}</imageTag>
     <spring-boot.build-image.imageName>georchestra/gateway:${imageTag}</spring-boot.build-image.imageName>
+    <lombok.version>1.18.30</lombok.version>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -41,12 +42,12 @@
       <dependency>
         <groupId>org.georchestra</groupId>
         <artifactId>georchestra-ldap-account-management</artifactId>
-	<version>${georchestra.version}</version>
+        <version>${georchestra.version}</version>
       </dependency>
       <dependency>
         <groupId>org.georchestra</groupId>
         <artifactId>georchestra-testcontainers</artifactId>
-	<version>${georchestra.version}</version>
+        <version>${georchestra.version}</version>
         <scope>test</scope>
       </dependency>
       <!--spring-security-oauth2 dependencies version forced to 5.6.2
@@ -61,78 +62,88 @@
           }
           which causes issues.
       -->
-     <dependency>
-       <groupId>org.springframework.security</groupId>
-       <artifactId>spring-security-oauth2-client</artifactId>
-       <version>5.6.2</version>
-     </dependency>
-     <dependency>
-       <groupId>org.springframework.security</groupId>
-       <artifactId>spring-security-oauth2-core</artifactId>
-       <version>5.6.2</version>
-     </dependency>
-     <dependency>
-       <groupId>org.springframework.security</groupId>
-       <artifactId>spring-security-oauth2-jose</artifactId>
-       <version>5.6.2</version>
-     </dependency>
-   </dependencies>
- </dependencyManagement>
- <repositories>
-   <repository>
-      <snapshots>
-        <enabled>true</enabled>
-        <checksumPolicy>ignore</checksumPolicy>
-        <updatePolicy>always</updatePolicy>
-      </snapshots>
+      <dependency>
+        <groupId>org.springframework.security</groupId>
+        <artifactId>spring-security-oauth2-client</artifactId>
+        <version>5.6.2</version>
+      </dependency>
+      <dependency>
+        <groupId>org.springframework.security</groupId>
+        <artifactId>spring-security-oauth2-core</artifactId>
+        <version>5.6.2</version>
+      </dependency>
+      <dependency>
+        <groupId>org.springframework.security</groupId>
+        <artifactId>spring-security-oauth2-jose</artifactId>
+        <version>5.6.2</version>
+      </dependency>
+      <dependency>
+        <groupId>org.projectlombok</groupId>
+        <artifactId>lombok</artifactId>
+        <version>${lombok.version}</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+  <repositories>
+    <repository>
       <releases>
         <enabled>true</enabled>
-        <checksumPolicy>ignore</checksumPolicy>
         <updatePolicy>always</updatePolicy>
+        <checksumPolicy>ignore</checksumPolicy>
       </releases>
+      <snapshots>
+        <enabled>true</enabled>
+        <updatePolicy>always</updatePolicy>
+        <checksumPolicy>ignore</checksumPolicy>
+      </snapshots>
       <id>georchestra</id>
       <url>https://artifactory.georchestra.org/artifactory/maven</url>
     </repository>
-   <repository>
-     <snapshots>
-       <enabled>false</enabled>
-     </snapshots>
-     <id>spring-milestones</id>
-     <name>Spring Milestones</name>
-     <url>https://repo.spring.io/milestone</url>
-   </repository>
- </repositories>
- <build>
-   <pluginManagement>
-     <plugins>
-       <plugin>
-         <groupId>org.springframework.boot</groupId>
-         <artifactId>spring-boot-maven-plugin</artifactId>
-         <configuration>
-           <excludes>
-             <exclude>
-               <groupId>org.projectlombok</groupId>
-               <artifactId>lombok</artifactId>
-             </exclude>
-           </excludes>
-         </configuration>
-       </plugin>
-       <plugin>
-         <groupId>org.codehaus.mojo</groupId>
-         <artifactId>flatten-maven-plugin</artifactId>
-         <version>1.2.2</version>
-       </plugin>
-       <plugin>
-         <groupId>net.revelc.code.formatter</groupId>
-         <artifactId>formatter-maven-plugin</artifactId>
-         <version>${formatter-maven-plugin.version}</version>
-       </plugin>
-       <plugin>
-         <groupId>com.github.ekryd.sortpom</groupId>
-         <artifactId>sortpom-maven-plugin</artifactId>
-         <version>2.15.0</version>
-       </plugin>
-     </plugins>
-   </pluginManagement>
- </build>
+    <repository>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+      <id>spring-milestones</id>
+      <name>Spring Milestones</name>
+      <url>https://repo.spring.io/milestone</url>
+    </repository>
+  </repositories>
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.springframework.boot</groupId>
+          <artifactId>spring-boot-maven-plugin</artifactId>
+          <configuration>
+            <excludes>
+              <exclude>
+                <groupId>org.projectlombok</groupId>
+                <artifactId>lombok</artifactId>
+              </exclude>
+            </excludes>
+          </configuration>
+        </plugin>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>flatten-maven-plugin</artifactId>
+          <version>1.4.1</version>
+        </plugin>
+        <plugin>
+          <groupId>net.revelc.code.formatter</groupId>
+          <artifactId>formatter-maven-plugin</artifactId>
+          <version>${formatter-maven-plugin.version}</version>
+        </plugin>
+        <plugin>
+          <groupId>com.github.ekryd.sortpom</groupId>
+          <artifactId>sortpom-maven-plugin</artifactId>
+          <version>2.15.0</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>3.12.1</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
 </project>


### PR DESCRIPTION
* enforcer-maven-plugin: allow java 11+
* Upgrade lombok and maven-compiler-plugin to latest versions
* Upgrade jacoco-maven-plugin:0.8.11
* Match spring-boot-configuration-processor version with current spring version
* Specify georchestra module dependency version separate from project version
