### PR TITLE
Catch application errors to display standardized error page

### DIFF
--- a/docs/custom-error-pages.adoc
+++ b/docs/custom-error-pages.adoc
@@ -29,3 +29,25 @@ spring:
 3. In the datadir create a folder from the root directory: "gateway/templates/error"
 4. Place your error page files named as per the status code. For example for 404: 404.html
 5. Restart georchestra gateway.
+
+== Using custom error pages for applications errors
+
+Custom error pages can also be used when an application behind the gateways returns an error.
+
+To enable it globally, add this to application.yaml :
+[application.yaml]
+----
+spring:
+  cloud:
+    gateway:
+      default-filters:
+        - ApplicationError
+----
+
+To enable it only on some routes, add this to concerned routes in routes.yaml :
+[routes.yaml]
+----
+        filters:
+        - name: ApplicationError
+----
+

--- a/gateway/src/main/java/org/georchestra/gateway/autoconfigure/app/FiltersAutoConfiguration.java
+++ b/gateway/src/main/java/org/georchestra/gateway/autoconfigure/app/FiltersAutoConfiguration.java
@@ -20,6 +20,7 @@ package org.georchestra.gateway.autoconfigure.app;
 
 import org.georchestra.gateway.filter.global.ResolveTargetGlobalFilter;
 import org.georchestra.gateway.filter.headers.HeaderFiltersConfiguration;
+import org.georchestra.gateway.filter.global.ApplicationErrorGatewayFilterFactory;
 import org.georchestra.gateway.model.GatewayConfigProperties;
 import org.georchestra.gateway.model.GeorchestraTargetConfig;
 import org.geoserver.cloud.gateway.filter.RouteProfileGatewayFilterFactory;
@@ -44,7 +45,7 @@ public class FiltersAutoConfiguration {
      * matched Route's GeorchestraTargetConfig for each HTTP request-response
      * interaction before other filters are applied.
      */
-    public @Bean ResolveTargetGlobalFilter resolveTargetWebFilter(GatewayConfigProperties config) {
+    @Bean ResolveTargetGlobalFilter resolveTargetWebFilter(GatewayConfigProperties config) {
         return new ResolveTargetGlobalFilter(config);
     }
 
@@ -63,5 +64,9 @@ public class FiltersAutoConfiguration {
 
     public @Bean StripBasePathGatewayFilterFactory stripBasePathGatewayFilterFactory() {
         return new StripBasePathGatewayFilterFactory();
+    }
+
+    @Bean ApplicationErrorGatewayFilterFactory applicationErrorGatewayFilterFactory() {
+        return new ApplicationErrorGatewayFilterFactory();
     }
 }

--- a/gateway/src/main/java/org/georchestra/gateway/filter/global/ApplicationErrorGatewayFilterFactory.java
+++ b/gateway/src/main/java/org/georchestra/gateway/filter/global/ApplicationErrorGatewayFilterFactory.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2024 by the geOrchestra PSC
+ *
+ * This file is part of geOrchestra.
+ *
+ * geOrchestra is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * geOrchestra is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * geOrchestra.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.georchestra.gateway.filter.global;
+
+import org.springframework.cloud.gateway.filter.GatewayFilter;
+import org.springframework.cloud.gateway.filter.GatewayFilterChain;
+import org.springframework.cloud.gateway.filter.factory.AbstractGatewayFilterFactory;
+import org.springframework.cloud.gateway.filter.factory.GatewayFilterFactory;
+import org.springframework.core.Ordered;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Mono;
+
+/**
+ * {@link GatewayFilterFactory} providing a {@link GatewayFilter} that throws a
+ * {@link ResponseStatusException} with the proxied response status code if the
+ * target responded with a {@code 400...} or {@code 500...} status code.
+ * 
+ */
+public class ApplicationErrorGatewayFilterFactory extends AbstractGatewayFilterFactory<Object> {
+
+	public ApplicationErrorGatewayFilterFactory() {
+		super(Object.class);
+	}
+
+	@Override
+	public GatewayFilter apply(final Object config) {
+		return new ServiceErrorGatewayFilter();
+	}
+
+	private static class ServiceErrorGatewayFilter implements GatewayFilter, Ordered {
+
+		public @Override Mono<Void> filter(ServerWebExchange exchange, GatewayFilterChain chain) {
+			return chain.filter(exchange).then(Mono.fromRunnable(() -> {
+				HttpStatus statusCode = exchange.getResponse().getStatusCode();
+				if (statusCode.is4xxClientError() || statusCode.is5xxServerError()) {
+					throw new ResponseStatusException(statusCode);
+				}
+			}));
+		}
+
+		@Override
+		public int getOrder() {
+			return ResolveTargetGlobalFilter.ORDER + 1;
+		}
+	}
+}

--- a/gateway/src/test/java/org/georchestra/gateway/filter/global/ApplicationErrorGatewayFilterFactoryTest.java
+++ b/gateway/src/test/java/org/georchestra/gateway/filter/global/ApplicationErrorGatewayFilterFactoryTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (C) 2024 by the geOrchestra PSC
+ *
+ * This file is part of geOrchestra.
+ *
+ * geOrchestra is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * geOrchestra is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * geOrchestra.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.georchestra.gateway.filter.global;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.springframework.cloud.gateway.support.ServerWebExchangeUtils.GATEWAY_ROUTE_ATTR;
+
+import java.net.URI;
+import java.util.List;
+
+import org.georchestra.gateway.model.HeaderMappings;
+import org.georchestra.gateway.model.RoleBasedAccessRule;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.cloud.gateway.filter.GatewayFilter;
+import org.springframework.cloud.gateway.filter.GatewayFilterChain;
+import org.springframework.cloud.gateway.route.Route;
+import org.springframework.http.HttpStatus;
+import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
+import org.springframework.mock.web.server.MockServerWebExchange;
+import org.springframework.web.server.ResponseStatusException;
+
+import reactor.core.publisher.Mono;
+
+class ApplicationErrorGatewayFilterFactoryTest {
+	
+	
+	private GatewayFilterChain chain;
+	private GatewayFilter filter;
+    private MockServerWebExchange exchange;
+
+    final URI matchedURI = URI.create("http://fake.backend.com:8080");
+    private Route matchedRoute;
+
+    HeaderMappings defaultHeaders;
+    List<RoleBasedAccessRule> defaultRules;
+
+    @BeforeEach
+    void setUp() throws Exception {
+    	var factory = new ApplicationErrorGatewayFilterFactory();
+		filter = factory.apply(factory.newConfig());
+
+        matchedRoute = mock(Route.class);
+        when(matchedRoute.getUri()).thenReturn(matchedURI);
+
+		chain = mock(GatewayFilterChain.class);
+        when(chain.filter(any())).thenReturn(Mono.empty());
+        MockServerHttpRequest request = MockServerHttpRequest.get("/test").build();
+        exchange = MockServerWebExchange.from(request);
+        exchange.getAttributes().put(GATEWAY_ROUTE_ATTR, matchedRoute);
+    }
+
+    @Test
+	void testNotAnErrorResponse() {
+		exchange.getResponse().setStatusCode(HttpStatus.OK);
+    	Mono<Void> result = filter.filter(exchange, chain);
+    	result.block();
+    	assertThat(exchange.getResponse().getRawStatusCode()).isEqualTo(200);
+	}
+
+    @Test
+    void test4xx() {
+		testApplicationError(HttpStatus.BAD_REQUEST);
+		testApplicationError(HttpStatus.UNAUTHORIZED);
+		testApplicationError(HttpStatus.FORBIDDEN);
+		testApplicationError(HttpStatus.NOT_FOUND);
+    }
+
+
+    @Test
+    void test5xx() {
+		testApplicationError(HttpStatus.INTERNAL_SERVER_ERROR);
+		testApplicationError(HttpStatus.SERVICE_UNAVAILABLE);
+		testApplicationError(HttpStatus.BAD_GATEWAY);
+    }
+    
+	private void testApplicationError(HttpStatus status) {
+		exchange.getResponse().setStatusCode(status);
+    	Mono<Void> result = filter.filter(exchange, chain);
+    	ResponseStatusException ex = assertThrows(ResponseStatusException.class, ()-> result.block());
+    	assertThat(ex.getStatus()).isEqualTo(status);
+	}
+}


### PR DESCRIPTION
We wanted to show a standardized error page when an application behind the gateway returns an HTTP 4xx or 5xx error, instead of an application specific error page.

It uses error pages templates embedded in gateway or overriden in `gateway/template/error` directory of datadir.

To enable it globally, add this to `gateway/application.yaml` of datadir :
```
spring:
  cloud:
    gateway:
      default-filters:
        - ApplicationError
```

To enable it only on some routes, add this to concerned routes in `gateway/routes.yaml` of datadir :
```
        filters:
        - name: ApplicationError
```

A side effect that can be discussed is that it prints a stack trace in gateway log as implementation throws an exception. Some things can be done differently, like using a more specific exception class, or catch it in a `AbstractErrorWebExceptionHandler` subclass to maybe avoid to print it in log, or do not throw an exception but replace content of response by content of `500.html` template. Suggestions are welcome.

Example of log with printed stacktrace :
```
gateway-1  | 2024-05-16 07:56:41.462 DEBUG 1 --- [or-http-epoll-7] o.s.s.w.s.u.m.OrServerWebExchangeMatcher : Trying to match using PathMatcherServerWebExchangeMatcher{pattern='/auth/login', method=null}
gateway-1  | 2024-05-16 07:56:41.462 DEBUG 1 --- [or-http-epoll-7] athPatternParserServerWebExchangeMatcher : Request 'GET /console/a' doesn't match 'null /auth/login'
gateway-1  | 2024-05-16 07:56:41.462 DEBUG 1 --- [or-http-epoll-7] o.s.s.w.s.u.m.OrServerWebExchangeMatcher : No matches found
gateway-1  | 2024-05-16 07:56:41.463 DEBUG 1 --- [or-http-epoll-7] ebSessionServerSecurityContextRepository : No SecurityContext found in WebSession: 'org.springframework.web.server.session.InMemoryWebSessionStore$InMemoryWebSession@e26b7e1'
gateway-1  | 2024-05-16 07:56:41.479 ERROR 1 --- [or-http-epoll-7] a.w.r.e.AbstractErrorWebExceptionHandler : [a3de8979-61]  500 Server Error for HTTP GET "/console/a"
gateway-1  | 
gateway-1  | java.lang.RuntimeException: SERVICE ERROR
gateway-1  |    at org.georchestra.gateway.filter.headers.ServiceErrorGatewayFilterFactory$ServiceErrorGatewayFilter.lambda$filter$0(ServiceErrorGatewayFilterFactory.java:43) ~[classes/:23.1-SNAPSHOT]
gateway-1  |    Suppressed: reactor.core.publisher.FluxOnAssembly$OnAssemblyException: 
gateway-1  | Error has been observed at the following site(s):
gateway-1  |    *__checkpoint ? org.springframework.security.web.server.authentication.AuthenticationWebFilter [DefaultWebFilterChain]
gateway-1  |    *__checkpoint ? org.springframework.cloud.gateway.filter.WeightCalculatorWebFilter [DefaultWebFilterChain]
gateway-1  |    *__checkpoint ? org.springframework.security.web.server.authorization.AuthorizationWebFilter [DefaultWebFilterChain]
gateway-1  |    *__checkpoint ? org.springframework.security.web.server.authorization.ExceptionTranslationWebFilter [DefaultWebFilterChain]
gateway-1  |    *__checkpoint ? org.springframework.security.web.server.authentication.logout.LogoutWebFilter [DefaultWebFilterChain]
gateway-1  |    *__checkpoint ? org.springframework.security.web.server.savedrequest.ServerRequestCacheWebFilter [DefaultWebFilterChain]
gateway-1  |    *__checkpoint ? org.springframework.security.web.server.context.SecurityContextServerWebExchangeWebFilter [DefaultWebFilterChain]
gateway-1  |    *__checkpoint ? org.springframework.security.oauth2.client.web.server.authentication.OAuth2LoginAuthenticationWebFilter [DefaultWebFilterChain]
gateway-1  |    *__checkpoint ? org.springframework.security.web.server.authentication.AuthenticationWebFilter [DefaultWebFilterChain]
gateway-1  |    *__checkpoint ? org.springframework.security.oauth2.client.web.server.OAuth2AuthorizationRequestRedirectWebFilter [DefaultWebFilterChain]
gateway-1  |    *__checkpoint ? org.springframework.security.web.server.authentication.AuthenticationWebFilter [DefaultWebFilterChain]
gateway-1  |    *__checkpoint ? org.springframework.security.web.server.context.ReactorContextWebFilter [DefaultWebFilterChain]
gateway-1  |    *__checkpoint ? org.springframework.security.web.server.header.HttpHeaderWriterWebFilter [DefaultWebFilterChain]
gateway-1  |    *__checkpoint ? org.springframework.security.config.web.server.ServerHttpSecurity$ServerWebExchangeReactorContextWebFilter [DefaultWebFilterChain]
gateway-1  |    *__checkpoint ? org.springframework.security.web.server.WebFilterChainProxy [DefaultWebFilterChain]
gateway-1  |    *__checkpoint ? org.springframework.boot.actuate.metrics.web.reactive.server.MetricsWebFilter [DefaultWebFilterChain]
gateway-1  |    *__checkpoint ? HTTP GET "/console/a" [ExceptionHandlingWebHandler]
gateway-1  | Original Stack Trace:
gateway-1  |            at org.georchestra.gateway.filter.headers.ServiceErrorGatewayFilterFactory$ServiceErrorGatewayFilter.lambda$filter$0(ServiceErrorGatewayFilterFactory.java:43) ~[classes/:23.1-SNAPSHOT]
gateway-1  |            at reactor.core.publisher.MonoRunnable.call(MonoRunnable.java:73) ~[reactor-core-3.4.29.jar:3.4.29]
                        < stack trace continues about 50 lines >
```