### PR TITLE
Fixed issue for authenticated by email users who change their email

### DIFF
--- a/gateway/src/main/java/org/georchestra/gateway/security/ldap/extended/DemultiplexingUsersApi.java
+++ b/gateway/src/main/java/org/georchestra/gateway/security/ldap/extended/DemultiplexingUsersApi.java
@@ -76,13 +76,6 @@ class DemultiplexingUsersApi {
         return extend(serviceName, user);
     }
 
-    public Optional<ExtendedGeorchestraUser> findByEmail(@NonNull String serviceName, @NonNull String email) {
-        UsersApi usersApi = usersByConfigName.get(serviceName);
-        Objects.requireNonNull(usersApi, () -> "No UsersApi found for config named " + serviceName);
-        Optional<GeorchestraUser> user = usersApi.findByEmail(email);
-        return extend(serviceName, user);
-    }
-
     private Optional<ExtendedGeorchestraUser> extend(String serviceName, Optional<GeorchestraUser> user) {
         OrganizationsApi orgsApi = orgsByConfigName.get(serviceName);
         Objects.requireNonNull(orgsApi, () -> "No OrganizationsApi found for config named " + serviceName);

--- a/gateway/src/main/java/org/georchestra/gateway/security/ldap/extended/ExtendedLdapAuthenticationProvider.java
+++ b/gateway/src/main/java/org/georchestra/gateway/security/ldap/extended/ExtendedLdapAuthenticationProvider.java
@@ -58,7 +58,7 @@ public class ExtendedLdapAuthenticationProvider extends LdapAuthenticationProvid
         }
         Assert.notNull(password, "Null password was supplied in authentication token");
         DirContextOperations userData = doAuthentication(userToken);
-        UserDetails user = this.userDetailsContextMapper.mapUserFromContext(userData, authentication.getName(),
+        UserDetails user = this.userDetailsContextMapper.mapUserFromContext(userData, username,
                 loadUserAuthorities(userData, authentication.getName(), (String) authentication.getCredentials()));
 
         return createSuccessfulAuthentication(userToken, user);

--- a/gateway/src/main/java/org/georchestra/gateway/security/ldap/extended/GeorchestraLdapAuthenticatedUserMapper.java
+++ b/gateway/src/main/java/org/georchestra/gateway/security/ldap/extended/GeorchestraLdapAuthenticatedUserMapper.java
@@ -68,10 +68,6 @@ class GeorchestraLdapAuthenticatedUserMapper implements GeorchestraUserMapperExt
         final String username = principal.getUsername();
 
         Optional<ExtendedGeorchestraUser> user = users.findByUsername(ldapConfigName, username);
-        if (user.isEmpty()) {
-            user = users.findByEmail(ldapConfigName, username);
-        }
-
         return user.map(u -> fixPrefixedRoleNames(u, token));
     }
 


### PR DESCRIPTION
When a user logs in using email address instead of username, then change his email, he is no longer logged in but also can't log out. As searches in LDAP were based on the same credential than supplied when logging in, theses searches no longer returned anything if user email has changed.

With this fix, user is searched using email only first time just after at log-in, then username is recorded as credential for the rest of the session (as if the user has logged in using username), which allows further email change without issue.