### PR TITLE
Adds preauth external provider header

### DIFF
--- a/docs/pre-authentication.adoc
+++ b/docs/pre-authentication.adoc
@@ -30,6 +30,8 @@ The following headers are expected to be received by the Gateway:
 * `preauth-firstname`: the first name of the user (e.g. "Pierre")
 * `preauth-lastname`: the surname of the user (e.g. "Mauduit")
 * `preauth-org`: the organisation identifier (e.g. "geOrchestra")
+* `preauth-provider`: __(optional)__ the external provider (e.g. "myexternalprovider")
+* `preauth-provider-id`: __(optional)__ the external provider identifier (e.g. "user_123456")
 
 == Charset considerations & encoded headers
 
@@ -152,6 +154,8 @@ The following Apache configuration has been used in a setup to interact with the
         RequestHeader unset preauth-firstname
         RequestHeader unset preauth-lastname
         RequestHeader unset preauth-org
+        RequestHeader unset preauth-provider
+        RequestHeader unset preauth-provider-id
 
         # The following ones are used by geOrchestra
         # You can find a list of headers here:
@@ -177,6 +181,8 @@ The following Apache configuration has been used in a setup to interact with the
         RequestHeader set preauth-firstname %{MELLON_GIVEN_NAME}e "expr=-n env('MELLON_GIVEN_NAME')"
         RequestHeader set preauth-lastname %{MELLON_SN}e "expr=-n env('MELLON_SN')"
         RequestHeader set preauth-org %{MELLON_O}e "expr=-n env('MELLON_O')"
+        RequestHeader set preauth-provider myexternalprovider "expr=-n env('MELLON_O')"
+        RequestHeader set preauth-provider-id %{MELLON_EPPN}e "expr=-n env('MELLON_EPPN')"
         # If needed to base64-encode the headers because of them containing accented characters, you can
         # use the following syntax and adapt the other headers above:
         # RequestHeader set preauth-lastname "expr={base64}%{base64:%{env:MELLON_SN}}"   "expr=-n env('MELLON_SN')"

--- a/gateway/src/main/java/org/georchestra/gateway/security/preauth/PreauthAuthenticationManager.java
+++ b/gateway/src/main/java/org/georchestra/gateway/security/preauth/PreauthAuthenticationManager.java
@@ -113,6 +113,7 @@ public class PreauthAuthenticationManager implements ReactiveAuthenticationManag
         user.setRoles(roleNames);
         user.setOAuth2Provider(provider);
         user.setOAuth2Uid(providerId);
+        //TODO rename oauth2 fields to a more generic name : externalProvider ?
         return user;
     }
 
@@ -124,5 +125,7 @@ public class PreauthAuthenticationManager implements ReactiveAuthenticationManag
         mutableHeaders.remove(PREAUTH_LASTNAME);
         mutableHeaders.remove(PREAUTH_ORG);
         mutableHeaders.remove(PREAUTH_ROLES);
+        mutableHeaders.remove(PREAUTH_PROVIDER);
+        mutableHeaders.remove(PREAUTH_PROVIDER_ID);
     }
 }

--- a/gateway/src/main/java/org/georchestra/gateway/security/preauth/PreauthAuthenticationManager.java
+++ b/gateway/src/main/java/org/georchestra/gateway/security/preauth/PreauthAuthenticationManager.java
@@ -48,6 +48,8 @@ public class PreauthAuthenticationManager implements ReactiveAuthenticationManag
     public static final String PREAUTH_LASTNAME = "preauth-lastname";
     public static final String PREAUTH_ORG = "preauth-org";
     public static final String PREAUTH_ROLES = "preauth-roles";
+    public static final String PREAUTH_PROVIDER = "preauth-provider";
+    public static final String PREAUTH_PROVIDER_ID = "preauth-provider-id";
 
     /**
      * @return {@code Mono.empty()} if the pre-auth request headers are not
@@ -93,6 +95,9 @@ public class PreauthAuthenticationManager implements ReactiveAuthenticationManag
         String lastName = SecurityHeaders.decode(requestHeaders.get(PREAUTH_LASTNAME));
         String org = SecurityHeaders.decode(requestHeaders.get(PREAUTH_ORG));
         String rolesValue = SecurityHeaders.decode(requestHeaders.get(PREAUTH_ROLES));
+        String provider = SecurityHeaders.decode(requestHeaders.get(PREAUTH_PROVIDER));
+        String providerId = SecurityHeaders.decode(requestHeaders.get(PREAUTH_PROVIDER_ID));
+
         List<String> roleNames = Optional.ofNullable(rolesValue)
                 .map(roles -> Stream
                         .concat(Stream.of("ROLE_USER"), Stream.of(roles.split(";")).filter(StringUtils::hasText))
@@ -106,6 +111,8 @@ public class PreauthAuthenticationManager implements ReactiveAuthenticationManag
         user.setLastName(lastName);
         user.setOrganization(org);
         user.setRoles(roleNames);
+        user.setOAuth2Provider(provider);
+        user.setOAuth2Uid(providerId);
         return user;
     }
 

--- a/gateway/src/test/java/org/georchestra/gateway/accounts/admin/CreateAccountUserCustomizerIT.java
+++ b/gateway/src/test/java/org/georchestra/gateway/accounts/admin/CreateAccountUserCustomizerIT.java
@@ -60,7 +60,10 @@ public class CreateAccountUserCustomizerIT {
             "preauth-email", "pierre.martin2@example.org", //
             "preauth-firstname", "Pierre-Jean-Pierre", //
             "preauth-lastname", "Martin", //
-            "preauth-org", "NEWORG");
+            "preauth-org", "NEWORG",
+            "preauth-provider", "georchestra",
+            "preauth-provider-id", "georchestra12"
+            );
 
     private static final Map<String, String> ANOTHER_NOT_EXISTING_ACCOUNT_HEADERS_EXISTING_ORG = Map.of( //
             "sec-georchestra-preauthenticated", "true", //
@@ -113,7 +116,9 @@ public class CreateAccountUserCustomizerIT {
                 .is2xxSuccessful()//
                 .expectBody()//
                 .jsonPath("$.GeorchestraUser").isNotEmpty()//
-                .jsonPath("$.GeorchestraUser.organization").isEqualTo("NEWORG");
+                .jsonPath("$.GeorchestraUser.organization").isEqualTo("NEWORG")
+                .jsonPath("$.GeorchestraUser.oauth2Provider").isEqualTo("georchestra")
+                .jsonPath("$.GeorchestraUser.oauth2Uid").isEqualTo("georchestra12");
 
         // Make sure the account has been created
         assertNotNull(accountDao.findByUID("pmartin2"));


### PR DESCRIPTION
This allows to use headers : 
```
  --header 'preauth-provider: myprov' \
  --header 'preauth-provider-id: myprovid' \
```
in preauth authentication