### PR TITLE
maven/build - adds a debian packaging profile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,3 +12,6 @@ docker:
 	echo tagging georchestra/gateway:$${TAG} as georchestra/gateway:latest && \
 	docker tag georchestra/gateway:$${TAG} georchestra/gateway:latest && \
 	docker images|grep "georchestra/gateway"|grep latest
+
+deb: install
+	./mvnw package deb:package -f gateway/ -PdebianPackage

--- a/gateway/pom.xml
+++ b/gateway/pom.xml
@@ -362,9 +362,6 @@
     </profile>
     <profile>
       <id>debianPackage</id>
-      <properties>
-        <maven.build.timestamp.format>yyyyMMddHHmm</maven.build.timestamp.format>
-      </properties>
       <build>
         <finalName>${project.artifactId}</finalName>
         <plugins>
@@ -398,7 +395,9 @@
               <execution>
                 <id>copy-deb-resources</id>
                 <phase>process-resources</phase>
-                <goals><goal>copy-resources</goal></goals>
+                <goals>
+                  <goal>copy-resources</goal>
+                </goals>
                 <configuration>
                   <overwrite>true</overwrite>
                   <outputDirectory>${project.build.directory}/deb</outputDirectory>
@@ -425,10 +424,8 @@
                 <configuration>
                   <exportAntProperties>true</exportAntProperties>
                   <target>
-                    <condition property="project.packageVersion"
-                               value="${build.closest.tag.name}.${maven.build.timestamp}~${build.commit.id.abbrev}"
-                               else="99.main.${maven.build.timestamp}~${build.commit.id.abbrev}">
-                      <matches string="${build.branch}" pattern="\d{2}\.\d\.x$" />
+                    <condition else="99.main.${maven.build.timestamp}~${build.commit.id.abbrev}" property="project.packageVersion" value="${build.closest.tag.name}.${maven.build.timestamp}~${build.commit.id.abbrev}">
+                      <matches pattern="\d{2}\.\d\.x$" string="${build.branch}"></matches>
                     </condition>
                   </target>
                 </configuration>
@@ -451,6 +448,9 @@
           </plugin>
         </plugins>
       </build>
+      <properties>
+        <maven.build.timestamp.format>yyyyMMddHHmm</maven.build.timestamp.format>
+      </properties>
     </profile>
   </profiles>
 </project>

--- a/gateway/pom.xml
+++ b/gateway/pom.xml
@@ -360,5 +360,97 @@
         </plugins>
       </build>
     </profile>
+    <profile>
+      <id>debianPackage</id>
+      <properties>
+        <maven.build.timestamp.format>yyyyMMddHHmm</maven.build.timestamp.format>
+      </properties>
+      <build>
+        <finalName>${project.artifactId}</finalName>
+        <plugins>
+          <plugin>
+            <groupId>pl.project13.maven</groupId>
+            <artifactId>git-commit-id-plugin</artifactId>
+            <version>4.9.10</version>
+            <executions>
+              <execution>
+                <goals>
+                  <goal>revision</goal>
+                </goals>
+              </execution>
+            </executions>
+            <configuration>
+              <prefix>build</prefix>
+              <failOnNoGitDirectory>false</failOnNoGitDirectory>
+              <skipPoms>false</skipPoms>
+              <verbose>false</verbose>
+              <gitDescribe>
+                <tags>true</tags>
+              </gitDescribe>
+              <injectIntoSysProperties>true</injectIntoSysProperties>
+            </configuration>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-resources-plugin</artifactId>
+            <version>3.3.1</version>
+            <executions>
+              <execution>
+                <id>copy-deb-resources</id>
+                <phase>process-resources</phase>
+                <goals><goal>copy-resources</goal></goals>
+                <configuration>
+                  <overwrite>true</overwrite>
+                  <outputDirectory>${project.build.directory}/deb</outputDirectory>
+                  <resources>
+                    <resource>
+                      <directory>src/deb/resources</directory>
+                    </resource>
+                  </resources>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-antrun-plugin</artifactId>
+            <version>3.1.0</version>
+            <executions>
+              <execution>
+                <id>set-project-packageversion</id>
+                <phase>package</phase>
+                <goals>
+                  <goal>run</goal>
+                </goals>
+                <configuration>
+                  <exportAntProperties>true</exportAntProperties>
+                  <target>
+                    <condition property="project.packageVersion"
+                               value="${build.closest.tag.name}.${maven.build.timestamp}~${build.commit.id.abbrev}"
+                               else="99.main.${maven.build.timestamp}~${build.commit.id.abbrev}">
+                      <matches string="${build.branch}" pattern="\d{2}\.\d\.x$" />
+                    </condition>
+                  </target>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>net.sf.debian-maven</groupId>
+            <artifactId>debian-maven-plugin</artifactId>
+            <version>1.0.6</version>
+            <configuration>
+              <packageName>georchestra-gateway</packageName>
+              <packageDescription>geOrchestra Gateway</packageDescription>
+              <packageVersion>${project.packageVersion}</packageVersion>
+              <projectOrganization>geOrchestra</projectOrganization>
+              <maintainerName>PSC</maintainerName>
+              <maintainerEmail>psc@georchestra.org</maintainerEmail>
+              <excludeAllDependencies>true</excludeAllDependencies>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
   </profiles>
 </project>

--- a/gateway/src/main/java/org/georchestra/gateway/accounts/admin/AccountManager.java
+++ b/gateway/src/main/java/org/georchestra/gateway/accounts/admin/AccountManager.java
@@ -38,7 +38,8 @@ public interface AccountManager {
      * @param mappedUser the user {@link ResolveGeorchestraUserGlobalFilter}
      *                   resolved by calling
      *                   {@link GeorchestraUserMapper#resolve(Authentication)}
-     * @return the stored version of the user if it exists, otherwise an empty Optional
+     * @return the stored version of the user if it exists, otherwise an empty
+     *         Optional
      */
     Optional<GeorchestraUser> find(GeorchestraUser mappedUser);
 

--- a/gateway/src/test/java/org/georchestra/gateway/accounts/admin/CreateAccountUserCustomizerIT.java
+++ b/gateway/src/test/java/org/georchestra/gateway/accounts/admin/CreateAccountUserCustomizerIT.java
@@ -147,9 +147,10 @@ public class CreateAccountUserCustomizerIT {
                 .is2xxSuccessful()//
                 .expectBody()//
                 .jsonPath("$.GeorchestraUser").isNotEmpty()//
-                .jsonPath("$.GeorchestraUser.roles").value(Matchers.contains("ROLE_ADMINISTRATOR", //
+                .jsonPath("$.GeorchestraUser.roles").value(Matchers.hasItems("ROLE_ADMINISTRATOR", //
                         "ROLE_SUPERUSER", //
                         "ROLE_GN_ADMIN", //
+                        "ROLE_IMPORT", //
                         "ROLE_USER", //
                         "ROLE_MAPSTORE_ADMIN", //
                         "ROLE_EMAILPROXY"));


### PR DESCRIPTION
This allow to generate a debian package using the following command:

```
% mvn clean package deb:package -PdebianPackage -pl gateway
```

at the root of the repository.

Here is an example of generated package:

```
% dpkg-deb --contents gateway/target/georchestra-gateway_99.main.202403201300\~638e3c8-1_all.deb
drwxr-xr-x root/root         0 2024-03-20 14:01 ./
drwxr-xr-x root/root         0 2024-03-20 14:01 ./usr/
drwxr-xr-x root/root         0 2024-03-20 14:01 ./usr/share/
drwxr-xr-x root/root         0 2024-03-20 14:01 ./usr/share/doc/
drwxr-xr-x root/root         0 2024-03-20 14:01 ./usr/share/doc/georchestra-gateway/
-rw-r--r-- root/root       187 2024-03-20 14:01 ./usr/share/doc/georchestra-gateway/copyright
drwxr-xr-x root/root         0 2024-03-20 14:01 ./usr/share/lib/
drwxr-xr-x root/root         0 2024-03-20 14:01 ./usr/share/lib/georchestra-gateway/
-rw-r--r-- root/root        11 2024-03-20 14:01 ./usr/share/lib/georchestra-gateway/georchestra-gateway-23.1-SNAPSHOT.inc
-rw-r--r-- root/root  47732260 2024-03-20 14:01 ./usr/share/lib/georchestra-gateway/georchestra-gateway.jar
lrwxrwxrwx root/root         0 2024-03-20 14:01 ./usr/share/lib/georchestra-gateway/georchestra-gateway.inc -> georchestra-gateway-23.1-SNAPSHOT.inc

```

Note: As opposed to what is generally done in georchestra/georchestra, we decided to drop the `git clone datadir`, as people generally set up their infra by doing a git clone by themselves of their datadir, so having a default configuration provided in `/etc/georchestra` is not necessary.

Note2: the modification on the Java file is unrelated and is due to the maven formatter plugin.

Tests: uploaded the `.deb` into a docker container, then `dpkg -i`  and trying to launch via `java -jar georchestra-gateway.jar`, the webapp is able to launch.
