### PR TITLE
accesslog - porting accesslogs capabilities from DT's gateway

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,7 +34,7 @@ services:
       - 3891:389
 
   gateway:
-    image: georchestra/gateway:22.1-SNAPSHOT
+    image: georchestra/gateway:latest
     depends_on:
       - ldap
       - database

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,14 +34,14 @@ services:
       - 3891:389
 
   gateway:
-    image: georchestra/gateway:latest
+    image: georchestra/gateway:22.1-SNAPSHOT
     depends_on:
       - ldap
       - database
     volumes:
       - datadir:/etc/georchestra
     environment:
-      - JAVA_TOOL_OPTIONS=-Dgeorchestra.datadir=/etc/georchestra -Dspring.profiles.active=docker -Xmx512M -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=0.0.0.0:5005
+      - JAVA_TOOL_OPTIONS=-Dgeorchestra.datadir=/etc/georchestra -Dspring.profiles.active=docker -Xmx512M -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=0.0.0.0:5005 -Dreactor.netty.http.server.accessLogEnabled=true
     restart: always
     ports:
       - 8080:8080
@@ -88,9 +88,8 @@ services:
     restart: always
     ports:
       - 10007:8080
-    
+
   echo:
     image: ealen/echo-server:latest
     ports:
       - 10009:80
-        

--- a/gateway/pom.xml
+++ b/gateway/pom.xml
@@ -32,6 +32,23 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-validation</artifactId>
+      <exclusions>
+        <exclusion>
+          <artifactId>spring-boot-starter-logging</artifactId>
+          <!-- exclude transitive dep on logging to remove logback,
+			         we're using log4j2 below to use its json output -->
+          <groupId>org.springframework.boot</groupId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>io.micrometer</groupId>
+      <artifactId>context-propagation</artifactId>
+      <version>1.0.4</version>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-reactive-httpclient</artifactId>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
@@ -76,7 +93,7 @@
     </dependency>
     <dependency>
       <!-- Annotation processor that generates metadata about classes annotated with @ConfigurationProperties. -->
-      <!-- This metadata is used by IDEs to provide auto-completion and documentation for the properties when editing application.properties 
+      <!-- This metadata is used by IDEs to provide auto-completion and documentation for the properties when editing application.properties
         and application.yaml -->
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-configuration-processor</artifactId>

--- a/gateway/pom.xml
+++ b/gateway/pom.xml
@@ -114,6 +114,20 @@
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-log4j2</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-layout-template-json</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <!-- support for SpringProfile in log4j2-spring.xml -->
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-spring-boot</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>
     </dependency>

--- a/gateway/src/main/java/org/georchestra/gateway/autoconfigure/app/FiltersAutoConfiguration.java
+++ b/gateway/src/main/java/org/georchestra/gateway/autoconfigure/app/FiltersAutoConfiguration.java
@@ -18,8 +18,11 @@
  */
 package org.georchestra.gateway.autoconfigure.app;
 
+import org.georchestra.gateway.filter.global.AccessLogFilter;
+import org.georchestra.gateway.filter.global.AccessLogFilterConfig;
 import org.georchestra.gateway.filter.global.ApplicationErrorGatewayFilterFactory;
 import org.georchestra.gateway.filter.global.LoginParamRedirectGatewayFilterFactory;
+import org.georchestra.gateway.filter.global.RequestIdGlobalFilter;
 import org.georchestra.gateway.filter.global.ResolveTargetGlobalFilter;
 import org.georchestra.gateway.filter.headers.HeaderFiltersConfiguration;
 import org.georchestra.gateway.model.GatewayConfigProperties;
@@ -56,7 +59,7 @@ import org.springframework.context.annotation.Import;
 @AutoConfiguration
 @AutoConfigureBefore(GatewayAutoConfiguration.class)
 @Import(HeaderFiltersConfiguration.class)
-@EnableConfigurationProperties(GatewayConfigProperties.class)
+@EnableConfigurationProperties({ GatewayConfigProperties.class, AccessLogFilterConfig.class })
 public class FiltersAutoConfiguration {
 
     /**
@@ -128,5 +131,15 @@ public class FiltersAutoConfiguration {
     @Bean
     ApplicationErrorGatewayFilterFactory applicationErrorGatewayFilterFactory() {
         return new ApplicationErrorGatewayFilterFactory();
+    }
+
+    @Bean
+    RequestIdGlobalFilter requestIdGlobalFilter() {
+        return new RequestIdGlobalFilter();
+    }
+
+    @Bean
+    AccessLogFilter accessLogGlobalFilter(AccessLogFilterConfig config) {
+        return new AccessLogFilter(config);
     }
 }

--- a/gateway/src/main/java/org/georchestra/gateway/filter/global/AccessLogFilter.java
+++ b/gateway/src/main/java/org/georchestra/gateway/filter/global/AccessLogFilter.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (C) 2022 by the geOrchestra PSC
+ *
+ * This file is part of geOrchestra.
+ *
+ * geOrchestra is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * geOrchestra is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * geOrchestra.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.georchestra.gateway.filter.global;
+
+import static org.springframework.cloud.gateway.support.ServerWebExchangeUtils.GATEWAY_REQUEST_URL_ATTR;
+import static org.springframework.cloud.gateway.support.ServerWebExchangeUtils.GATEWAY_ROUTE_ATTR;
+
+import java.net.InetSocketAddress;
+import java.net.URI;
+import java.security.Principal;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.slf4j.MDC;
+import org.springframework.cloud.gateway.filter.GatewayFilterChain;
+import org.springframework.cloud.gateway.filter.GlobalFilter;
+import org.springframework.cloud.gateway.route.Route;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.http.server.reactive.ServerHttpResponse;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.web.server.ServerWebExchange;
+
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import reactor.core.publisher.Mono;
+
+@RequiredArgsConstructor
+@Slf4j(topic = "org.georchestra.gateway.accesslog")
+public class AccessLogFilter implements GlobalFilter {
+
+    private final @NonNull AccessLogFilterConfig config;
+
+    @Override
+    public Mono<Void> filter(ServerWebExchange exchange, GatewayFilterChain chain) {
+        if (config.matches(exchange.getRequest().getURI())) {
+            exchange.getResponse().beforeCommit(() -> {
+                return log(exchange);
+            });
+        }
+
+        return chain.filter(exchange);
+    }
+
+    private static final AnonymousAuthenticationToken ANNON = new AnonymousAuthenticationToken("anonymous", "anonymous",
+            List.of(new SimpleGrantedAuthority("ROLE_ANONYMOUS")));
+
+    /**
+     * @param exchange
+     */
+    private Mono<Void> log(ServerWebExchange exchange) {
+        if (!log.isInfoEnabled())
+            return Mono.empty();
+
+        return exchange.getPrincipal().switchIfEmpty(Mono.just(ANNON)).doOnNext(p -> {
+            doLog(p, exchange);
+        }).then();
+    }
+
+    private void doLog(Principal principal, ServerWebExchange exchange) {
+        ServerHttpRequest request = exchange.getRequest();
+        ServerHttpResponse response = exchange.getResponse();
+        URI uri = request.getURI();
+
+        Route route = exchange.getAttribute(GATEWAY_ROUTE_ATTR);
+        URI routeUri = exchange.getAttribute(GATEWAY_REQUEST_URL_ATTR);
+
+        String requestId = request.getHeaders().getFirst(RequestIdGlobalFilter.REQUEST_ID_HEADER);
+
+        InetSocketAddress addr = request.getRemoteAddress();
+        String remoteAddress = addr == null ? "unknown" : addr.toString();
+
+        MDC.put("route-id", route.getId());
+        MDC.put("route-uri", String.valueOf(routeUri));
+        MDC.put(RequestIdGlobalFilter.REQUEST_ID_HEADER, requestId);
+        MDC.put("remoteAddress", remoteAddress);
+        MDC.put("auth-user", principal.getName());
+        if (principal instanceof Authentication && principal != ANNON) {
+            String roles = ((Authentication) principal).getAuthorities().stream().map(GrantedAuthority::getAuthority)
+                    .collect(Collectors.joining(", "));
+            MDC.put("auth-roles", roles);
+        }
+
+        log.info("{} {} {} ", request.getMethodValue(), response.getRawStatusCode(), uri);
+    }
+}

--- a/gateway/src/main/java/org/georchestra/gateway/filter/global/AccessLogFilterConfig.java
+++ b/gateway/src/main/java/org/georchestra/gateway/filter/global/AccessLogFilterConfig.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2022 by the geOrchestra PSC
+ *
+ * This file is part of geOrchestra.
+ *
+ * geOrchestra is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * geOrchestra is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * geOrchestra.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.georchestra.gateway.filter.global;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import lombok.Data;
+
+/**
+ * Configuration to set white/black list over the request URL to determine if
+ * the access log filter will log an entry for it.
+ */
+@Data
+@ConfigurationProperties(prefix = "georchestra.gateway.accesslog")
+public class AccessLogFilterConfig {
+
+    /**
+     * Enable/disable the access log filter
+     */
+    private boolean enabled = true;
+
+    /**
+     * A list of java regular expressions applied to the request URL to include them
+     * from logging.
+     */
+    List<Pattern> include = new ArrayList<>();
+
+    /**
+     * A list of java regular expressions applied to the request URL to exclude them
+     * from logging. A request URL must pass all the include filters before being
+     * tested for exclusion. Useful to avoid flooding the logs with frequent
+     * non-important requests such as static resources (i.e. static images, etc).
+     */
+    List<Pattern> exclude = new ArrayList<>();
+
+    /**
+     * @param uri the origin URL (e.g. https://my.domain.com/geoserver/web/)
+     * @return {@code true} if disabled or an access log entry shall be logged for
+     *         this request
+     */
+    public boolean matches(URI uri) {
+        if (!enabled || (include.isEmpty() && exclude.isEmpty()))
+            return true;
+
+        String url = uri.toString();
+        return matches(url, include, true) && !matches(url, exclude, false);
+    }
+
+    private boolean matches(String url, List<Pattern> patterns, boolean fallbackIfEmpty) {
+        return (patterns == null || patterns.isEmpty()) ? fallbackIfEmpty
+                : patterns.stream().anyMatch(pattern -> pattern.matcher(url).matches());
+    }
+}

--- a/gateway/src/main/java/org/georchestra/gateway/filter/global/RequestIdGlobalFilter.java
+++ b/gateway/src/main/java/org/georchestra/gateway/filter/global/RequestIdGlobalFilter.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2022 by the geOrchestra PSC
+ *
+ * This file is part of geOrchestra.
+ *
+ * geOrchestra is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * geOrchestra is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * geOrchestra.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.georchestra.gateway.filter.global;
+
+import org.apache.commons.lang3.RandomStringUtils;
+import org.springframework.cloud.gateway.filter.GatewayFilterChain;
+import org.springframework.cloud.gateway.filter.GlobalFilter;
+import org.springframework.core.Ordered;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.http.server.reactive.ServerHttpResponse;
+import org.springframework.web.server.ServerWebExchange;
+
+import reactor.core.publisher.Mono;
+
+/**
+ * Makes sure both the request and response have the same
+ * {@literal X-Request-ID} header.
+ * <p>
+ * A new value is created for the header if not provided by the client.
+ */
+public class RequestIdGlobalFilter implements GlobalFilter, Ordered {
+
+    static final String REQUEST_ID_HEADER = "X-Request-ID";
+
+    /**
+     * @return {@link Ordered#HIGHEST_PRECEDENCE}
+     */
+    public @Override int getOrder() {
+        return Ordered.HIGHEST_PRECEDENCE;
+    }
+
+    /**
+     * Makes sure both the request and response have the same
+     * {@literal X-Request-ID} header.
+     * <p>
+     * A new value is created for the header if not provided by the client.
+     */
+    public @Override Mono<Void> filter(ServerWebExchange exchange, GatewayFilterChain chain) {
+
+        final String requestId;
+        final ServerHttpRequest request;
+        String providedRequestId = exchange.getRequest().getHeaders().getFirst(REQUEST_ID_HEADER);
+        if (null == providedRequestId) {
+            requestId = RandomStringUtils.randomNumeric(16);
+            request = exchange.getRequest().mutate().header(REQUEST_ID_HEADER, requestId).build();
+            exchange = exchange.mutate().request(request).build();
+        } else {
+            requestId = providedRequestId;
+            request = exchange.getRequest();
+        }
+
+        ServerHttpResponse response = exchange.getResponse();
+        response.beforeCommit(() -> {
+            response.getHeaders().set(REQUEST_ID_HEADER, requestId);
+            return Mono.empty();
+        });
+
+        return chain.filter(exchange);
+    }
+
+}

--- a/gateway/src/main/resources/application.yml
+++ b/gateway/src/main/resources/application.yml
@@ -135,13 +135,17 @@ management:
 logging:
   level:
     root: warn
+    '[reactor.netty.http ]': warn
+    '[reactor.netty.http.server.logging.AccessLog]': warn
+    '[reactor.netty.http.client]': warn
     '[org.springframework]': info
     '[org.springframework.cloud.gateway]': info
     '[org.springframework.security]': info
     '[org.springframework.security.oauth2]': debug
     '[reactor.netty.http]': info
     '[org.georchestra.gateway]': info
-    '[org.georchestra.gateway.filter.headers]': info
+    '[org.georchestra.gateway.accesslog]': info
+    '[org.georchestra.gateway.filter.headers]': debug
     '[org.georchestra.gateway.config.security]': debug
     '[org.georchestra.gateway.config.security.accessrules]': debug
     '[org.georchestra.gateway.security.ldap]': debug

--- a/gateway/src/main/resources/log4j2-spring.xml
+++ b/gateway/src/main/resources/log4j2-spring.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="WARN">
+  <Appenders>
+    <Console name="Console">
+      <PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss.SSS} %p %notEmpty{[X-Request-ID=%X{X-Request-ID}]} %notEmpty{[trace=%X{traceId}]} %notEmpty{[span=%X{spanId}]} --- [%t] %c : %msg%n" />
+    </Console>
+    <SpringProfile name="jsonlogs">
+      <Console name="Console" target="SYSTEM_OUT" follow="true">
+        <!--  see https://github.com/vy/log4j2-logstash-layout/blob/master/layout/src/main/resources/LogstashJsonEventLayoutV1.json -->
+        <JsonTemplateLayout
+          eventTemplateUri="classpath:LogstashJsonEventLayoutV1.json">
+          <!-- EventTemplateAdditionalField key="HOME_DIR" value="${env:HOME}" /-->
+        </JsonTemplateLayout>
+      </Console>
+    </SpringProfile>
+  </Appenders>
+  <Loggers>
+    <Root level="info">
+      <AppenderRef ref="Console" />
+    </Root>
+  </Loggers>
+</Configuration>

--- a/gateway/src/test/java/org/georchestra/gateway/filter/global/AccessLogFilterConfigTest.java
+++ b/gateway/src/test/java/org/georchestra/gateway/filter/global/AccessLogFilterConfigTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2022 by the geOrchestra PSC
+ *
+ * This file is part of geOrchestra.
+ *
+ * geOrchestra is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * geOrchestra is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * geOrchestra.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.georchestra.gateway.filter.global;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.URI;
+import java.util.regex.Pattern;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ */
+class AccessLogFilterConfigTest {
+
+    private AccessLogFilterConfig config;
+
+    @BeforeEach
+    void setUp() {
+        config = new AccessLogFilterConfig();
+    }
+
+    @Test
+    void testDisabled() {
+        config.setEnabled(false);
+        assertThat(config.matches(URI.create("https://my.host"))).isTrue();
+
+        config.getExclude().add(Pattern.compile(".*"));
+        assertThat(config.matches(URI.create("https://my.host"))).isTrue();
+    }
+
+    @Test
+    void testIncludes() {
+        config.getInclude().add(Pattern.compile(".*/ows/.*GetFeature.*"));
+        config.getInclude().add(Pattern.compile(".*/ows/.*GetMap.*"));
+
+        assertThat(config.matches(URI.create("https://my.host/ows/?request=GetFeature&typeName=test"))).isTrue();
+        assertThat(config.matches(URI.create("https://my.host/ows/?request=GetMap&typeName=test"))).isTrue();
+        assertThat(config.matches(URI.create("https://my.host/some/path/img1.svg"))).isFalse();
+    }
+
+    @Test
+    void testExcludes() {
+        config.getExclude().add(Pattern.compile(".*\\.png"));
+        config.getExclude().add(Pattern.compile(".*\\.jpeg"));
+
+        assertThat(config.matches(URI.create("https://my.host/some/path/img1.png"))).isFalse();
+        assertThat(config.matches(URI.create("https://my.host/some/path/img1.svg"))).isTrue();
+
+        assertThat(config.matches(URI.create("https://my.host/some/path/img2.jpeg"))).isFalse();
+        assertThat(config.matches(URI.create("https://my.host/some/path/img2.svg"))).isTrue();
+    }
+
+    @Test
+    void testIncludesAndExcludes() {
+        config.getInclude().add(Pattern.compile(".*/ows/.*"));
+        config.getExclude().add(Pattern.compile(".*/ows/.*GetMap.*"));
+
+        assertThat(config.matches(URI.create("https://my.host/ows/?request=GetFeature&typeName=test"))).isTrue();
+        assertThat(config.matches(URI.create("https://my.host/ows/?request=GetMap&typeName=test"))).isFalse();
+    }
+}


### PR DESCRIPTION
Somehow relates to https://github.com/georchestra/georchestra-gateway/issues/112

This work has been done on the DT fork but not ported here yet.

TODO:

* Adding documentation ; DT is making use of JSON format, I think we can have something as JSON or closer to what is expected in #112 with only changes in the logging configuration, making everyone happy. Note that the `-Dreactor.netty.http.server.accessLogEnabled=true` should also be documented
* ~One test related to rabbitmq event emission is failing, because it expects an output from the console testcontainer, which somehow does not work with the modified logging configuration. There might be something more relevant than parsing the container output as test result, but not sure of what could be a better approach yet.~

