### PR TITLE
Set default georchestra datadir location

### DIFF
--- a/gateway/src/main/resources/application.yml
+++ b/gateway/src/main/resources/application.yml
@@ -67,6 +67,7 @@ spring:
       #routes: ought to be loaded from gateway.yaml, preferrably from georchestra's datadir
 
 georchestra:
+  datadir: /etc/georchestra
   gateway:
     security:
       create-non-existing-users-in-l-d-a-p: false


### PR DESCRIPTION
The purpose of this PR is to set the default geOrchestra datadir location. In order to avoid having to specify it in all our deployments.

`/etc/georchestra` is a standard directory used in Docker and even in Debian package for geOrchestra.

It is already included inside many of our Dockerfile: https://github.com/search?q=repo%3Ageorchestra%2Fgeorchestra%20%2Fetc%2Fgeorchestra&type=code and even sometimes in the application.yml itself: https://github.com/georchestra/georchestra/blob/5f9743f0a773eaf5f276ca459c80423e16cad364/datafeeder/src/main/resources/application.yml#L108

I'm proposing this PR because as of right now we can't customize the Dockerfile so we can't set a default geOrchestra datadir location through this file.

@pmauduit told me that you can still change the parameter even though it is compiled from the source code: https://docs.spring.io/spring-boot/reference/features/external-config.html. Using a method like `JAVA_TOOL_OPTIONS: "-Dgeorchestra.datadir=/etc/georchestra"`. So nobody is stuck with this static directory.