### PR TITLE
Refactored OAuth2 accounts in LDAP

### DIFF
--- a/gateway/src/main/java/org/georchestra/gateway/accounts/admin/AbstractAccountsManager.java
+++ b/gateway/src/main/java/org/georchestra/gateway/accounts/admin/AbstractAccountsManager.java
@@ -50,8 +50,8 @@ public abstract class AbstractAccountsManager implements AccountManager {
     }
 
     protected Optional<GeorchestraUser> findInternal(GeorchestraUser mappedUser) {
-        if (null != mappedUser.getOAuth2ProviderId()) {
-            return findByOAuth2ProviderId(mappedUser.getOAuth2ProviderId());
+        if ((null != mappedUser.getOAuth2Provider()) && (null != mappedUser.getOAuth2Uid())) {
+            return findByOAuth2Uid(mappedUser.getOAuth2Provider(), mappedUser.getOAuth2Uid());
         }
         return findByUsername(mappedUser.getUsername());
     }
@@ -73,7 +73,7 @@ public abstract class AbstractAccountsManager implements AccountManager {
         }
     }
 
-    protected abstract Optional<GeorchestraUser> findByOAuth2ProviderId(String oauth2ProviderId);
+    protected abstract Optional<GeorchestraUser> findByOAuth2Uid(String oauth2Provider, String oauth2Uid);
 
     protected abstract Optional<GeorchestraUser> findByUsername(String username);
 

--- a/gateway/src/main/java/org/georchestra/gateway/accounts/admin/CreateAccountUserCustomizer.java
+++ b/gateway/src/main/java/org/georchestra/gateway/accounts/admin/CreateAccountUserCustomizer.java
@@ -61,7 +61,8 @@ public class CreateAccountUserCustomizer implements GeorchestraUserCustomizerExt
         final boolean isOauth2 = auth instanceof OAuth2AuthenticationToken;
         final boolean isPreAuth = auth instanceof PreAuthenticatedAuthenticationToken;
         if (isOauth2) {
-            Objects.requireNonNull(mappedUser.getOAuth2ProviderId(), "GeorchestraUser.oAuth2ProviderId is null");
+            Objects.requireNonNull(mappedUser.getOAuth2Provider(), "GeorchestraUser.oAuth2Provider is null");
+            Objects.requireNonNull(mappedUser.getOAuth2Uid(), "GeorchestraUser.oAuth2Uid is null");
         }
         if (isPreAuth) {
             Objects.requireNonNull(mappedUser.getUsername(), "GeorchestraUser.username is null");

--- a/gateway/src/main/java/org/georchestra/gateway/accounts/admin/ldap/LdapAccountsManager.java
+++ b/gateway/src/main/java/org/georchestra/gateway/accounts/admin/ldap/LdapAccountsManager.java
@@ -73,8 +73,8 @@ class LdapAccountsManager extends AbstractAccountsManager {
     }
 
     @Override
-    protected Optional<GeorchestraUser> findByOAuth2ProviderId(@NonNull String oauth2ProviderId) {
-        return usersApi.findByOAuth2ProviderId(oauth2ProviderId).map(this::ensureRolesPrefixed);
+    protected Optional<GeorchestraUser> findByOAuth2Uid(@NonNull String oAuth2Provider, @NonNull String oAuth2Uid) {
+        return usersApi.findByOAuth2Uid(oAuth2Provider, oAuth2Uid).map(this::ensureRolesPrefixed);
     }
 
     @Override
@@ -145,10 +145,11 @@ class LdapAccountsManager extends AbstractAccountsManager {
         String phone = "";
         String title = "";
         String description = "";
-        final @javax.annotation.Nullable String oAuth2ProviderId = preAuth.getOAuth2ProviderId();
+        final @javax.annotation.Nullable String oAuth2Provider = preAuth.getOAuth2Provider();
+        final @javax.annotation.Nullable String oAuth2Uid = preAuth.getOAuth2Uid();
 
         Account newAccount = AccountFactory.createBrief(username, password, firstName, lastName, email, phone, title,
-                description, oAuth2ProviderId);
+                description, oAuth2Provider, oAuth2Uid);
         newAccount.setPending(false);
         if (StringUtils.isEmpty(org) && !StringUtils.isBlank(defaultOrganization)) {
             newAccount.setOrg(defaultOrganization);

--- a/gateway/src/main/java/org/georchestra/gateway/accounts/events/rabbitmq/RabbitmqAccountCreatedEventSender.java
+++ b/gateway/src/main/java/org/georchestra/gateway/accounts/events/rabbitmq/RabbitmqAccountCreatedEventSender.java
@@ -44,21 +44,14 @@ public class RabbitmqAccountCreatedEventSender {
     @EventListener(AccountCreated.class)
     public void on(AccountCreated event) {
         GeorchestraUser user = event.getUser();
-        final String oAuth2ProviderId = user.getOAuth2ProviderId();
-        if (null != oAuth2ProviderId) {
+        final String oAuth2Provider = user.getOAuth2Provider();
+        if (null != oAuth2Provider) {
             String fullName = user.getFirstName() + " " + user.getLastName();
             String localUid = user.getUsername();
             String email = user.getEmail();
             String organization = user.getOrganization();
-            String[] providerFields = oAuth2ProviderId.split(";");
-            String providerName = "";
-            String providerUid = "";
-            if(providerFields.length == 2)
-            {
-                providerName = providerFields[0];
-                providerUid = providerFields[1];
-            }
-            sendNewOAuthAccountMessage(fullName, localUid, email, organization, providerName, providerUid);
+            String oAuth2Uid = user.getOAuth2Uid();
+            sendNewOAuthAccountMessage(fullName, localUid, email, organization, oAuth2Provider, oAuth2Uid);
         }
     }
 

--- a/gateway/src/main/java/org/georchestra/gateway/security/oauth2/OAuth2UserMapper.java
+++ b/gateway/src/main/java/org/georchestra/gateway/security/oauth2/OAuth2UserMapper.java
@@ -78,9 +78,8 @@ public class OAuth2UserMapper implements GeorchestraUserMapperExtension {
 
         OAuth2User oAuth2User = token.getPrincipal();
         GeorchestraUser user = new GeorchestraUser();
-        final String oAuth2ProviderId = String.format("%s;%s", token.getAuthorizedClientRegistrationId(),
-                token.getName());
-        user.setOAuth2ProviderId(oAuth2ProviderId);
+        user.setOAuth2Provider(token.getAuthorizedClientRegistrationId());
+        user.setOAuth2Uid(token.getName());
 
         Map<String, Object> attributes = oAuth2User.getAttributes();
 

--- a/gateway/src/main/java/org/georchestra/gateway/security/oauth2/OpenIdConnectUserMapper.java
+++ b/gateway/src/main/java/org/georchestra/gateway/security/oauth2/OpenIdConnectUserMapper.java
@@ -152,6 +152,8 @@ public class OpenIdConnectUserMapper extends OAuth2UserMapper {
         try {
             applyStandardClaims(oidcUser, user);
             applyNonStandardClaims(oidcUser.getClaims(), user);
+            user.setUsername((token.getAuthorizedClientRegistrationId() + "_" + user.getUsername())
+                    .replaceAll("[^a-zA-Z0-9-_]", "_"));
         } catch (Exception e) {
             log.error("Error mapping non-standard OIDC claims for authenticated user", e);
             throw new IllegalStateException(e);
@@ -193,7 +195,7 @@ public class OpenIdConnectUserMapper extends OAuth2UserMapper {
         String formattedAddress = address == null ? null : address.getFormatted();
 
         apply(target::setId, subjectId);
-        apply(target::setUsername, preferredUsername, email);
+        apply(target::setUsername, preferredUsername, subjectId);
         apply(target::setFirstName, givenName);
         apply(target::setLastName, familyName);
         apply(target::setEmail, email);

--- a/gateway/src/main/java/org/georchestra/gateway/security/oauth2/OpenIdConnectUserMapper.java
+++ b/gateway/src/main/java/org/georchestra/gateway/security/oauth2/OpenIdConnectUserMapper.java
@@ -153,7 +153,7 @@ public class OpenIdConnectUserMapper extends OAuth2UserMapper {
             applyStandardClaims(oidcUser, user);
             applyNonStandardClaims(oidcUser.getClaims(), user);
             user.setUsername((token.getAuthorizedClientRegistrationId() + "_" + user.getUsername())
-                    .replaceAll("[^a-zA-Z0-9-_]", "_"));
+                    .replaceAll("[^a-zA-Z0-9-_]", "_").toLowerCase());
         } catch (Exception e) {
             log.error("Error mapping non-standard OIDC claims for authenticated user", e);
             throw new IllegalStateException(e);


### PR DESCRIPTION
Following changes to apply :
* Changed UID format from email address to `provider_uid`
* Split `oAuth2ProviderId` to two fields : `oAuth2Provider` and `oAuth2Uid`

Need [georchestra PR#4162](https://github.com/georchestra/georchestra/pull/4162) to build and work