### PR TITLE
Fixed OAuth2 account deletion

### DIFF
--- a/gateway/src/main/java/org/georchestra/gateway/accounts/admin/AbstractAccountsManager.java
+++ b/gateway/src/main/java/org/georchestra/gateway/accounts/admin/AbstractAccountsManager.java
@@ -41,7 +41,7 @@ public abstract class AbstractAccountsManager implements AccountManager {
         return find(mappedUser).orElseGet(() -> createIfMissing(mappedUser));
     }
 
-    protected Optional<GeorchestraUser> find(GeorchestraUser mappedUser) {
+    public Optional<GeorchestraUser> find(GeorchestraUser mappedUser) {
         lock.readLock().lock();
         try {
             return findInternal(mappedUser);

--- a/gateway/src/main/java/org/georchestra/gateway/accounts/admin/AccountManager.java
+++ b/gateway/src/main/java/org/georchestra/gateway/accounts/admin/AccountManager.java
@@ -24,11 +24,23 @@ import org.georchestra.security.model.GeorchestraUser;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.security.core.Authentication;
 
+import java.util.Optional;
+
 /**
  * @see CreateAccountUserCustomizer
  * @see ResolveGeorchestraUserGlobalFilter
  */
 public interface AccountManager {
+
+    /**
+     * Finds the stored user that belongs to the {@code mappedUser} if it exists
+     *
+     * @param mappedUser the user {@link ResolveGeorchestraUserGlobalFilter}
+     *                   resolved by calling
+     *                   {@link GeorchestraUserMapper#resolve(Authentication)}
+     * @return the stored version of the user if it exists, otherwise an empty Optional
+     */
+    Optional<GeorchestraUser> find(GeorchestraUser mappedUser);
 
     /**
      * Finds the stored user that belongs to the {@code mappedUser} or creates it if


### PR DESCRIPTION
When a OAuth2 user tries to delete its account from the console profile, this local account was immediately re-created when the user loads any page, even if he is redirected to the log out page.

I added a cache that can continue to serve last known user until he effectively logs out, and prevent it to be re-created until the user logs out. If he logs in again after, a new empty account will still be created, but it should not be a problem as a user which asks for account deletion should not try to log-in again, and if he does, most of its data have been deleted.