### PR TITLE
Use a GatewayFilter to redirect to the login page when given a login query parameter

### DIFF
--- a/docs/custom_filters.adoc
+++ b/docs/custom_filters.adoc
@@ -1,0 +1,111 @@
+= geOrchestra Gateway custom filters
+:toc:
+:toc-placement!:
+
+toc::[]
+
+
+== Global filters
+
+https://docs.spring.io/spring-cloud-gateway/reference/spring-cloud-gateway/global-filters.html[Gobal filters]
+are special filters that are conditionally applied to all routes.
+
+The **geOrchestra Gateway** provides the following global filters
+
+=== ResolveTargetGlobalFilter
+
+Resolves the `GeorchestraTargetConfig` for the request's matched `Route` and stores as a `ServerWebExchange` attribute.
+`GeorchestraTargetConfig` contains the target service's security header requirements and the set of role-based access
+rules to different service endpoints.
+
+
+=== ResolveGeorchestraUserGlobalFilter
+
+Resolves the `GeorchestraUser` from the request's `Authentication` so it can be retrieved down the chain during a server
+web exchange filter chain execution.
+
+The resolved per-request `GeorchestraUser` object can then, for example, be used to append the necessary `sec-*` headers that relate
+to user information to proxied http requests.
+
+
+== GatewayFilter Factories
+
+Route filters allow the modification of the incoming HTTP request or outgoing HTTP response in some manner.
+Route filters are scoped to a particular route, or can be applied to all routes when used in the
+`spring.cloud.gateway.default-filters` configuration.
+
+Spring Cloud Gateway comes with a number of
+https://cloud.spring.io/spring-cloud-gateway/multi/multi__gatewayfilter_factories.html[GatewayFilter Factories]
+
+The **geOrchestra Gateway** provides the following gateway filters:
+
+
+=== LoginParamRedirectGatewayFilterFactory
+
+Redirects idempotent requests (`GET`, `HEAD`, `OPTIONS`, `TRACE`) that contains a `login` query
+parameter to the `/login` endpoint, as long as the request is not already authenticated.
+
+That is, for example, a `GET /geonetwork/?login` request will be forced to return a `302` redirect
+HTTP status with a `Location: /login` response header, if the request was not authenticated already,
+and will proceed normally otherwise.
+
+Usage:
+
+As a default filter, to be applied to all routes:
+----
+spring:
+  cloud:
+    gateway:
+      default-filters:
+      - LoginParamRedirect
+----
+
+For a specific route:
+----
+spring:
+  cloud:
+    gateway:
+      routes:
+      - id: geonetwork
+        uri: http://geonetwork:8080
+        predicates:
+        - path: /geonetwork/**
+        filters:
+        - LoginParamRedirect
+----
+
+=== RemoveSecurityHeadersGatewayFilter
+
+Removes any incoming `sec-\*` request header to prevent impersonation. Valid `sec-*` headers ought to be
+computed by the filter chain and appended to proxied requests.
+
+=== AddSecHeadersGatewayFilter
+
+Adds all necessary `sec-*` request  headers to proxied requests. Delegates to the `HeaderContributor` extension
+point to prepare the exact set of headers to append to each request.
+
+Implementations can use the resolved `GeorchestraTargetConfig` and `GeorchestraUser` to compute 
+the target service required header names and values.
+
+[source,mermaid]
+----
+classDiagram
+  direction LR
+  HeaderContributor <|-- GeorchestraUserHeadersContributor
+  HeaderContributor <|-- GeorchestraOrganizationHeadersContributor
+  HeaderContributor <|-- JsonPayloadHeadersContributor
+  HeaderContributor <|-- SecProxyHeaderContributor
+  class HeaderContributor{
+    <<interface>>
+    prepare(ServerWebExchange exchange) Consumer~HttpHeaders~
+  }
+----
+
+
+=== RouteProfileGatewayFilterFactory
+
+TODO: document
+
+=== StripBasePathGatewayFilterFactory
+
+TODO: document

--- a/docs/index.adoc
+++ b/docs/index.adoc
@@ -51,43 +51,7 @@ flowchart TB
     proxy_filter-->proxied
 ----
 
-**RemoveSecurityHeadersGatewayFilter** removes any incoming `sec-\*` request header to
-prevent impersonation. Valid `sec-*` headers ought to be computed by the filter chain
-and appended to proxied requests.
-
-**ResolveTargetGlobalFilter** resolves the `GeorchestraTargetConfig`
-for the request's matched `Route` and stores as a `ServerWebExchange` attribute.
-`GeorchestraTargetConfig` contains the target service's security header requirements
-and the set of role-based access rules to different service endpoints.
-
-**ResolveGeorchestraUserGlobalFilter** resolves the `GeorchestraUser` from the
-request's `Authentication` so it can be retrieved down the chain during a server
-web exchange filter chain execution.
-The resolved per-request `GeorchestraUser` object can then, for
-example, be used to append the necessary `sec-*` headers that relate
-to user information to proxied http requests.
-
-**AddSecHeadersGatewayFilter** adds all necessary `sec-*` request  headers to proxied requests.
-Delegates to the `HeaderContributor` extension point to prepare the exact set of headers to append
-to each request.
-
-Implementations can use the resolved `GeorchestraTargetConfig` and `GeorchestraUser` to compute 
-the target service required header names and values.
-
-[source,mermaid]
-----
-classDiagram
-  direction LR
-  HeaderContributor <|-- GeorchestraUserHeadersContributor
-  HeaderContributor <|-- GeorchestraOrganizationHeadersContributor
-  HeaderContributor <|-- JsonPayloadHeadersContributor
-  HeaderContributor <|-- SecProxyHeaderContributor
-  class HeaderContributor{
-    <<interface>>
-    prepare(ServerWebExchange exchange) Consumer~HttpHeaders~
-  }
-----
-
+Refer to xref:custom-filters.adoc[geOrchestra Gateway custom filters] for more information.
 
 == Data directory property sources
 

--- a/gateway/src/main/java/org/georchestra/gateway/autoconfigure/app/FiltersAutoConfiguration.java
+++ b/gateway/src/main/java/org/georchestra/gateway/autoconfigure/app/FiltersAutoConfiguration.java
@@ -18,9 +18,10 @@
  */
 package org.georchestra.gateway.autoconfigure.app;
 
+import org.georchestra.gateway.filter.global.ApplicationErrorGatewayFilterFactory;
+import org.georchestra.gateway.filter.global.LoginParamRedirectGatewayFilterFactory;
 import org.georchestra.gateway.filter.global.ResolveTargetGlobalFilter;
 import org.georchestra.gateway.filter.headers.HeaderFiltersConfiguration;
-import org.georchestra.gateway.filter.global.ApplicationErrorGatewayFilterFactory;
 import org.georchestra.gateway.model.GatewayConfigProperties;
 import org.georchestra.gateway.model.GeorchestraTargetConfig;
 import org.geoserver.cloud.gateway.filter.RouteProfileGatewayFilterFactory;
@@ -48,6 +49,11 @@ public class FiltersAutoConfiguration {
     @Bean
     ResolveTargetGlobalFilter resolveTargetWebFilter(GatewayConfigProperties config) {
         return new ResolveTargetGlobalFilter(config);
+    }
+
+    @Bean
+    LoginParamRedirectGatewayFilterFactory loginParamRedirectGatewayFilterFactory() {
+        return new LoginParamRedirectGatewayFilterFactory();
     }
 
     /**

--- a/gateway/src/main/java/org/georchestra/gateway/filter/global/LoginParamRedirectGatewayFilterFactory.java
+++ b/gateway/src/main/java/org/georchestra/gateway/filter/global/LoginParamRedirectGatewayFilterFactory.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright (C) 2024 by the geOrchestra PSC
+ *
+ * This file is part of geOrchestra.
+ *
+ * geOrchestra is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * geOrchestra is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * geOrchestra.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.georchestra.gateway.filter.global;
+
+import static org.springframework.http.HttpMethod.GET;
+import static org.springframework.http.HttpMethod.HEAD;
+import static org.springframework.http.HttpMethod.OPTIONS;
+import static org.springframework.http.HttpMethod.TRACE;
+
+import java.util.List;
+import java.util.Set;
+
+import org.springframework.cloud.gateway.filter.GatewayFilter;
+import org.springframework.cloud.gateway.filter.GatewayFilterChain;
+import org.springframework.cloud.gateway.filter.factory.AbstractGatewayFilterFactory;
+import org.springframework.cloud.gateway.filter.factory.GatewayFilterFactory;
+import org.springframework.cloud.gateway.filter.factory.RedirectToGatewayFilterFactory;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.ReactiveSecurityContextHolder;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.web.server.ServerWebExchange;
+
+import com.google.common.annotations.VisibleForTesting;
+
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import reactor.core.publisher.Mono;
+
+/**
+ * {@link GatewayFilterFactory} that redirects to {@literal /login} if the
+ * request's query string contains a {@literal login} parameter and the request
+ * is not already authenticated.
+ * <p>
+ * Sample usage:
+ * 
+ * <pre>
+ * <code>
+ * spring:
+ *   cloud:
+ *    gateway:
+ *      routes:
+ *      - id: routeid
+ *        uri: ...
+ *        filters:
+ *        - LoginParamRedirect
+ * </code>
+ * </pre>
+ * 
+ */
+@Slf4j
+public class LoginParamRedirectGatewayFilterFactory extends AbstractGatewayFilterFactory<Object> {
+
+    private static final Set<HttpMethod> redirectMethods = Set.of(GET, HEAD, OPTIONS, TRACE);
+
+    @Override
+    public LoginParamRedirectGatewayFilter apply(Object config) {
+        RedirectToGatewayFilterFactory.Config redirectConfig = new RedirectToGatewayFilterFactory.Config();
+        redirectConfig.setStatus("302");
+        redirectConfig.setUrl("/login");
+        GatewayFilter delegate = new RedirectToGatewayFilterFactory().apply(redirectConfig);
+        return new LoginParamRedirectGatewayFilter(delegate);
+    }
+
+    @RequiredArgsConstructor
+    public static class LoginParamRedirectGatewayFilter implements GatewayFilter {
+
+        private static final Authentication UNAUTHENTICATED = new AnonymousAuthenticationToken("nobody", "nobody",
+                List.of(new SimpleGrantedAuthority("ROLE_ANONYMOUS")));
+
+        private final @NonNull GatewayFilter delegate;
+
+        @Override
+        public Mono<Void> filter(ServerWebExchange exchange, GatewayFilterChain chain) {
+            HttpMethod method = exchange.getRequest().getMethod();
+            if (redirectMethods.contains(method) && containsLoginQueryParam(exchange)) {
+                log.info("Applying ?login query param redirect filter for {} {}", method,
+                        exchange.getRequest().getURI());
+                return redirectToLoginIfNotAuthenticated(exchange, chain);
+            }
+            return chain.filter(exchange);
+        }
+
+        private Mono<Void> redirectToLoginIfNotAuthenticated(ServerWebExchange exchange, GatewayFilterChain chain) {
+
+            return getAuthentication()//
+                    .filter(Authentication::isAuthenticated)//
+                    .switchIfEmpty(Mono.just(UNAUTHENTICATED))//
+                    .flatMap(authentication -> {
+                        // delegate to the redirect filter otherwise
+                        if (authentication instanceof AnonymousAuthenticationToken) {
+                            log.info("redirecting to /login: {}", exchange.getRequest().getURI());
+                            return delegate.filter(exchange, chain);
+                        }
+                        // proceed if already authenticated
+                        log.info("already authenticated ({}), proceeding without redirection to /login",
+                                authentication.getName());
+                        return chain.filter(exchange);
+                    });
+        }
+
+        @VisibleForTesting
+        public Mono<Authentication> getAuthentication() {
+            return ReactiveSecurityContextHolder.getContext().map(SecurityContext::getAuthentication);
+        }
+
+        private boolean containsLoginQueryParam(ServerWebExchange exchange) {
+            ServerHttpRequest request = exchange.getRequest();
+            return request.getQueryParams().containsKey("login");
+        }
+
+    }
+}

--- a/gateway/src/main/java/org/georchestra/gateway/security/accessrules/AccessRulesCustomizer.java
+++ b/gateway/src/main/java/org/georchestra/gateway/security/accessrules/AccessRulesCustomizer.java
@@ -30,15 +30,12 @@ import org.georchestra.gateway.security.ServerHttpSecurityCustomizer;
 import org.springframework.security.config.web.server.ServerHttpSecurity;
 import org.springframework.security.config.web.server.ServerHttpSecurity.AuthorizeExchangeSpec;
 import org.springframework.security.config.web.server.ServerHttpSecurity.AuthorizeExchangeSpec.Access;
-import org.springframework.security.web.server.util.matcher.ServerWebExchangeMatcher;
-import org.springframework.web.server.ServerWebExchange;
 
 import com.google.common.annotations.VisibleForTesting;
 
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import reactor.core.publisher.Mono;
 
 /**
  * {@link ServerHttpSecurityCustomizer} to apply {@link RoleBasedAccessRule ROLE
@@ -68,15 +65,6 @@ public class AccessRulesCustomizer implements ServerHttpSecurityCustomizer {
 
         // apply service-specific rules before global rules, order matters, and
         // otherwise global path matches would be applied before service ones.
-
-        log.info("Applying ?login query param rule...");
-        authorizeExchange.matchers(new ServerWebExchangeMatcher() {
-            @Override
-            public Mono<MatchResult> matches(ServerWebExchange exchange) {
-                var hasParam = exchange.getRequest().getQueryParams().containsKey("login");
-                return hasParam ? MatchResult.match() : MatchResult.notMatch();
-            }
-        }).authenticated();
 
         config.getServices().forEach((name, service) -> {
             log.info("Applying access rules for backend service '{}' at {}", name, service.getTarget());

--- a/gateway/src/main/resources/application.yml
+++ b/gateway/src/main/resources/application.yml
@@ -55,6 +55,7 @@ spring:
       - AddSecHeaders
       - PreserveHostHeader
       - ApplicationError
+      - LoginParamRedirect
       global-filter:
         websocket-routing:
           enabled: true

--- a/gateway/src/test/java/org/georchestra/gateway/autoconfigure/app/FiltersAutoConfigurationTest.java
+++ b/gateway/src/test/java/org/georchestra/gateway/autoconfigure/app/FiltersAutoConfigurationTest.java
@@ -21,6 +21,7 @@ package org.georchestra.gateway.autoconfigure.app;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import org.georchestra.gateway.filter.global.LoginParamRedirectGatewayFilterFactory;
 import org.georchestra.gateway.filter.global.ResolveTargetGlobalFilter;
 import org.georchestra.gateway.filter.headers.AddSecHeadersGatewayFilterFactory;
 import org.georchestra.gateway.filter.headers.RemoveHeadersGatewayFilterFactory;
@@ -44,7 +45,6 @@ class FiltersAutoConfigurationTest {
     @Test
     void testContext() {
         runner.run(context -> {
-
             assertThat(context).hasSingleBean(GatewayConfigProperties.class);
             assertThat(context).hasSingleBean(ResolveTargetGlobalFilter.class);
             assertThat(context).hasSingleBean(AddSecHeadersGatewayFilterFactory.class);
@@ -53,6 +53,7 @@ class FiltersAutoConfigurationTest {
             assertThat(context).hasSingleBean(GeorchestraOrganizationHeadersContributor.class);
             assertThat(context).hasSingleBean(RemoveHeadersGatewayFilterFactory.class);
             assertThat(context).hasSingleBean(RemoveSecurityHeadersGatewayFilterFactory.class);
+            assertThat(context).hasSingleBean(LoginParamRedirectGatewayFilterFactory.class);
         });
     }
 

--- a/gateway/src/test/java/org/georchestra/gateway/filter/global/LoginParamRedirectGatewayFilterFactoryTest.java
+++ b/gateway/src/test/java/org/georchestra/gateway/filter/global/LoginParamRedirectGatewayFilterFactoryTest.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (C) 2024 by the geOrchestra PSC
+ *
+ * This file is part of geOrchestra.
+ *
+ * geOrchestra is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * geOrchestra is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * geOrchestra.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.georchestra.gateway.filter.global;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import org.georchestra.gateway.autoconfigure.app.FiltersAutoConfiguration;
+import org.georchestra.gateway.filter.global.LoginParamRedirectGatewayFilterFactory.LoginParamRedirectGatewayFilter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.cloud.gateway.filter.GatewayFilterChain;
+import org.springframework.http.HttpStatus;
+import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
+import org.springframework.mock.web.server.MockServerWebExchange;
+import org.springframework.security.authentication.TestingAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.server.ServerWebExchange;
+
+import reactor.core.publisher.Mono;
+
+/**
+ * Verify the {@link LoginParamRedirectGatewayFilterFactory} redirects to
+ * {@code /login} when a {@code ?login} query parameter is present in a request
+ * that's not already authenticated
+ */
+class LoginParamRedirectGatewayFilterFactoryTest {
+
+    LoginParamRedirectGatewayFilter filter;
+    ServerWebExchange exchange;
+    MockServerHttpRequest request;
+    GatewayFilterChain chain;
+
+    @BeforeEach
+    void before() {
+        filter = new LoginParamRedirectGatewayFilterFactory().apply(/* unused, filter has config class */ new Object());
+        request = MockServerHttpRequest.get("/test/?login").build();
+
+        exchange = MockServerWebExchange.from(request);
+        exchange.getResponse().setStatusCode(HttpStatus.I_AM_A_TEAPOT);
+
+        chain = mock(GatewayFilterChain.class);
+        when(chain.filter(any())).thenReturn(Mono.empty());
+    }
+
+    @Test
+    @DisplayName("when no login query param is given, then continue with the filter chain")
+    void ifNoLoginParamThenPassThruChain() {
+        // no ?login query param
+        request = MockServerHttpRequest.get("/test").build();
+        exchange = MockServerWebExchange.from(request);
+        exchange.getResponse().setStatusCode(HttpStatus.I_AM_A_TEAPOT);
+
+        filter.filter(exchange, chain).block();
+        verify(chain, times(1)).filter(exchange);
+
+        assertThat(exchange.getResponse().getStatusCode()).isEqualTo(HttpStatus.I_AM_A_TEAPOT);
+    }
+
+    @Test
+    @DisplayName("given the request is already authenticated, then the login parameter is ignored")
+    void ifLoginParamAndAlreadyAuthorizedThenPassThruChain() {
+        login();
+        filter.filter(exchange, chain).block();
+        verify(chain, times(1)).filter(exchange);
+        assertThat(exchange.getResponse().getStatusCode())
+                .as("Expected I_AM_A_TEAPOT since the reques is already authrized").isEqualTo(HttpStatus.I_AM_A_TEAPOT);
+    }
+
+    @Test
+    @DisplayName("given the request is not authenticated and has a login parameter, then the response is redirected to /login")
+    void ifLoginParamAndNotAlreadyAuthorizedThenRedirect() {
+        filter.filter(exchange, chain).block();
+        verify(chain, never()).filter(exchange);
+
+        assertThat(exchange.getResponse().getStatusCode())
+                .as("Expected 302 Found since the request has ?login and is not pre-authrized")
+                .isEqualTo(HttpStatus.FOUND);
+        assertThat(exchange.getResponse().getHeaders()).containsEntry("Location", List.of("/login"));
+    }
+
+    private void login() {
+        Authentication auth = new TestingAuthenticationToken("testuser", null, "ROLE_USER");
+        filter = spy(filter);
+        when(filter.getAuthentication()).thenReturn(Mono.just(auth));
+    }
+
+}

--- a/gateway/src/test/java/org/georchestra/gateway/security/accessrules/AccessRulesCustomizerIT.java
+++ b/gateway/src/test/java/org/georchestra/gateway/security/accessrules/AccessRulesCustomizerIT.java
@@ -19,10 +19,14 @@
 
 package org.georchestra.gateway.security.accessrules;
 
-import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
-import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
-import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
-import lombok.extern.slf4j.Slf4j;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.noContent;
+import static com.github.tomakehurst.wiremock.client.WireMock.ok;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching;
+
+import java.net.URI;
+
 import org.georchestra.gateway.app.GeorchestraGatewayApplication;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -36,9 +40,11 @@ import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.test.web.reactive.server.WebTestClient;
 
-import java.net.URI;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
 
-import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * Integration tests for {@link AccessRulesCustomizer} for the access rules in
@@ -271,36 +277,6 @@ class AccessRulesCustomizerIT {
                 .expectStatus().isOk();
 
         testClient.get().uri("/mapstore/any/thing")//
-                .header("Host", "localhost")//
-                .exchange()//
-                .expectStatus().isOk();
-    }
-
-    @Test
-    void testQueryParamAuthentication_forbidden_when_anonymous() {
-        mockService.stubFor(get(urlMatching("/header(.*)?")).willReturn(ok()));
-
-        testClient.get().uri("/header?login")//
-                .exchange()//
-                .expectStatus().is3xxRedirection();
-
-        testClient.get().uri("/header")//
-                .header("Host", "localhost")//
-                .exchange()//
-                .expectStatus().isOk();
-    }
-
-    @Test
-    @WithMockUser(authorities = { "ROLE_USER" })
-    void testQueryParamAuthentication_authorized_if_logged_in() {
-        mockService.stubFor(get(urlMatching("/header(.*)?")).willReturn(ok()));
-
-        testClient.get().uri("/header?login")//
-                .header("Host", "localhost")//
-                .exchange()//
-                .expectStatus().isOk();
-
-        testClient.get().uri("/header")//
                 .header("Host", "localhost")//
                 .exchange()//
                 .expectStatus().isOk();

--- a/gateway/src/test/java/org/georchestra/gateway/security/accessrules/AccessRulesCustomizerTest.java
+++ b/gateway/src/test/java/org/georchestra/gateway/security/accessrules/AccessRulesCustomizerTest.java
@@ -203,16 +203,6 @@ class AccessRulesCustomizerTest {
         verify(customizer, never()).permitAll(any());
     }
 
-    @Test
-    void testApplyRule_AppliesQueryParamAuthenticationRule() {
-        AuthorizeExchangeSpec spec = http.authorizeExchange();
-        RoleBasedAccessRule rule = rule("/test?login");
-        customizer = spy(customizer);
-        customizer.apply(spec, rule);
-
-        verify(customizer, times(1)).requireAuthenticatedUser(any());
-    }
-
     private RoleBasedAccessRule rule(String... interceptUrls) {
         RoleBasedAccessRule rule = new RoleBasedAccessRule();
         rule.setInterceptUrl(List.of(interceptUrls));


### PR DESCRIPTION
The geOrchestra Gateway has a requirement to redirect to /login when a request has a `login` query parameter (e.g. `/geonetwork/?login` -> `/login`), that comes from the old security proxy.

So far it was implemented in `AccessRulesCustomizer` by requiring such requests to be authenticated, and delegating to spring security to perform the redirection.

When the request is not authenticated already, and the request headers do not contain `Accept: text/html`, spring security would challenge with a basic auth popup instead.

This patch introduces a `LoginParamRedirectGatewayFilter`, set up as one of the default filters in `application.yml`, that performs a redirect in either case, delegating to a
`org.springframework.cloud.gateway.filter.factory.RedirectToGatewayFilterFactory`.

Check out `docs/custom_filters.adoc` for configuration information.

---

Note for the docker composition, the following datadir PR is required:
https://github.com/georchestra/datadir/pull/415
The rationale is in the PR description

---

Fixes #132