### PR TITLE
Map connection exceptions to HTTP 503 status code instead of 500

### DIFF
--- a/gateway/src/main/java/org/georchestra/gateway/autoconfigure/app/CustomErrorAttributes.java
+++ b/gateway/src/main/java/org/georchestra/gateway/autoconfigure/app/CustomErrorAttributes.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2023 by the geOrchestra PSC
+ *
+ * This file is part of geOrchestra.
+ *
+ * geOrchestra is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * geOrchestra is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * geOrchestra.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.georchestra.gateway.autoconfigure.app;
+
+import java.net.ConnectException;
+import java.net.UnknownHostException;
+import java.util.Map;
+
+import org.springframework.boot.autoconfigure.web.reactive.error.ErrorWebFluxAutoConfiguration;
+import org.springframework.boot.web.error.ErrorAttributeOptions;
+import org.springframework.boot.web.reactive.error.DefaultErrorAttributes;
+import org.springframework.boot.web.reactive.error.ErrorAttributes;
+import org.springframework.boot.web.reactive.error.ErrorWebExceptionHandler;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.reactive.function.server.ServerRequest;
+
+/**
+ * Maps connection exceptions to HTTP 503 status code instead of 500
+ * <p>
+ * In the event that a route exists and the downstream service is not available,
+ * usually the Gateway returns a 503 status code as expected.
+ * <p>
+ * On a dynamic environment though, such as k8s and docker compose, the
+ * underlying error results from a DNS lookup failure, and the default error is
+ * 500 instead.
+ * <p>
+ * This {@link ErrorAttributes} overrides the {@link DefaultErrorAttributes}
+ * configured in {@link ErrorWebFluxAutoConfiguration} and injected to the
+ * {@link ErrorWebExceptionHandler}, and translates
+ * {@link java.net.UnknownHostException} and {@link java.net.ConnectException}
+ * to {@link HttpStatus#SERVICE_UNAVAILABLE}
+ */
+class CustomErrorAttributes extends DefaultErrorAttributes {
+
+    @Override
+    public Map<String, Object> getErrorAttributes(ServerRequest request, ErrorAttributeOptions options) {
+        Map<String, Object> attributes = super.getErrorAttributes(request, options);
+        Throwable error = super.getError(request);
+        if (error instanceof UnknownHostException || error instanceof ConnectException) {
+            attributes.put("status", HttpStatus.SERVICE_UNAVAILABLE.value());
+            attributes.put("error", HttpStatus.SERVICE_UNAVAILABLE.getReasonPhrase());
+        }
+        return attributes;
+    }
+
+}

--- a/gateway/src/main/java/org/georchestra/gateway/autoconfigure/app/ErrorCustomizerAutoConfiguration.java
+++ b/gateway/src/main/java/org/georchestra/gateway/autoconfigure/app/ErrorCustomizerAutoConfiguration.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2023 by the geOrchestra PSC
+ *
+ * This file is part of geOrchestra.
+ *
+ * geOrchestra is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * geOrchestra is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * geOrchestra.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.georchestra.gateway.autoconfigure.app;
+
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.web.reactive.error.ErrorWebFluxAutoConfiguration;
+import org.springframework.boot.web.reactive.error.ErrorWebExceptionHandler;
+import org.springframework.context.annotation.Bean;
+
+/**
+ * Overrides the {@lin k DefaultErrorAttributes} configured in
+ * {@link ErrorWebFluxAutoConfiguration} and injected to the
+ * {@link ErrorWebExceptionHandler}
+ */
+@AutoConfiguration(before = ErrorWebFluxAutoConfiguration.class)
+public class ErrorCustomizerAutoConfiguration {
+
+    @Bean
+    CustomErrorAttributes customErrorAttributes() {
+        return new CustomErrorAttributes();
+    }
+}

--- a/gateway/src/main/resources/META-INF/spring.factories
+++ b/gateway/src/main/resources/META-INF/spring.factories
@@ -7,4 +7,5 @@ org.georchestra.gateway.autoconfigure.security.LdapSecurityAutoConfiguration,\
 org.georchestra.gateway.autoconfigure.security.OAuth2SecurityAutoConfiguration,\
 org.georchestra.gateway.autoconfigure.security.HeaderPreAuthenticationAutoConfiguration,\
 org.georchestra.gateway.autoconfigure.accounts.GeorchestraLdapAccountsCreationAutoConfiguration,\
-org.georchestra.gateway.autoconfigure.accounts.RabbitmqEventsAutoConfiguration
+org.georchestra.gateway.autoconfigure.accounts.RabbitmqEventsAutoConfiguration,\
+org.georchestra.gateway.autoconfigure.app.ErrorCustomizerAutoConfiguration

--- a/gateway/src/test/resources/test-datadir/gateway/gateway.yaml
+++ b/gateway/src/test/resources/test-datadir/gateway/gateway.yaml
@@ -7,6 +7,10 @@ spring:
         uri: http://test.com
         predicates:
         - Path=/test
+      - id: unknownHostRoute
+        uri: http://not.a.valid.host
+        predicates:
+        - Path=/path/to/unavailable/service
 georchestra:
   test-datadir: true #used to verify the config is loaded from the datadir
   gateway:
@@ -24,3 +28,7 @@ georchestra:
         - ROLE_ADMINISTRATOR
         - ROLE_GN_ADMIN
         - ROLE_GP.GDI.ADMINISTRATOR
+    global-access-rules:
+    - intercept-url:
+      - /**
+      anonymous: true


### PR DESCRIPTION
In the event that a route exists and the downstream service is not available, usually the Gateway returns a 503 status code as expected.

On a dynamic environment though, such as k8s and docker compose, the underlying error results from a DNS lookup failure, and the default error is 500 instead.

A custom `org.springframework.boot.web.reactive.error.ErrorAttributes` is now used to override the `DefaultErrorAttributes` configured in `ErrorWebFluxAutoConfiguration` and injected to the `ErrorWebExceptionHandler`, and translates `java.net.UnknownHostException` and `java.net.ConnectException` to `HttpStatus.SERVICE_UNAVAILABLE` instead.