### PR TITLE
preserve host header + set forward-headers-strategy FRAMEWORK

### DIFF
--- a/gateway/src/main/java/org/georchestra/gateway/autoconfigure/app/CustomErrorAttributes.java
+++ b/gateway/src/main/java/org/georchestra/gateway/autoconfigure/app/CustomErrorAttributes.java
@@ -47,7 +47,7 @@ import org.springframework.web.reactive.function.server.ServerRequest;
  * {@link java.net.UnknownHostException} and {@link java.net.ConnectException}
  * to {@link HttpStatus#SERVICE_UNAVAILABLE}
  */
-class CustomErrorAttributes extends DefaultErrorAttributes {
+public class CustomErrorAttributes extends DefaultErrorAttributes {
 
     @Override
     public Map<String, Object> getErrorAttributes(ServerRequest request, ErrorAttributeOptions options) {

--- a/gateway/src/main/resources/application.yml
+++ b/gateway/src/main/resources/application.yml
@@ -15,6 +15,7 @@ server:
   ssl:
     enabled: false
     #TODO: configure SSL with a self-signed certificate
+  forward-headers-strategy: FRAMEWORK
 
 spring:
   config:
@@ -52,6 +53,7 @@ spring:
       - RemoveSecurityHeaders
       # AddSecHeaders appends sec-* headers to proxied requests based on the currently authenticated user
       - AddSecHeaders
+      - PreserveHostHeader
       - ApplicationError
       global-filter:
         websocket-routing:

--- a/gateway/src/test/java/org/georchestra/gateway/security/ResolveGeorchestraUserGlobalFilterIT.java
+++ b/gateway/src/test/java/org/georchestra/gateway/security/ResolveGeorchestraUserGlobalFilterIT.java
@@ -110,6 +110,7 @@ public class ResolveGeorchestraUserGlobalFilterIT {
 
     public @Test void testSecOrgnamePresent() {
         testClient.get().uri("/echo/")//
+                .header("Host", "localhost")//
                 .header("Authorization", "Basic dGVzdGFkbWluOnRlc3RhZG1pbg==") // testadmin:testadmin
                 .exchange()//
                 .expectStatus()//

--- a/gateway/src/test/java/org/georchestra/gateway/security/ResolveGeorchestraUserGlobalFilterIT.java
+++ b/gateway/src/test/java/org/georchestra/gateway/security/ResolveGeorchestraUserGlobalFilterIT.java
@@ -68,6 +68,7 @@ public class ResolveGeorchestraUserGlobalFilterIT {
         assertNotNull(context.getBean(JsonPayloadHeadersContributor.class));
 
         testClient.get().uri("/echo/")//
+                .header("Host", "localhost")//
                 .header("Authorization", "Basic dGVzdGFkbWluOnRlc3RhZG1pbg==") // testadmin:testadmin
                 .exchange()//
                 .expectStatus()//
@@ -81,6 +82,7 @@ public class ResolveGeorchestraUserGlobalFilterIT {
         gatewayConfig.getDefaultHeaders().setJsonOrganization(Optional.of(false));
 
         testClient.get().uri("/echo/")//
+                .header("Host", "localhost")//
                 .header("Authorization", "Basic dGVzdGFkbWluOnRlc3RhZG1pbg==") // testadmin:testadmin
                 .exchange()//
                 .expectStatus()//
@@ -96,6 +98,7 @@ public class ResolveGeorchestraUserGlobalFilterIT {
         gatewayConfig.getDefaultHeaders().setJsonOrganization(Optional.of(true));
 
         testClient.get().uri("/echo/")//
+                .header("Host", "localhost")//
                 .header("Authorization", "Basic dGVzdGFkbWluOnRlc3RhZG1pbg==") // testadmin:testadmin
                 .exchange()//
                 .expectStatus()//

--- a/gateway/src/test/java/org/georchestra/gateway/security/accessrules/AccessRulesCustomizerIT.java
+++ b/gateway/src/test/java/org/georchestra/gateway/security/accessrules/AccessRulesCustomizerIT.java
@@ -19,14 +19,10 @@
 
 package org.georchestra.gateway.security.accessrules;
 
-import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
-import static com.github.tomakehurst.wiremock.client.WireMock.get;
-import static com.github.tomakehurst.wiremock.client.WireMock.noContent;
-import static com.github.tomakehurst.wiremock.client.WireMock.ok;
-import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching;
-
-import java.net.URI;
-
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
+import lombok.extern.slf4j.Slf4j;
 import org.georchestra.gateway.app.GeorchestraGatewayApplication;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -40,11 +36,9 @@ import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.test.web.reactive.server.WebTestClient;
 
-import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
-import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
-import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
+import java.net.URI;
 
-import lombok.extern.slf4j.Slf4j;
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
 
 /**
  * Integration tests for {@link AccessRulesCustomizer} for the access rules in
@@ -133,8 +127,12 @@ class AccessRulesCustomizerIT {
                 .withHeader("sec-proxy", equalTo("true"))//
                 .willReturn(ok()));
 
-        testClient.get().uri("/header").exchange().expectStatus().isOk();
-        testClient.get().uri("/header/img/logo.png").exchange().expectStatus().isOk();
+        testClient.get().uri("/header")//
+                .header("Host", "localhost")//
+                .exchange().expectStatus().isOk();
+        testClient.get().uri("/header/img/logo.png")//
+                .header("Host", "localhost")//
+                .exchange().expectStatus().isOk();
     }
 
     /**
@@ -172,10 +170,12 @@ class AccessRulesCustomizerIT {
         mockService.stubFor(get(urlMatching("/import(/.*)?")).willReturn(ok()));
 
         testClient.get().uri("/import")//
+                .header("Host", "localhost")//
                 .exchange()//
                 .expectStatus().isOk();
 
         testClient.get().uri("/import/any/thing")//
+                .header("Host", "localhost")//
                 .exchange()//
                 .expectStatus().isOk();
     }
@@ -216,10 +216,12 @@ class AccessRulesCustomizerIT {
         mockService.stubFor(get(urlMatching("/analytics(/.*)?")).willReturn(ok()));
 
         testClient.get().uri("/analytics")//
+                .header("Host", "localhost")//
                 .exchange()//
                 .expectStatus().isOk();
 
         testClient.get().uri("/analytics/any/thing")//
+                .header("Host", "localhost")//
                 .exchange()//
                 .expectStatus().isOk();
     }
@@ -264,10 +266,12 @@ class AccessRulesCustomizerIT {
         mockService.stubFor(get(urlMatching("/mapstore(/.*)?")).willReturn(ok()));
 
         testClient.get().uri("/mapstore")//
+                .header("Host", "localhost")//
                 .exchange()//
                 .expectStatus().isOk();
 
         testClient.get().uri("/mapstore/any/thing")//
+                .header("Host", "localhost")//
                 .exchange()//
                 .expectStatus().isOk();
     }
@@ -281,6 +285,7 @@ class AccessRulesCustomizerIT {
                 .expectStatus().is3xxRedirection();
 
         testClient.get().uri("/header")//
+                .header("Host", "localhost")//
                 .exchange()//
                 .expectStatus().isOk();
     }
@@ -291,10 +296,12 @@ class AccessRulesCustomizerIT {
         mockService.stubFor(get(urlMatching("/header(.*)?")).willReturn(ok()));
 
         testClient.get().uri("/header?login")//
+                .header("Host", "localhost")//
                 .exchange()//
                 .expectStatus().isOk();
 
         testClient.get().uri("/header")//
+                .header("Host", "localhost")//
                 .exchange()//
                 .expectStatus().isOk();
     }


### PR DESCRIPTION
Related to https://github.com/georchestra/georchestra-gateway/pull/104

1. This has been discussed to set `forward-headers-strategy` to `FRAMEWORK` in order to pass through the x-forwarded headers sent by the reverse proxy.
     A deep explanation is available here: https://stackoverflow.com/a/68318932
2. And also not touching the host header sent by the reverse proxy using the parameter `PreserveHostHeader`