### PR TITLE
Returns `ExtendedGeorchestraUser` object when `createUserInLdap` set to `true`

### DIFF
--- a/docs/authzn.adoc
+++ b/docs/authzn.adoc
@@ -276,3 +276,24 @@ sec-roles: ROLE_ORG_6007280321;ROLE_GDI_PLANER;ROLE_GDI_EDITOR;ROLE_USER
 sec-org: 6007280321
 ```
 
+== Automatically creating users in a geOrchestra LDAP
+
+As in the <<pre-authentication.adoc#,pre-authentication method>>, it is possible
+to create externally authenticated users into a geOrchestra (extended) LDAP, so
+that an administrator can promote the user to a higher role than `USER` by default.
+
+In order to do so, you will need to set the following property, and make sure
+an `extended` LDAP named `default` is defined, as in the following configuration
+snippet:
+
+```
+georchestra:
+  gateway:
+    security:
+      create-non-existing-users-in-l-d-a-p: true
+      ldap:
+        default:
+          enabled: true
+          extended: true
+          [...]
+```

--- a/gateway/src/main/java/org/georchestra/gateway/accounts/admin/AbstractAccountsManager.java
+++ b/gateway/src/main/java/org/georchestra/gateway/accounts/admin/AbstractAccountsManager.java
@@ -18,17 +18,15 @@
  */
 package org.georchestra.gateway.accounts.admin;
 
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.georchestra.gateway.security.exceptions.DuplicatedEmailFoundException;
+import org.georchestra.security.model.GeorchestraUser;
+import org.springframework.context.ApplicationEventPublisher;
+
 import java.util.Optional;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
-import java.util.function.Consumer;
-
-import org.georchestra.gateway.security.exceptions.DuplicatedEmailFoundException;
-import org.georchestra.security.model.GeorchestraUser;
-
-import lombok.NonNull;
-import lombok.RequiredArgsConstructor;
-import org.springframework.context.ApplicationEventPublisher;
 
 @RequiredArgsConstructor
 public abstract class AbstractAccountsManager implements AccountManager {
@@ -58,7 +56,7 @@ public abstract class AbstractAccountsManager implements AccountManager {
         return findByUsername(mappedUser.getUsername());
     }
 
-    GeorchestraUser createIfMissing(GeorchestraUser mapped) throws DuplicatedEmailFoundException {
+    protected GeorchestraUser createIfMissing(GeorchestraUser mapped) throws DuplicatedEmailFoundException {
         lock.writeLock().lock();
         try {
             GeorchestraUser existing = findInternal(mapped).orElse(null);

--- a/gateway/src/main/java/org/georchestra/gateway/accounts/admin/AccountCreated.java
+++ b/gateway/src/main/java/org/georchestra/gateway/accounts/admin/AccountCreated.java
@@ -24,7 +24,7 @@ import lombok.NonNull;
 import lombok.Value;
 
 /**
- * Application event published when a new account was created
+ * Application event published when a new account has been created
  */
 @Value
 public class AccountCreated {

--- a/gateway/src/main/java/org/georchestra/gateway/accounts/admin/ldap/LdapAccountsManager.java
+++ b/gateway/src/main/java/org/georchestra/gateway/accounts/admin/ldap/LdapAccountsManager.java
@@ -18,7 +18,6 @@
  */
 package org.georchestra.gateway.accounts.admin.ldap;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -38,11 +37,11 @@ import org.georchestra.ds.users.DuplicatedEmailException;
 import org.georchestra.ds.users.DuplicatedUidException;
 import org.georchestra.gateway.accounts.admin.AbstractAccountsManager;
 import org.georchestra.gateway.accounts.admin.AccountManager;
+import org.georchestra.gateway.security.GeorchestraGatewaySecurityConfigProperties;
 import org.georchestra.gateway.security.exceptions.DuplicatedEmailFoundException;
 import org.georchestra.gateway.security.exceptions.DuplicatedUsernameFoundException;
-import org.georchestra.security.api.UsersApi;
+import org.georchestra.gateway.security.ldap.extended.DemultiplexingUsersApi;
 import org.georchestra.security.model.GeorchestraUser;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.ldap.NameNotFoundException;
 
@@ -57,30 +56,31 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j(topic = "org.georchestra.gateway.accounts.admin.ldap")
 class LdapAccountsManager extends AbstractAccountsManager {
 
-    private @Value("${georchestra.gateway.security.defaultOrganization:}") String defaultOrganization;
+    private final @NonNull GeorchestraGatewaySecurityConfigProperties georchestraGatewaySecurityConfigProperties;
     private final @NonNull AccountDao accountDao;
     private final @NonNull RoleDao roleDao;
-
     private final @NonNull OrgsDao orgsDao;
-    private final @NonNull UsersApi usersApi;
+    private final @NonNull DemultiplexingUsersApi demultiplexingUsersApi;
 
     public LdapAccountsManager(ApplicationEventPublisher eventPublisher, AccountDao accountDao, RoleDao roleDao,
-            OrgsDao orgsDao, UsersApi usersApi) {
+            OrgsDao orgsDao, DemultiplexingUsersApi demultiplexingUsersApi,
+            GeorchestraGatewaySecurityConfigProperties georchestraGatewaySecurityConfigProperties) {
         super(eventPublisher);
         this.accountDao = accountDao;
         this.roleDao = roleDao;
         this.orgsDao = orgsDao;
-        this.usersApi = usersApi;
+        this.demultiplexingUsersApi = demultiplexingUsersApi;
+        this.georchestraGatewaySecurityConfigProperties = georchestraGatewaySecurityConfigProperties;
     }
 
     @Override
     protected Optional<GeorchestraUser> findByOAuth2Uid(@NonNull String oAuth2Provider, @NonNull String oAuth2Uid) {
-        return usersApi.findByOAuth2Uid(oAuth2Provider, oAuth2Uid).map(this::ensureRolesPrefixed);
+        return demultiplexingUsersApi.findByOAuth2Uid(oAuth2Provider, oAuth2Uid).map(this::ensureRolesPrefixed);
     }
 
     @Override
     protected Optional<GeorchestraUser> findByUsername(@NonNull String username) {
-        return usersApi.findByUsername(username).map(this::ensureRolesPrefixed);
+        return demultiplexingUsersApi.findByUsername(username).map(this::ensureRolesPrefixed);
     }
 
     private GeorchestraUser ensureRolesPrefixed(GeorchestraUser user) {
@@ -103,7 +103,14 @@ class LdapAccountsManager extends AbstractAccountsManager {
             throw new DuplicatedUsernameFoundException(accountError.getMessage());
         }
 
-        ensureOrgExists(newAccount);
+        try {
+            ensureOrgExists(newAccount);
+        } catch (IllegalStateException orgError) {
+            log.error("Error when trying to create / update the organisation {}, reverting the account creation",
+                    newAccount.getOrg(), orgError);
+            rollbackAccount(newAccount, newAccount.getOrg());
+            throw orgError;
+        }
 
         ensureRolesExist(mapped, newAccount);
     }
@@ -156,48 +163,65 @@ class LdapAccountsManager extends AbstractAccountsManager {
         Account newAccount = AccountFactory.createBrief(username, password, firstName, lastName, email, phone, title,
                 description, oAuth2Provider, oAuth2Uid);
         newAccount.setPending(false);
-        if (StringUtils.isEmpty(org) && !StringUtils.isBlank(defaultOrganization)) {
-            newAccount.setOrg(defaultOrganization);
+        String defaultOrg = this.georchestraGatewaySecurityConfigProperties.getDefaultOrganization();
+        if (StringUtils.isEmpty(org) && !StringUtils.isBlank(defaultOrg)) {
+            newAccount.setOrg(defaultOrg);
         } else {
             newAccount.setOrg(org);
         }
         return newAccount;
     }
 
+    /**
+     * @throws IllegalStateException if the org can't be created/updated
+     */
     private void ensureOrgExists(@NonNull Account newAccount) {
-        String orgId = newAccount.getOrg();
-        if (StringUtils.isEmpty(orgId))
-            return;
-        try { // account created, add org
-            Org org;
-            try {
-                org = orgsDao.findByCommonName(orgId);
-                // org already in the LDAP, add the newly
-                // created account to it
-                List<String> currentMembers = org.getMembers();
-                currentMembers.add(newAccount.getUid());
-                org.setMembers(currentMembers);
-                orgsDao.update(org);
-            } catch (NameNotFoundException e) {
-                log.info("Org {} does not exist, trying to create it", orgId);
-                // org does not exist yet, create it
-                org = new Org();
-                org.setId(orgId);
-                org.setName(orgId);
-                org.setShortName(orgId);
-                org.setOrgType("Other");
-                org.setMembers(Arrays.asList(newAccount.getUid()));
-                orgsDao.insert(org);
-            }
+        final String orgId = newAccount.getOrg();
+        if (!StringUtils.isEmpty(orgId)) {
+            findOrg(orgId).ifPresentOrElse(org -> addAccountToOrg(newAccount, org),
+                    () -> createOrgAndAddAccount(newAccount, orgId));
+        }
+    }
+
+    private void createOrgAndAddAccount(Account newAccount, final String orgId) {
+        try {
+            log.info("Org {} does not exist, trying to create it", orgId);
+            Org org = newOrg(orgId);
+            org.getMembers().add(newAccount.getUid());
+            orgsDao.insert(org);
         } catch (Exception orgError) {
-            log.error("Error when trying to create / update the organisation {}, reverting the account creation", orgId,
-                    orgError);
-            try {// roll-back account
-                accountDao.delete(newAccount);
-            } catch (NameNotFoundException | DataServiceException rollbackError) {
-                log.warn("Error reverting user creation after orgsDao update failure", rollbackError);
-            }
             throw new IllegalStateException(orgError);
         }
+    }
+
+    private void addAccountToOrg(Account newAccount, Org org) {
+        // org already in the LDAP, add the newly created account to it
+        org.getMembers().add(newAccount.getUid());
+        orgsDao.update(org);
+    }
+
+    private Optional<Org> findOrg(String orgId) {
+        try {
+            return Optional.of(orgsDao.findByCommonName(orgId));
+        } catch (NameNotFoundException e) {
+            return Optional.empty();
+        }
+    }
+
+    private void rollbackAccount(Account newAccount, final String orgId) {
+        try {// roll-back account
+            accountDao.delete(newAccount);
+        } catch (NameNotFoundException | DataServiceException rollbackError) {
+            log.warn("Error reverting user creation after orgsDao update failure", rollbackError);
+        }
+    }
+
+    private Org newOrg(final String orgId) {
+        Org org = new Org();
+        org.setId(orgId);
+        org.setName(orgId);
+        org.setShortName(orgId);
+        org.setOrgType("Other");
+        return org;
     }
 }

--- a/gateway/src/main/java/org/georchestra/gateway/autoconfigure/accounts/ConditionalOnCreateLdapAccounts.java
+++ b/gateway/src/main/java/org/georchestra/gateway/autoconfigure/accounts/ConditionalOnCreateLdapAccounts.java
@@ -35,7 +35,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
 @ConditionalOnDefaultGeorchestraLdapEnabled
-@ConditionalOnProperty(name = "georchestra.gateway.security.createNonExistingUsersInLDAP", havingValue = "true", matchIfMissing = false)
+@ConditionalOnProperty(name = "georchestra.gateway.security.create-non-existing-users-in-l-d-a-p", havingValue = "true", matchIfMissing = false)
 public @interface ConditionalOnCreateLdapAccounts {
 
 }

--- a/gateway/src/main/java/org/georchestra/gateway/autoconfigure/accounts/GeorchestraLdapAccountsCreationAutoConfiguration.java
+++ b/gateway/src/main/java/org/georchestra/gateway/autoconfigure/accounts/GeorchestraLdapAccountsCreationAutoConfiguration.java
@@ -18,9 +18,18 @@
  */
 package org.georchestra.gateway.autoconfigure.accounts;
 
+import java.util.List;
+
+import javax.annotation.PostConstruct;
+
 import org.georchestra.gateway.accounts.admin.ldap.GeorchestraLdapAccountManagementConfiguration;
+import org.georchestra.gateway.security.ldap.extended.ExtendedLdapAuthenticationConfiguration;
+import org.georchestra.gateway.security.ldap.extended.ExtendedLdapConfig;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.context.annotation.Import;
+
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
 
 /**
  * {@link AutoConfiguration @AutoConfiguration}
@@ -30,6 +39,17 @@ import org.springframework.context.annotation.Import;
  */
 @AutoConfiguration
 @ConditionalOnCreateLdapAccounts
-@Import(GeorchestraLdapAccountManagementConfiguration.class)
+@Import({ GeorchestraLdapAccountManagementConfiguration.class, ExtendedLdapAuthenticationConfiguration.class })
+@RequiredArgsConstructor
 public class GeorchestraLdapAccountsCreationAutoConfiguration {
+
+    @NonNull
+    private final List<ExtendedLdapConfig> configs;
+
+    @PostConstruct
+    void failIfNoExtendedLdapCongfigs() {
+        if (configs.isEmpty()) {
+            throw new IllegalStateException("LDAP account creation requires an extended LDAP configuration");
+        }
+    }
 }

--- a/gateway/src/main/java/org/georchestra/gateway/autoconfigure/security/AtLeastOneLdapDatasourceEnabledCondition.java
+++ b/gateway/src/main/java/org/georchestra/gateway/autoconfigure/security/AtLeastOneLdapDatasourceEnabledCondition.java
@@ -28,7 +28,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import org.georchestra.gateway.security.ldap.LdapConfigProperties;
+import org.georchestra.gateway.security.GeorchestraGatewaySecurityConfigProperties;
 import org.springframework.boot.autoconfigure.condition.ConditionMessage;
 import org.springframework.boot.autoconfigure.condition.ConditionMessage.ItemsBuilder;
 import org.springframework.boot.autoconfigure.condition.ConditionOutcome;
@@ -48,7 +48,7 @@ import com.google.common.collect.Streams;
  * the externalized config properties
  * {@code georchestra.gateway.security.ldap.<configName>.enabled}
  * 
- * @see LdapConfigProperties
+ * @see GeorchestraGatewaySecurityConfigProperties
  */
 class AtLeastOneLdapDatasourceEnabledCondition extends SpringBootCondition {
 

--- a/gateway/src/main/java/org/georchestra/gateway/security/GeorchestraGatewaySecurityConfigProperties.java
+++ b/gateway/src/main/java/org/georchestra/gateway/security/GeorchestraGatewaySecurityConfigProperties.java
@@ -16,7 +16,7 @@
  * You should have received a copy of the GNU General Public License along with
  * geOrchestra.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.georchestra.gateway.security.ldap;
+package org.georchestra.gateway.security;
 
 import java.util.List;
 import java.util.Map;
@@ -26,6 +26,8 @@ import java.util.stream.Stream;
 
 import javax.validation.Valid;
 
+import org.georchestra.gateway.security.ldap.LdapConfigBuilder;
+import org.georchestra.gateway.security.ldap.LdapConfigPropertiesValidations;
 import org.georchestra.gateway.security.ldap.basic.LdapServerConfig;
 import org.georchestra.gateway.security.ldap.extended.ExtendedLdapConfig;
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -61,9 +63,11 @@ import lombok.experimental.Accessors;
 @Validated
 @Accessors(chain = true)
 @ConfigurationProperties(prefix = "georchestra.gateway.security")
-public class LdapConfigProperties implements Validator {
+public class GeorchestraGatewaySecurityConfigProperties implements Validator {
 
     private boolean createNonExistingUsersInLDAP = true;
+
+    private String defaultOrganization = "";
 
     @Valid
     private Map<String, Server> ldap = Map.of();
@@ -182,12 +186,12 @@ public class LdapConfigProperties implements Validator {
     }
 
     public @Override boolean supports(Class<?> clazz) {
-        return LdapConfigProperties.class.equals(clazz);
+        return GeorchestraGatewaySecurityConfigProperties.class.equals(clazz);
     }
 
     @Override
     public void validate(Object target, Errors errors) {
-        LdapConfigProperties config = (LdapConfigProperties) target;
+        GeorchestraGatewaySecurityConfigProperties config = (GeorchestraGatewaySecurityConfigProperties) target;
         Map<String, Server> ldap = config.getLdap();
         if (ldap == null || ldap.isEmpty()) {
             return;

--- a/gateway/src/main/java/org/georchestra/gateway/security/exceptions/DuplicatedEmailFoundException.java
+++ b/gateway/src/main/java/org/georchestra/gateway/security/exceptions/DuplicatedEmailFoundException.java
@@ -1,11 +1,28 @@
+/*
+ * Copyright (C) 2024 by the geOrchestra PSC
+ *
+ * This file is part of geOrchestra.
+ *
+ * geOrchestra is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * geOrchestra is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * geOrchestra.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.georchestra.gateway.security.exceptions;
 
+@SuppressWarnings("serial")
 public class DuplicatedEmailFoundException extends RuntimeException {
-    private String message;
 
     public DuplicatedEmailFoundException(String message) {
         super(message);
-        this.message = message;
     }
 
     public DuplicatedEmailFoundException() {

--- a/gateway/src/main/java/org/georchestra/gateway/security/exceptions/DuplicatedUsernameFoundException.java
+++ b/gateway/src/main/java/org/georchestra/gateway/security/exceptions/DuplicatedUsernameFoundException.java
@@ -1,11 +1,28 @@
+/*
+ * Copyright (C) 2024 by the geOrchestra PSC
+ *
+ * This file is part of geOrchestra.
+ *
+ * geOrchestra is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * geOrchestra is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * geOrchestra.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.georchestra.gateway.security.exceptions;
 
+@SuppressWarnings("serial")
 public class DuplicatedUsernameFoundException extends RuntimeException {
-    private String message;
 
     public DuplicatedUsernameFoundException(String message) {
         super(message);
-        this.message = message;
     }
 
     public DuplicatedUsernameFoundException() {

--- a/gateway/src/main/java/org/georchestra/gateway/security/ldap/LdapAuthenticationConfiguration.java
+++ b/gateway/src/main/java/org/georchestra/gateway/security/ldap/LdapAuthenticationConfiguration.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.georchestra.gateway.security.GeorchestraGatewaySecurityConfigProperties;
 import org.georchestra.gateway.security.ServerHttpSecurityCustomizer;
 import org.georchestra.gateway.security.ldap.basic.BasicLdapAuthenticationConfiguration;
 import org.georchestra.gateway.security.ldap.basic.BasicLdapAuthenticationProvider;
@@ -49,9 +50,11 @@ import lombok.extern.slf4j.Slf4j;
  * authorization across multiple LDAP databases.
  * <p>
  * This configuration sets up the required beans for spring-based LDAP
- * authentication and authorization, using {@link LdapConfigProperties} to get
- * the {@link LdapConfigProperties#getUrl() connection URL} and the
- * {@link LdapConfigProperties#getBaseDn() base DN}.
+ * authentication and authorization, using
+ * {@link GeorchestraGatewaySecurityConfigProperties} to get the
+ * {@link GeorchestraGatewaySecurityConfigProperties#getUrl() connection URL}
+ * and the {@link GeorchestraGatewaySecurityConfigProperties#getBaseDn() base
+ * DN}.
  * <p>
  * As a result, the {@link ServerHttpSecurity} will have HTTP-Basic
  * authentication enabled and {@link ServerHttpSecurity#formLogin() form login}
@@ -68,12 +71,12 @@ import lombok.extern.slf4j.Slf4j;
  * the matching gateway-route configuration. See
  * {@link ExtendedLdapAuthenticationConfiguration} for further details.
  * 
- * @see LdapConfigProperties
+ * @see GeorchestraGatewaySecurityConfigProperties
  * @see BasicLdapAuthenticationConfiguration
  * @see ExtendedLdapAuthenticationConfiguration
  */
 @Configuration(proxyBeanMethods = true)
-@EnableConfigurationProperties(LdapConfigProperties.class)
+@EnableConfigurationProperties(GeorchestraGatewaySecurityConfigProperties.class)
 @Import({ //
         BasicLdapAuthenticationConfiguration.class, //
         ExtendedLdapAuthenticationConfiguration.class })

--- a/gateway/src/main/java/org/georchestra/gateway/security/ldap/LdapConfigBuilder.java
+++ b/gateway/src/main/java/org/georchestra/gateway/security/ldap/LdapConfigBuilder.java
@@ -22,7 +22,7 @@ import static java.util.Optional.ofNullable;
 
 import java.util.Optional;
 
-import org.georchestra.gateway.security.ldap.LdapConfigProperties.Server;
+import org.georchestra.gateway.security.GeorchestraGatewaySecurityConfigProperties.Server;
 import org.georchestra.gateway.security.ldap.basic.LdapServerConfig;
 import org.georchestra.gateway.security.ldap.extended.ExtendedLdapConfig;
 import org.springframework.util.StringUtils;
@@ -32,7 +32,7 @@ import lombok.extern.slf4j.Slf4j;
 /**
  */
 @Slf4j
-class LdapConfigBuilder {
+public class LdapConfigBuilder {
 
     public LdapServerConfig asBasicLdapConfig(String name, Server config) {
         String searchFilter = usersSearchFilter(name, config);

--- a/gateway/src/main/java/org/georchestra/gateway/security/ldap/LdapConfigPropertiesValidations.java
+++ b/gateway/src/main/java/org/georchestra/gateway/security/ldap/LdapConfigPropertiesValidations.java
@@ -21,13 +21,13 @@ package org.georchestra.gateway.security.ldap;
 import static java.lang.String.format;
 import static org.springframework.validation.ValidationUtils.rejectIfEmptyOrWhitespace;
 
-import org.georchestra.gateway.security.ldap.LdapConfigProperties.Server;
+import org.georchestra.gateway.security.GeorchestraGatewaySecurityConfigProperties.Server;
 import org.springframework.validation.Errors;
 
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j(topic = "org.georchestra.gateway.security.ldap")
-class LdapConfigPropertiesValidations {
+public class LdapConfigPropertiesValidations {
 
     public void validate(String name, Server config, Errors errors) {
         if (!config.isEnabled()) {

--- a/gateway/src/main/java/org/georchestra/gateway/security/ldap/basic/BasicLdapAuthenticationConfiguration.java
+++ b/gateway/src/main/java/org/georchestra/gateway/security/ldap/basic/BasicLdapAuthenticationConfiguration.java
@@ -22,7 +22,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import org.georchestra.gateway.security.ServerHttpSecurityCustomizer;
-import org.georchestra.gateway.security.ldap.LdapConfigProperties;
+import org.georchestra.gateway.security.GeorchestraGatewaySecurityConfigProperties;
 import org.georchestra.gateway.security.ldap.extended.ExtendedLdapAuthenticationConfiguration;
 import org.springframework.beans.factory.BeanCreationException;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -41,9 +41,11 @@ import lombok.extern.slf4j.Slf4j;
  * authorization across multiple LDAP databases.
  * <p>
  * This configuration sets up the required beans for spring-based LDAP
- * authentication and authorization, using {@link LdapConfigProperties} to get
- * the {@link LdapConfigProperties#getUrl() connection URL} and the
- * {@link LdapConfigProperties#getBaseDn() base DN}.
+ * authentication and authorization, using
+ * {@link GeorchestraGatewaySecurityConfigProperties} to get the
+ * {@link GeorchestraGatewaySecurityConfigProperties#getUrl() connection URL}
+ * and the {@link GeorchestraGatewaySecurityConfigProperties#getBaseDn() base
+ * DN}.
  * <p>
  * As a result, the {@link ServerHttpSecurity} will have HTTP-Basic
  * authentication enabled and {@link ServerHttpSecurity#formLogin() form login}
@@ -61,10 +63,10 @@ import lombok.extern.slf4j.Slf4j;
  * {@link ExtendedLdapAuthenticationConfiguration} for further details.
  * 
  * @see ExtendedLdapAuthenticationConfiguration
- * @see LdapConfigProperties
+ * @see GeorchestraGatewaySecurityConfigProperties
  */
 @Configuration(proxyBeanMethods = false)
-@EnableConfigurationProperties(LdapConfigProperties.class)
+@EnableConfigurationProperties(GeorchestraGatewaySecurityConfigProperties.class)
 @Slf4j(topic = "org.georchestra.gateway.security.ldap.basic")
 public class BasicLdapAuthenticationConfiguration {
 
@@ -74,7 +76,7 @@ public class BasicLdapAuthenticationConfiguration {
     }
 
     @Bean
-    List<LdapServerConfig> enabledSimpleLdapConfigs(LdapConfigProperties config) {
+    List<LdapServerConfig> enabledSimpleLdapConfigs(GeorchestraGatewaySecurityConfigProperties config) {
         return config.simpleEnabled();
     }
 

--- a/gateway/src/main/java/org/georchestra/gateway/security/ldap/extended/DemultiplexingUsersApi.java
+++ b/gateway/src/main/java/org/georchestra/gateway/security/ldap/extended/DemultiplexingUsersApi.java
@@ -49,7 +49,7 @@ import lombok.RequiredArgsConstructor;
  * {@literal username}.
  */
 @RequiredArgsConstructor
-class DemultiplexingUsersApi {
+public class DemultiplexingUsersApi {
 
     private final @NonNull Map<String, UsersApi> usersByConfigName;
     private final @NonNull Map<String, OrganizationsApi> orgsByConfigName;
@@ -59,12 +59,12 @@ class DemultiplexingUsersApi {
     }
 
     /**
-     * 
+     *
      * @param serviceName the configured LDAP service name, as from the
      *                    configuration properties
      *                    {@code georchestra.gateway.security.<serviceName>}
      * @param username    the user name to query the service's {@link UsersApi} with
-     * 
+     *
      * @return the {@link GeorchestraUser} returned by the service's
      *         {@link UsersApi}, or {@link Optional#empty() empty} if not found
      */
@@ -72,6 +72,28 @@ class DemultiplexingUsersApi {
         UsersApi usersApi = usersByConfigName.get(serviceName);
         Objects.requireNonNull(usersApi, () -> "No UsersApi found for config named " + serviceName);
         Optional<GeorchestraUser> user = usersApi.findByUsername(username);
+
+        return extend(serviceName, user);
+    }
+
+    public Optional<ExtendedGeorchestraUser> findByUsername(@NonNull String username) {
+        // TODO: iterates over every possible geOrchestra LDAP being registered ?
+        // I would expect to have generally only one geOrchestra (extended) LDAP
+        // configured,
+        // so the first extended LDAP should do.
+        String serviceName = usersByConfigName.keySet().stream().findFirst().get();
+        UsersApi usersApi = usersByConfigName.get(serviceName);
+        Optional<GeorchestraUser> user = usersApi.findByUsername(username);
+
+        return extend(serviceName, user);
+    }
+
+    public Optional<ExtendedGeorchestraUser> findByOAuth2Uid(@NonNull String oauth2Provider,
+            @NonNull String oauth2Uid) {
+        String serviceName = usersByConfigName.keySet().stream().findFirst().get();
+        UsersApi usersApi = usersByConfigName.get(serviceName);
+        Objects.requireNonNull(usersApi, () -> "No UsersApi found for config named " + serviceName);
+        Optional<GeorchestraUser> user = usersApi.findByOAuth2Uid(oauth2Provider, oauth2Uid);
 
         return extend(serviceName, user);
     }

--- a/gateway/src/main/java/org/georchestra/gateway/security/ldap/extended/ExtendedLdapAuthenticationConfiguration.java
+++ b/gateway/src/main/java/org/georchestra/gateway/security/ldap/extended/ExtendedLdapAuthenticationConfiguration.java
@@ -37,8 +37,8 @@ import org.georchestra.ds.users.AccountDao;
 import org.georchestra.ds.users.AccountDaoImpl;
 import org.georchestra.ds.users.UserRule;
 import org.georchestra.gateway.security.GeorchestraUserMapperExtension;
-import org.georchestra.gateway.security.ldap.LdapConfigProperties;
-import org.georchestra.gateway.security.ldap.LdapConfigProperties.Server;
+import org.georchestra.gateway.security.GeorchestraGatewaySecurityConfigProperties;
+import org.georchestra.gateway.security.GeorchestraGatewaySecurityConfigProperties.Server;
 import org.georchestra.gateway.security.ldap.basic.LdapAuthenticatorProviderBuilder;
 import org.georchestra.security.api.OrganizationsApi;
 import org.georchestra.security.api.UsersApi;
@@ -62,7 +62,7 @@ import lombok.extern.slf4j.Slf4j;
  * {@literal georchestra-ldap-account-management} module's {@link UsersApi}.
  */
 @Configuration(proxyBeanMethods = false)
-@EnableConfigurationProperties(LdapConfigProperties.class)
+@EnableConfigurationProperties(GeorchestraGatewaySecurityConfigProperties.class)
 @Slf4j(topic = "org.georchestra.gateway.security.ldap.extended")
 public class ExtendedLdapAuthenticationConfiguration {
 
@@ -72,7 +72,7 @@ public class ExtendedLdapAuthenticationConfiguration {
     }
 
     @Bean
-    List<ExtendedLdapConfig> enabledExtendedLdapConfigs(LdapConfigProperties config) {
+    List<ExtendedLdapConfig> enabledExtendedLdapConfigs(GeorchestraGatewaySecurityConfigProperties config) {
         return config.extendedEnabled();
     }
 

--- a/gateway/src/main/java/org/georchestra/gateway/security/ldap/extended/ExtendedLdapConfig.java
+++ b/gateway/src/main/java/org/georchestra/gateway/security/ldap/extended/ExtendedLdapConfig.java
@@ -22,6 +22,7 @@ package org.georchestra.gateway.security.ldap.extended;
 import java.util.Optional;
 
 import lombok.Builder;
+import lombok.Builder.Default;
 import lombok.Generated;
 import lombok.NonNull;
 import lombok.Value;
@@ -42,8 +43,10 @@ public class ExtendedLdapConfig {
     // null = all atts, empty == none
     private String[] returningAttributes;
 
-    private @NonNull Optional<String> adminDn;
-    private @NonNull Optional<String> adminPassword;
+    @Default
+    private @NonNull Optional<String> adminDn = Optional.empty();
+    @Default
+    private @NonNull Optional<String> adminPassword = Optional.empty();
 
     private @NonNull String orgsRdn;
     private @NonNull String pendingOrgsRdn;

--- a/gateway/src/main/java/org/georchestra/gateway/security/oauth2/OAuth2Configuration.java
+++ b/gateway/src/main/java/org/georchestra/gateway/security/oauth2/OAuth2Configuration.java
@@ -28,7 +28,7 @@ import java.util.Collections;
 import javax.crypto.spec.SecretKeySpec;
 
 import org.georchestra.gateway.security.ServerHttpSecurityCustomizer;
-import org.georchestra.gateway.security.ldap.LdapConfigProperties;
+import org.georchestra.gateway.security.GeorchestraGatewaySecurityConfigProperties;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -67,7 +67,7 @@ import java.util.stream.Collectors;
 
 @Configuration(proxyBeanMethods = false)
 @EnableConfigurationProperties({ OAuth2ProxyConfigProperties.class, OpenIdConnectCustomClaimsConfigProperties.class,
-        LdapConfigProperties.class, ExtendedOAuth2ClientProperties.class })
+        GeorchestraGatewaySecurityConfigProperties.class, ExtendedOAuth2ClientProperties.class })
 @Slf4j(topic = "org.georchestra.gateway.security.oauth2")
 public class OAuth2Configuration {
 

--- a/gateway/src/main/java/org/georchestra/gateway/security/oauth2/OpenIdConnectUserMapper.java
+++ b/gateway/src/main/java/org/georchestra/gateway/security/oauth2/OpenIdConnectUserMapper.java
@@ -27,7 +27,7 @@ import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
 
-import org.georchestra.gateway.security.ldap.LdapConfigProperties;
+import org.georchestra.gateway.security.GeorchestraGatewaySecurityConfigProperties;
 import org.georchestra.security.model.GeorchestraUser;
 import org.slf4j.Logger;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -131,7 +131,7 @@ import lombok.extern.slf4j.Slf4j;
  * </ul>
  */
 @RequiredArgsConstructor
-@EnableConfigurationProperties({ LdapConfigProperties.class })
+@EnableConfigurationProperties({ GeorchestraGatewaySecurityConfigProperties.class })
 @Slf4j(topic = "org.georchestra.gateway.security.oauth2")
 public class OpenIdConnectUserMapper extends OAuth2UserMapper {
 

--- a/gateway/src/test/java/org/georchestra/gateway/app/GeorchestraGatewayApplicationTests.java
+++ b/gateway/src/test/java/org/georchestra/gateway/app/GeorchestraGatewayApplicationTests.java
@@ -44,6 +44,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySources;
 import org.springframework.test.web.reactive.server.WebTestClient;
 import org.springframework.web.server.ServerWebExchange;
 

--- a/gateway/src/test/java/org/georchestra/gateway/autoconfigure/security/LdapSecurityAutoConfigurationTest.java
+++ b/gateway/src/test/java/org/georchestra/gateway/autoconfigure/security/LdapSecurityAutoConfigurationTest.java
@@ -23,7 +23,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import org.georchestra.gateway.security.ldap.LdapAuthenticationConfiguration;
 import org.georchestra.gateway.security.ldap.LdapAuthenticationConfiguration.LDAPAuthenticationCustomizer;
-import org.georchestra.gateway.security.ldap.LdapConfigProperties;
+import org.georchestra.gateway.security.GeorchestraGatewaySecurityConfigProperties;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
@@ -63,7 +63,7 @@ class LdapSecurityAutoConfigurationTest {
 
     private void testDisabled(ApplicationContextRunner runner) {
         runner.run(context -> {
-            assertThat(context).doesNotHaveBean(LdapConfigProperties.class);
+            assertThat(context).doesNotHaveBean(GeorchestraGatewaySecurityConfigProperties.class);
             assertThat(context).doesNotHaveBean(LDAPAuthenticationCustomizer.class);
             assertThat(context).doesNotHaveBean(AuthenticationWebFilter.class);
             assertThat(context).doesNotHaveBean(ReactiveAuthenticationManager.class);
@@ -99,18 +99,26 @@ class LdapSecurityAutoConfigurationTest {
                 , "georchestra.gateway.security.ldap.ldap1.orgs.rdn: ou=orgs" //
         );
 
-        testEnabled(runner);
+        testEnabled(runner, true);
     }
 
     private void testEnabled(ApplicationContextRunner runner) {
+        testEnabled(runner, false);
+    }
+
+    private void testEnabled(ApplicationContextRunner runner, boolean extended) {
         runner.run(context -> {
-            assertThat(context).hasSingleBean(LdapConfigProperties.class);
+            assertThat(context).hasSingleBean(GeorchestraGatewaySecurityConfigProperties.class);
             assertThat(context).hasSingleBean(LDAPAuthenticationCustomizer.class);
             assertThat(context).hasSingleBean(AuthenticationWebFilter.class);
 
             assertThat(context).hasBean("ldapAuthenticationManager");
             assertThat(context.getBean("ldapAuthenticationManager"))
                     .isInstanceOf(ReactiveAuthenticationManagerAdapter.class);
+
+            if (extended) {
+                assertThat(context).hasBean("georchestraLdapAuthenticatedUserMapper");
+            }
         });
     }
 }

--- a/gateway/src/test/java/org/georchestra/gateway/security/ResolveGeorchestraUserGlobalFilterIT.java
+++ b/gateway/src/test/java/org/georchestra/gateway/security/ResolveGeorchestraUserGlobalFilterIT.java
@@ -21,6 +21,7 @@ import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.utility.DockerImageName;
 
 import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -51,7 +52,7 @@ public class ResolveGeorchestraUserGlobalFilterIT {
     };
 
     public static @BeforeAll void startUpContainers() {
-        httpEcho.setExposedPorts(Arrays.asList(new Integer[] { 80 }));
+        httpEcho.setExposedPorts(List.of(80));
         httpEcho.start();
         ldap.start();
     }
@@ -102,7 +103,16 @@ public class ResolveGeorchestraUserGlobalFilterIT {
                 .expectBody()//
                 .jsonPath(".request.headers.sec-user").doesNotHaveJsonPath()//
                 .jsonPath(".request.headers.sec-organization").exists();
+    }
 
+    public @Test void testSecOrgnamePresent() {
+        testClient.get().uri("/echo/")//
+                .header("Authorization", "Basic dGVzdGFkbWluOnRlc3RhZG1pbg==") // testadmin:testadmin
+                .exchange()//
+                .expectStatus()//
+                .is2xxSuccessful()//
+                .expectBody()//
+                .jsonPath(".request.headers.sec-orgname").exists();
     }
 
     /**

--- a/gateway/src/test/java/org/georchestra/gateway/security/ldap/LdapConfigPropertiesValidationsTest.java
+++ b/gateway/src/test/java/org/georchestra/gateway/security/ldap/LdapConfigPropertiesValidationsTest.java
@@ -21,6 +21,7 @@ package org.georchestra.gateway.security.ldap;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import org.georchestra.gateway.security.GeorchestraGatewaySecurityConfigProperties;
 import org.georchestra.gateway.security.ldap.basic.LdapServerConfig;
 import org.georchestra.gateway.security.ldap.extended.ExtendedLdapConfig;
 import org.junit.jupiter.api.Test;
@@ -32,14 +33,15 @@ import org.springframework.context.annotation.Configuration;
  * Test cases for {@link LdapConfigPropertiesValidations}.
  * <p>
  * {@link LdapConfigPropertiesValidations} will forbid application startup if
- * {@link LdapConfigProperties} is invalid.
+ * {@link GeorchestraGatewaySecurityConfigProperties} is invalid.
  * <p>
- * {@link LdapConfigProperties} is loaded from application properties, usually
- * from georchestra datadirectory's {@literal gateway/gateway.yaml}
+ * {@link GeorchestraGatewaySecurityConfigProperties} is loaded from application
+ * properties, usually from georchestra datadirectory's
+ * {@literal gateway/gateway.yaml}
  */
 class LdapConfigPropertiesValidationsTest {
 
-    @EnableConfigurationProperties(LdapConfigProperties.class)
+    @EnableConfigurationProperties(GeorchestraGatewaySecurityConfigProperties.class)
     static @Configuration class EnableConfigProps {
 
     }
@@ -49,8 +51,8 @@ class LdapConfigPropertiesValidationsTest {
 
     public @Test void no_ldap_configs() {
         runner.run(context -> {
-            assertThat(context).hasSingleBean(LdapConfigProperties.class);
-            assertThat(context.getBean(LdapConfigProperties.class).getLdap()).isEmpty();
+            assertThat(context).hasSingleBean(GeorchestraGatewaySecurityConfigProperties.class);
+            assertThat(context.getBean(GeorchestraGatewaySecurityConfigProperties.class).getLdap()).isEmpty();
         });
     }
 
@@ -59,8 +61,9 @@ class LdapConfigPropertiesValidationsTest {
                 "georchestra.gateway.security.ldap.ldap1.enabled: false" //
                 , "georchestra.gateway.security.ldap.ldap2.enabled: false" //
         ).run(context -> {
-            assertThat(context).hasSingleBean(LdapConfigProperties.class);
-            LdapConfigProperties config = context.getBean(LdapConfigProperties.class);
+            assertThat(context).hasSingleBean(GeorchestraGatewaySecurityConfigProperties.class);
+            GeorchestraGatewaySecurityConfigProperties config = context
+                    .getBean(GeorchestraGatewaySecurityConfigProperties.class);
             assertThat(config.getLdap()).hasSize(2);
             assertThat(config.simpleEnabled()).isEmpty();
             assertThat(config.extendedEnabled()).isEmpty();
@@ -239,7 +242,8 @@ class LdapConfigPropertiesValidationsTest {
                 , "georchestra.gateway.security.ldap.ldap1.roles.searchFilter: (member={0})" //
         ).run(context -> {
             assertThat(context).hasNotFailed();
-            LdapConfigProperties config = context.getBean(LdapConfigProperties.class);
+            GeorchestraGatewaySecurityConfigProperties config = context
+                    .getBean(GeorchestraGatewaySecurityConfigProperties.class);
             assertThat(config.simpleEnabled()).hasSize(1);
             assertThat(config.extendedEnabled()).isEmpty();
 
@@ -269,7 +273,8 @@ class LdapConfigPropertiesValidationsTest {
                 , "georchestra.gateway.security.ldap.ldap1.orgs.rdn: ou=orgs" //
         ).run(context -> {
             assertThat(context).hasNotFailed();
-            LdapConfigProperties config = context.getBean(LdapConfigProperties.class);
+            GeorchestraGatewaySecurityConfigProperties config = context
+                    .getBean(GeorchestraGatewaySecurityConfigProperties.class);
             assertThat(config.simpleEnabled()).isEmpty();
             assertThat(config.extendedEnabled()).hasSize(1);
 
@@ -327,7 +332,8 @@ class LdapConfigPropertiesValidationsTest {
         ).run(context -> {
             assertThat(context).hasNotFailed();
 
-            LdapConfigProperties config = context.getBean(LdapConfigProperties.class);
+            GeorchestraGatewaySecurityConfigProperties config = context
+                    .getBean(GeorchestraGatewaySecurityConfigProperties.class);
             assertThat(config.simpleEnabled()).hasSize(3);
             assertThat(config.extendedEnabled()).hasSize(1);
         });

--- a/gateway/src/test/resources/test-datadir/gateway/security.yaml
+++ b/gateway/src/test/resources/test-datadir/gateway/security.yaml
@@ -4,7 +4,7 @@ georchestra:
       oauth2:
         enabled: true
       ldap:
-        openldap:
+        default:
           enabled: true
           extended: true
           url: ldap://ldap:389


### PR DESCRIPTION
Considering the following configuration scenario:

* external authentication (oidc/oauth2 or pre-auth) being configured
* `createUsersInGeorchestraLdap` set to true

Then the resolved `GeorchestraUser` should be an `ExtendedGeorchestraUser`, in order to have a behaviour coherent with the geOrchestra LDAP authentication (via the classic login form provided by the gateway).

Without doing so, users externally authenticated will resolve as a classic GeorchestraUser, leading to missing http headers and breaking some geOrchestra applications (e.g. datafeeder, which requires the `sec-orgname` provided only when resolving to an `ExtendedGeorchestraUser`).

This also refactors the `LdapConfigProperties` to `GeorchestraGatewaySecurityConfigProperties`, as the object is not only about LDAP, but also nests some other configureable features (OIDC, ...).

Documentation has been updated to describe / explain the behaviour.

Tests:
* testsuite adapted
* added specific tests case scenario
* Runtime tested onto a setup making use of pre-authentication: as a member of the `IMPORT` role, being externally authenticated, I was able to import a dataset following the datafeeder wizard.

