### PR TITLE
Fix truncated response body when catching application errors to display standardized error page

### DIFF
--- a/gateway/src/main/java/org/georchestra/gateway/autoconfigure/app/FiltersAutoConfiguration.java
+++ b/gateway/src/main/java/org/georchestra/gateway/autoconfigure/app/FiltersAutoConfiguration.java
@@ -45,7 +45,8 @@ public class FiltersAutoConfiguration {
      * matched Route's GeorchestraTargetConfig for each HTTP request-response
      * interaction before other filters are applied.
      */
-    @Bean ResolveTargetGlobalFilter resolveTargetWebFilter(GatewayConfigProperties config) {
+    @Bean
+    ResolveTargetGlobalFilter resolveTargetWebFilter(GatewayConfigProperties config) {
         return new ResolveTargetGlobalFilter(config);
     }
 
@@ -66,7 +67,8 @@ public class FiltersAutoConfiguration {
         return new StripBasePathGatewayFilterFactory();
     }
 
-    @Bean ApplicationErrorGatewayFilterFactory applicationErrorGatewayFilterFactory() {
+    @Bean
+    ApplicationErrorGatewayFilterFactory applicationErrorGatewayFilterFactory() {
         return new ApplicationErrorGatewayFilterFactory();
     }
 }

--- a/gateway/src/main/java/org/georchestra/gateway/filter/global/ApplicationErrorGatewayFilterFactory.java
+++ b/gateway/src/main/java/org/georchestra/gateway/filter/global/ApplicationErrorGatewayFilterFactory.java
@@ -18,47 +18,110 @@
  */
 package org.georchestra.gateway.filter.global;
 
+import java.net.URI;
+
 import org.springframework.cloud.gateway.filter.GatewayFilter;
 import org.springframework.cloud.gateway.filter.GatewayFilterChain;
 import org.springframework.cloud.gateway.filter.factory.AbstractGatewayFilterFactory;
 import org.springframework.cloud.gateway.filter.factory.GatewayFilterFactory;
+import org.springframework.cloud.gateway.support.HttpStatusHolder;
+import org.springframework.cloud.gateway.support.ServerWebExchangeUtils;
 import org.springframework.core.Ordered;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.server.reactive.ServerHttpResponse;
+import org.springframework.http.server.reactive.ServerHttpResponseDecorator;
+import org.springframework.lang.Nullable;
 import org.springframework.web.server.ResponseStatusException;
 import org.springframework.web.server.ServerWebExchange;
+
+import lombok.extern.slf4j.Slf4j;
 import reactor.core.publisher.Mono;
 
 /**
+ * Filter to allow custom error pages to be used when an application behind the
+ * gateways returns an error.
+ * <p>
  * {@link GatewayFilterFactory} providing a {@link GatewayFilter} that throws a
  * {@link ResponseStatusException} with the proxied response status code if the
  * target responded with a {@code 400...} or {@code 500...} status code.
  * 
+ * <p>
+ * Usage: to enable it globally, add this to application.yaml :
+ * 
+ * <pre>
+ * <code>
+ * spring:
+ *  cloud:
+ *    gateway:
+ *      default-filters:
+ *        - ApplicationError
+ * </code>
+ * </pre>
+ * 
+ * To enable it only on some routes, add this to concerned routes in
+ * {@literal routes.yaml}:
+ * 
+ * <pre>
+ * <code>
+ *        filters:
+ *       - name: ApplicationError
+ * </code>
+ * </pre>
  */
+@Slf4j
 public class ApplicationErrorGatewayFilterFactory extends AbstractGatewayFilterFactory<Object> {
 
-	public ApplicationErrorGatewayFilterFactory() {
-		super(Object.class);
-	}
+    public ApplicationErrorGatewayFilterFactory() {
+        super(Object.class);
+    }
 
-	@Override
-	public GatewayFilter apply(final Object config) {
-		return new ServiceErrorGatewayFilter();
-	}
+    @Override
+    public GatewayFilter apply(final Object config) {
+        return new ServiceErrorGatewayFilter();
+    }
 
-	private static class ServiceErrorGatewayFilter implements GatewayFilter, Ordered {
+    private static class ServiceErrorGatewayFilter implements GatewayFilter, Ordered {
 
-		public @Override Mono<Void> filter(ServerWebExchange exchange, GatewayFilterChain chain) {
-			return chain.filter(exchange).then(Mono.fromRunnable(() -> {
-				HttpStatus statusCode = exchange.getResponse().getStatusCode();
-				if (statusCode.is4xxClientError() || statusCode.is5xxServerError()) {
-					throw new ResponseStatusException(statusCode);
-				}
-			}));
-		}
+        public @Override Mono<Void> filter(ServerWebExchange exchange, GatewayFilterChain chain) {
 
-		@Override
-		public int getOrder() {
-			return ResolveTargetGlobalFilter.ORDER + 1;
-		}
-	}
+            ApplicationErrorConveyorHttpResponse response;
+            response = new ApplicationErrorConveyorHttpResponse(exchange.getResponse());
+
+            exchange = exchange.mutate().response(response).build();
+            return chain.filter(exchange);
+        }
+
+        @Override
+        public int getOrder() {
+            return ResolveTargetGlobalFilter.ORDER + 1;
+        }
+
+    }
+
+    /**
+     * A response decorator that throws a {@link ResponseStatusException} at
+     * {@link #setStatusCode(HttpStatus)} if the status code is an error code, thus
+     * letting the gateway render the appropriate custom error page instead of the
+     * original application response body.
+     */
+    private static class ApplicationErrorConveyorHttpResponse extends ServerHttpResponseDecorator {
+
+        public ApplicationErrorConveyorHttpResponse(ServerHttpResponse delegate) {
+            super(delegate);
+        }
+
+        @Override
+        public boolean setStatusCode(@Nullable HttpStatus status) {
+            checkStatusCode(status);
+            return super.setStatusCode(status);
+        }
+
+        private void checkStatusCode(HttpStatus statusCode) {
+            log.debug("native status code: {}", statusCode);
+            if (statusCode.is4xxClientError() || statusCode.is5xxServerError()) {
+                log.debug("Conveying {} response status", statusCode);
+                throw new ResponseStatusException(statusCode);
+            }
+        }
+    }
 }

--- a/gateway/src/main/resources/application.yml
+++ b/gateway/src/main/resources/application.yml
@@ -52,6 +52,7 @@ spring:
       - RemoveSecurityHeaders
       # AddSecHeaders appends sec-* headers to proxied requests based on the currently authenticated user
       - AddSecHeaders
+      - ApplicationError
       global-filter:
         websocket-routing:
           enabled: true


### PR DESCRIPTION
Throwing the `ResponseStatusException` too late during the request processing causes the response body to be partially committed and not displaying the customized error page.

Use a `ServerHttpResponseDecorator` that throws the exception as soon as its `setStatusCode()` method is called.