### PR TITLE
ldap - avoid providing sensitive (hashed password) on the /whoami endpoint

### DIFF
--- a/gateway/src/main/java/org/georchestra/gateway/accounts/admin/AccountManager.java
+++ b/gateway/src/main/java/org/georchestra/gateway/accounts/admin/AccountManager.java
@@ -38,7 +38,8 @@ public interface AccountManager {
      * @param mappedUser the user {@link ResolveGeorchestraUserGlobalFilter}
      *                   resolved by calling
      *                   {@link GeorchestraUserMapper#resolve(Authentication)}
-     * @return the stored version of the user if it exists, otherwise an empty Optional
+     * @return the stored version of the user if it exists, otherwise an empty
+     *         Optional
      */
     Optional<GeorchestraUser> find(GeorchestraUser mappedUser);
 

--- a/gateway/src/main/java/org/georchestra/gateway/security/ldap/NoPasswordLdapUserDetailsMapper.java
+++ b/gateway/src/main/java/org/georchestra/gateway/security/ldap/NoPasswordLdapUserDetailsMapper.java
@@ -1,0 +1,11 @@
+package org.georchestra.gateway.security.ldap;
+
+import org.springframework.security.ldap.userdetails.LdapUserDetailsMapper;
+
+public class NoPasswordLdapUserDetailsMapper extends LdapUserDetailsMapper {
+
+    @Override
+    protected String mapPassword(Object passwordValue) {
+        return null;
+    }
+}

--- a/gateway/src/main/java/org/georchestra/gateway/security/ldap/basic/LdapAuthenticatorProviderBuilder.java
+++ b/gateway/src/main/java/org/georchestra/gateway/security/ldap/basic/LdapAuthenticatorProviderBuilder.java
@@ -21,6 +21,7 @@ package org.georchestra.gateway.security.ldap.basic;
 import static java.util.Objects.requireNonNull;
 
 import org.georchestra.ds.users.AccountDao;
+import org.georchestra.gateway.security.ldap.NoPasswordLdapUserDetailsMapper;
 import org.georchestra.gateway.security.ldap.extended.ExtendedLdapAuthenticationProvider;
 import org.georchestra.gateway.security.ldap.extended.ExtendedPasswordPolicyAwareContextSource;
 import org.springframework.ldap.core.support.BaseLdapPathContextSource;
@@ -72,7 +73,7 @@ public class LdapAuthenticatorProviderBuilder {
 
         final GrantedAuthoritiesMapper rolesMapper = ldapAuthoritiesMapper();
         provider.setAuthoritiesMapper(rolesMapper);
-        provider.setUserDetailsContextMapper(new LdapUserDetailsMapper());
+        provider.setUserDetailsContextMapper(new NoPasswordLdapUserDetailsMapper());
         provider.setAccountDao(accountDao);
         return provider;
     }

--- a/gateway/src/test/java/org/georchestra/gateway/accounts/admin/CreateAccountUserCustomizerIT.java
+++ b/gateway/src/test/java/org/georchestra/gateway/accounts/admin/CreateAccountUserCustomizerIT.java
@@ -16,6 +16,8 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.ApplicationContext;
 import org.springframework.ldap.NameNotFoundException;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.test.web.reactive.server.WebTestClient;
 
 import java.util.Map;
@@ -44,6 +46,12 @@ public class CreateAccountUserCustomizerIT {
 
     public static @AfterAll void shutDownContainers() {
         ldap.stop();
+    }
+
+    @DynamicPropertySource
+    static void registerLdap(DynamicPropertyRegistry registry) {
+        registry.add("testcontainers.georchestra.ldap.host", () -> "127.0.0.1");
+        registry.add("testcontainers.georchestra.ldap.port", ldap::getMappedLdapPort);
     }
 
     private static final Map<String, String> NOT_EXISTING_ACCOUNT_HEADERS = Map.of( //

--- a/gateway/src/test/java/org/georchestra/gateway/security/ldap/basic/BasicLdapAuthenticationIT.java
+++ b/gateway/src/test/java/org/georchestra/gateway/security/ldap/basic/BasicLdapAuthenticationIT.java
@@ -1,0 +1,44 @@
+package org.georchestra.gateway.security.ldap.basic;
+
+import org.georchestra.gateway.app.GeorchestraGatewayApplication;
+import org.georchestra.testcontainers.ldap.GeorchestraLdapContainer;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.reactive.server.WebTestClient;
+
+@SpringBootTest(classes = GeorchestraGatewayApplication.class)
+@ActiveProfiles({ "basicldap" })
+@AutoConfigureWebTestClient(timeout = "PT20S")
+@Disabled("ExtendedLdapAuthenticationProvider being built instead of a Basic one after https://github.com/georchestra/georchestra-gateway/pull/50/files ?")
+public class BasicLdapAuthenticationIT {
+
+    public static GeorchestraLdapContainer ldap = new GeorchestraLdapContainer();
+
+    private @Autowired WebTestClient testClient;
+
+    public static @BeforeAll void startUpContainers() {
+        ldap.start();
+    }
+
+    public static @AfterAll void shutDownContainers() {
+        ldap.stop();
+    }
+
+    public @Test void testWhoamiNoPasswordRevealed() {
+        testClient.get().uri("/whoami")//
+                .header("Authorization", "Basic dGVzdGFkbWluOnRlc3RhZG1pbg==") // testadmin:testadmin
+                .exchange()//
+                .expectStatus()//
+                .is2xxSuccessful()//
+                .expectBody(String.class)//
+                .value(Matchers.not(Matchers.containsString("{SHA}")));
+    }
+
+}

--- a/gateway/src/test/java/org/georchestra/gateway/security/ldap/extended/ExtendedLdapAuthenticationIT.java
+++ b/gateway/src/test/java/org/georchestra/gateway/security/ldap/extended/ExtendedLdapAuthenticationIT.java
@@ -56,6 +56,16 @@ public class ExtendedLdapAuthenticationIT {
                 .jsonPath("$.GeorchestraUser.username").isEqualTo("testadmin");
     }
 
+    public @Test void testWhoamiUsingEmail() {
+        testClient.get().uri("/whoami")//
+                .header("Authorization", "Basic cHNjK3Rlc3RhZG1pbkBnZW9yY2hlc3RyYS5vcmc6dGVzdGFkbWlu") // psc+testadmin@georchestra.org:testadmin
+                .exchange()//
+                .expectStatus()//
+                .is2xxSuccessful()//
+                .expectBody()//
+                .jsonPath("$.GeorchestraUser.username").isEqualTo("testadmin");
+    }
+
     public @Test void testWhoamiNoPasswordRevealed() {
         testClient.get().uri("/whoami")//
                 .header("Authorization", "Basic dGVzdGFkbWluOnRlc3RhZG1pbg==") // testadmin:testadmin

--- a/gateway/src/test/resources/application-basicldap.yml
+++ b/gateway/src/test/resources/application-basicldap.yml
@@ -1,0 +1,39 @@
+ # This YAML file configures the geOrchestra gateway with
+ # a basic LDAP (extended set to false).
+ #
+georchestra:
+  gateway:
+    default-headers:
+      # Default security headers to append to proxied requests
+      proxy: true
+      username: true
+      roles: true
+      org: true
+      orgname: true
+    global-access-rules:
+      - intercept-url:
+          - "/**"
+          - "/proxy/?url=*"
+        anonymous: true
+    security:
+      ldap:
+        default:
+          enabled: true
+          extended: false
+          url: ldap://${ldapHost}:${ldapPort}/
+          baseDn: dc=georchestra,dc=org
+          adminDn: cn=admin,dc=georchestra,dc=org
+          adminPassword: secret
+spring:
+  cloud:
+    gateway:
+      enabled: true
+      default-filters:
+        - SecureHeaders
+        - TokenRelay
+        - RemoveSecurityHeaders
+        # AddSecHeaders appends sec-* headers to proxied requests based on the
+        # georchestra.gateway.default-headers and georchestra.gateway.servies.<service>.headers config properties
+        - AddSecHeaders
+      httpclient.wiretap: true
+      httpserver.wiretap: false

--- a/gateway/src/test/resources/application-createaccount.yml
+++ b/gateway/src/test/resources/application-createaccount.yml
@@ -1,3 +1,9 @@
+ # This YAML file configures the geOrchestra gateway with
+ # * a geOrchestra extended LDAP
+ # * authentication via HTTP headers
+ #
+ # It is mainly used for integration testing the preauthentication mechanisms.
+ #
 georchestra:
   gateway:
     default-headers:
@@ -21,7 +27,7 @@ georchestra:
         default:
           enabled: true
           extended: true
-          url: ldap://${ldapHost}:${ldapPort}/
+          url: ldap://${testcontainers.georchestra.ldap.host}:${testcontainers.georchestra.ldap.port}/
           baseDn: dc=georchestra,dc=org
           adminDn: cn=admin,dc=georchestra,dc=org
           adminPassword: secret


### PR DESCRIPTION
This is a kind of a revisit of the PR #88. The default mapper provided by Spring security maps all the fields retrieved from the LDAP, including the `userPassword`. Even if hashed, I think it it safer not to have the endpoint revealing such information.

This PR suggests to use a mapper which always return null when calling `mapPassword`.

Note: When working on this one, I first began to patch the case when authenticated onto an Extended/geOrchestra LDAP, then I introduced a new profile to test a case with an LDAP not declared as extended (simply a copy/paste of the previous one, with LDAP extended property set to false), and stumbled upon some modifications introduced in https://github.com/georchestra/georchestra-gateway/pull/50/files that I could not make sense of: from the `basic` ldap package classes, we are creating a `ExtendedLdapAuthenticationProvider` ? For me it does not make sense, and we should revert the previously introduced modifications onto the [LdapAuthenticatorProviderBuilder.java](https://github.com/georchestra/georchestra-gateway/pull/50/files#diff-51b79d58e6a23713094636017177cd3551a843bdc696edf29d1142f1a72eda9b) class.
