### PR TITLE
Enable accessLogs by default and remove debug headers ones

### DIFF
--- a/gateway/src/main/resources/application.yml
+++ b/gateway/src/main/resources/application.yml
@@ -156,9 +156,9 @@ logging:
     '[org.springframework.cloud.gateway]': info
     '[org.springframework.security]': info
     '[org.springframework.security.oauth2]': debug
-    '[reactor.netty.http ]': debug
+    '[reactor.netty.http]': info
     '[org.georchestra.gateway]': info
-    '[org.georchestra.gateway.filter.headers]': debug
+    '[org.georchestra.gateway.filter.headers]': info
     '[org.georchestra.gateway.config.security]': debug
     '[org.georchestra.gateway.config.security.accessrules]': debug
     '[org.georchestra.gateway.security.ldap]': debug


### PR DESCRIPTION
A whitespace was blocking the logs and remove the `org.georchestra.gateway.filter.headers   :Appending header sec-username: jdoe` and friends headers

Access log must be activated with java system properties `-Dreactor.netty.http.server.accessLogEnabled=true` as explained[ here](https://docs.spring.io/spring-cloud-gateway/reference/spring-cloud-gateway/reactor-netty-access-logs.html)
