### PR TITLE
Preserve host header and pass x-forwarded headers

### DIFF
--- a/gateway/src/main/resources/application.yml
+++ b/gateway/src/main/resources/application.yml
@@ -32,6 +32,12 @@ spring:
     - org.springframework.boot.autoconfigure.amqp.RabbitAutoConfiguration
   cloud:
     gateway:
+      x-forwarded:
+        for-enabled: false
+        host-enabled: false
+        port-enabled: false
+        proto-enabled: false
+        prefix-enabled: false
       enabled: true
       global-filter.websocket-routing.enabled: true
       metrics.enabled: true
@@ -52,6 +58,7 @@ spring:
       - RemoveSecurityHeaders
       # AddSecHeaders appends sec-* headers to proxied requests based on the currently authenticated user
       - AddSecHeaders
+      - PreserveHostHeader
       global-filter:
         websocket-routing:
           enabled: true


### PR DESCRIPTION
This fixes both bug reported in https://github.com/georchestra/georchestra-gateway/issues/102

Also, this helps with the issue https://github.com/georchestra/georchestra-gateway/issues/94 like explained in https://github.com/georchestra/georchestra-gateway/issues/94#issuecomment-1948028574

I made the decision to avoid the gateway modifying the x-forwarded-* headers so that the final application receive the headers in the correct format sent by the original reverse proxy.

You can find documentation about the changes here:
- https://docs.spring.io/spring-cloud-gateway/docs/3.1.7/reference/html/#the-preservehostheader-gatewayfilter-factory
- https://docs.spring.io/spring-cloud-gateway/docs/3.1.7/reference/html/#xforwarded-headers-filter