### PR TITLE
Customize error pages

### DIFF
--- a/gateway/src/main/java/org/georchestra/gateway/app/GeorchestraGatewayApplication.java
+++ b/gateway/src/main/java/org/georchestra/gateway/app/GeorchestraGatewayApplication.java
@@ -151,6 +151,15 @@ public class GeorchestraGatewayApplication {
         return "login";
     }
 
+    @GetMapping(path = "/config", produces = "application/json")
+    @ResponseBody
+    public Mono<Map<String, Object>> config(ServerWebExchange exchange) {
+        Map<String, Object> ret = new LinkedHashMap<>();
+        ret.put("stylesheet", georchestraStylesheet);
+        ret.put("logo", logoUrl);
+        return Mono.just(ret);
+    }
+
     @EventListener(ApplicationReadyEvent.class)
     public void onApplicationReady(ApplicationReadyEvent e) {
         Environment env = e.getApplicationContext().getEnvironment();

--- a/gateway/src/main/java/org/georchestra/gateway/app/GeorchestraGatewayApplication.java
+++ b/gateway/src/main/java/org/georchestra/gateway/app/GeorchestraGatewayApplication.java
@@ -151,9 +151,9 @@ public class GeorchestraGatewayApplication {
         return "login";
     }
 
-    @GetMapping(path = "/config", produces = "application/json")
+    @GetMapping(path = "/style-config", produces = "application/json")
     @ResponseBody
-    public Mono<Map<String, Object>> config(ServerWebExchange exchange) {
+    public Mono<Map<String, Object>> styleConfig() {
         Map<String, Object> ret = new LinkedHashMap<>();
         ret.put("stylesheet", georchestraStylesheet);
         ret.put("logo", logoUrl);

--- a/gateway/src/main/resources/static/login/error.css
+++ b/gateway/src/main/resources/static/login/error.css
@@ -1,0 +1,57 @@
+:root {
+    --georchestra: #85127e;
+    --google: #4285F4;
+}
+html, body{
+    padding: 0;
+    margin: 0;
+    font-family: Inter, sans-serif, Georgia, Cambria, "Times New Roman", Times, serif;
+    color: #333;
+}
+body {
+    width: 100vw;
+    height: 100vh;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+}
+p {
+    margin-top: 0;
+}
+.error-desc {
+    font-weight: bold;
+    font-size: 1.25rem;
+}
+.error-back {
+    display: block;
+    text-decoration: none;
+    color: white;
+    font-weight: bold;
+    background: var(--georchestra);
+    padding: 8px 8px;
+    margin-top: 20px;
+    border-radius: 5px;
+}
+.error-back:hover {
+    background: color-mix(in srgb,var(--georchestra),#000 25%);
+}
+#error-img {
+    max-height: 200px;
+    max-width: 50vw;
+}
+.error-code{
+    font-size: 15rem;
+    font-weight: bold;
+    background-image: linear-gradient(180deg, color-mix(in srgb,var(--georchestra),#fff 40%), color-mix(in srgb,var(--georchestra),#fff 95%));
+    background-size: 100%;
+    -webkit-background-clip: text;
+    -moz-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    -moz-text-fill-color: transparent;
+}
+.error-hint {
+    font-size: 1rem;
+    font-weight: 500;
+    color: var(--georchestra);
+}

--- a/gateway/src/main/resources/static/login/getConfig.js
+++ b/gateway/src/main/resources/static/login/getConfig.js
@@ -1,4 +1,4 @@
-fetch("/config").then(res => {
+fetch("/style-config").then(res => {
     if (res.ok) {
         return res.json();
     }

--- a/gateway/src/main/resources/static/login/getConfig.js
+++ b/gateway/src/main/resources/static/login/getConfig.js
@@ -1,0 +1,13 @@
+fetch("/config").then(res => {
+    if (res.ok) {
+        return res.json();
+    }
+    throw new Error("Gateway down")
+}).then(json => {
+    if (json.stylesheet){
+        var styleSheet = document.createElement("style")
+        styleSheet.textContent = json.stylesheet
+        document.head.appendChild(styleSheet)
+    }
+
+})

--- a/gateway/src/main/resources/templates/error/403.html
+++ b/gateway/src/main/resources/templates/error/403.html
@@ -7,6 +7,7 @@
     <meta name="googlebot" content="noarchive"/>
     <title>Access forbidden</title>
     <link href="login/error.css" rel="stylesheet"/>
+    <script src="login/getConfig.js"></script>
 </head>
 <body lang="EN">
 <div id="wrapper">
@@ -17,20 +18,5 @@
     <a href="/" class="error-back">Return to the homepage</a>
 </div>
 </body>
-<script>
-    fetch("/config").then(res => {
-        if (res.ok) {
-            return res.json();
-        }
-        throw new Error("Gateway down")
-    }).then(json => {
-        if (json.stylesheet){
-            var styleSheet = document.createElement("style")
-            styleSheet.textContent = json.stylesheet
-            document.head.appendChild(styleSheet)
-        }
-
-    })
-</script>
 </html>
 

--- a/gateway/src/main/resources/templates/error/403.html
+++ b/gateway/src/main/resources/templates/error/403.html
@@ -1,39 +1,36 @@
 <html>
-  <head>
-    <meta http-equiv="content-type" content="text/html; charset=utf-8" />
-    <meta http-equiv="cache-control" content="no-cache" />
-    <meta http-equiv="pragma" content="no-cache" />
-    <meta name="robots" content="none" />
-    <meta name="googlebot" content="noarchive" />
+<head>
+    <meta http-equiv="content-type" content="text/html; charset=utf-8"/>
+    <meta http-equiv="cache-control" content="no-cache"/>
+    <meta http-equiv="pragma" content="no-cache"/>
+    <meta name="robots" content="none"/>
+    <meta name="googlebot" content="noarchive"/>
     <title>Access forbidden</title>
-    <style type="text/css">
-      body {
-        background-color:#e6e6e6;
-        font-family:Calibri;
-        text-align:center;
-      }
-      #wrapper {
-        background:#fff;
-        width:492px;
-        position:relative;
-        margin-left:auto;
-        margin-right:auto;
-        text-align:left;
-        border:3px solid #999;
-        overflow:hidden;
-	padding: 30px;
-        border-bottom-right-radius: 16px;
-        border-bottom-left-radius: 16px;
-      }
-      #wrapper p {
-        padding:5px;
-      }
-    </style>
-  </head>
-  <body lang=EN>
-    <div id="wrapper">
-      <img src="https://www.georchestra.org/public/logos/georchestra_logo.png" alt="geOrchestra" />
-      <p>Sorry, access to this page is forbidden. Return to the <a href="/">homepage</a>.</p>
-    </div>
-  </body>
+    <link href="login/error.css" rel="stylesheet"/>
+</head>
+<body lang="EN">
+<div id="wrapper">
+    <div class="error-code">403</div>
+    <img src="" alt="" style="display: none" id="error-img">
+    <p class="error-desc">Forbidden</p>
+    <p>Sorry, access to this page is forbidden.</p>
+    <a href="/" class="error-back">Return to the homepage</a>
+</div>
+</body>
+<script>
+    fetch("/config").then(res => {
+        if (res.ok) {
+            return res.json();
+        }
+        throw new Error("Gateway down")
+    }).then(json => {
+        if (json.stylesheet){
+            var styleSheet = document.createElement("style")
+            styleSheet.textContent = json.stylesheet
+            document.head.appendChild(styleSheet)
+        }
+
+    })
+</script>
 </html>
+

--- a/gateway/src/main/resources/templates/error/404.html
+++ b/gateway/src/main/resources/templates/error/404.html
@@ -6,34 +6,30 @@
     <meta name="robots" content="none" />
     <meta name="googlebot" content="noarchive" />
     <title>Page not found</title>
-    <style type="text/css">
-      body {
-        background-color:#e6e6e6;
-        font-family:Calibri;
-        text-align:center;
-      }
-      #wrapper {
-        background:#fff;
-        width:492px;
-        position:relative;
-        margin-left:auto;
-        margin-right:auto;
-        text-align:left;
-        border:3px solid #999;
-        overflow:hidden;
-	padding: 30px;
-        border-bottom-right-radius: 16px;
-        border-bottom-left-radius: 16px;
-      }
-      #wrapper p {
-        padding:5px;
-      }
-    </style>
+    <link href="login/error.css" rel="stylesheet"/>
   </head>
   <body lang=EN>
     <div id="wrapper">
-      <img src="https://www.georchestra.org/public/logos/georchestra_logo.png" alt="geOrchestra" />
-      <p>Page not found. Return to the <a href="/">homepage</a>.</p>
+      <div class="error-code">404</div>
+      <img src="" alt="" style="display: none" id="error-img">
+      <p class="error-desc">Page not found</p>
+      <p>Sorry the page you requested doesn't exist.</p>
+      <a href="/" class="error-back">Return to the homepage</a>
     </div>
   </body>
+  <script>
+    fetch("/config").then(res => {
+      if (res.ok) {
+        return res.json();
+      }
+      throw new Error("Gateway down")
+    }).then(json => {
+      if (json.stylesheet){
+        var styleSheet = document.createElement("link")
+        styleSheet.href = json.stylesheet
+        styleSheet.rel = "stylesheet"
+        document.head.appendChild(styleSheet)
+      }
+    })
+  </script>
 </html>

--- a/gateway/src/main/resources/templates/error/404.html
+++ b/gateway/src/main/resources/templates/error/404.html
@@ -7,6 +7,7 @@
     <meta name="googlebot" content="noarchive" />
     <title>Page not found</title>
     <link href="login/error.css" rel="stylesheet"/>
+    <script src="login/getConfig.js"></script>
   </head>
   <body lang=EN>
     <div id="wrapper">
@@ -17,19 +18,4 @@
       <a href="/" class="error-back">Return to the homepage</a>
     </div>
   </body>
-  <script>
-    fetch("/config").then(res => {
-      if (res.ok) {
-        return res.json();
-      }
-      throw new Error("Gateway down")
-    }).then(json => {
-      if (json.stylesheet){
-        var styleSheet = document.createElement("link")
-        styleSheet.href = json.stylesheet
-        styleSheet.rel = "stylesheet"
-        document.head.appendChild(styleSheet)
-      }
-    })
-  </script>
 </html>

--- a/gateway/src/main/resources/templates/error/500.html
+++ b/gateway/src/main/resources/templates/error/500.html
@@ -5,42 +5,34 @@
     <meta http-equiv="pragma" content="no-cache" />
     <meta name="robots" content="none" />
     <meta name="googlebot" content="noarchive" />
+    <meta http-equiv="refresh" content="5">
     <title>Site in maintenance</title>
-    <style type="text/css">
-      body {
-        background-color:#e6e6e6;
-        font-family:Calibri;
-        text-align:center;
-      }
-      #wrapper {
-        background:#fff;
-        width:492px;
-        position:relative;
-        margin-left:auto;
-        margin-right:auto;
-        text-align:left;
-        border:3px solid #999;
-        overflow:hidden;
-	padding: 30px;
-        border-bottom-right-radius: 16px;
-        border-bottom-left-radius: 16px;
-      }
-      #wrapper p {
-        padding:5px;
-      }
-    </style>
+    <link href="login/error.css" rel="stylesheet"/>
   </head>
-  <body lang=FR>
-    <div id="wrapper">
-      <img src="https://www.georchestra.org/public/logos/georchestra_logo.png" alt="geOrchestra" />
-      <p>
-        Due to maintenance, this service is temporarily unavailable.
-      </p>
-      <p>We're sorry for the inconvenience !</p>
-      <p>Hint: do not close the tab - the requested page will show up in a few seconds.</p>
-    </div>
+  <body lang=EN>
+  <div id="wrapper">
+    <div class="error-code">500</div>
+    <p class="error-desc">Site in maintenance</p>
+    <p>
+      Due to maintenance, this service is temporarily unavailable.
+    </p>
+    <p>We're sorry for the inconvenience !</p>
+    <p class="error-hint">Hint: do not close the tab - the requested page will show up in a few seconds.</p>
+  </div>
   </body>
   <script>
-    window.setTimeout(function() {window.location.href = window.location.href}, 5000);
+    fetch("/config").then(res => {
+      if (res.ok) {
+        return res.json();
+      }
+      throw new Error("Gateway down")
+    }).then(json => {
+      if (json.stylesheet){
+        var styleSheet = document.createElement("link")
+        styleSheet.href = json.stylesheet
+        styleSheet.rel = "stylesheet"
+        document.head.appendChild(styleSheet)
+      }
+    })
   </script>
 </html>

--- a/gateway/src/main/resources/templates/error/500.html
+++ b/gateway/src/main/resources/templates/error/500.html
@@ -1,38 +1,24 @@
 <html>
-  <head>
-    <meta http-equiv="content-type" content="text/html; charset=utf-8" />
-    <meta http-equiv="cache-control" content="no-cache" />
-    <meta http-equiv="pragma" content="no-cache" />
-    <meta name="robots" content="none" />
-    <meta name="googlebot" content="noarchive" />
+<head>
+    <meta http-equiv="content-type" content="text/html; charset=utf-8"/>
+    <meta http-equiv="cache-control" content="no-cache"/>
+    <meta http-equiv="pragma" content="no-cache"/>
+    <meta name="robots" content="none"/>
+    <meta name="googlebot" content="noarchive"/>
     <meta http-equiv="refresh" content="5">
     <title>Site in maintenance</title>
     <link href="login/error.css" rel="stylesheet"/>
-  </head>
-  <body lang=EN>
-  <div id="wrapper">
+    <script src="login/getConfig.js"></script>
+</head>
+<body lang=EN>
+<div id="wrapper">
     <div class="error-code">500</div>
     <p class="error-desc">Site in maintenance</p>
     <p>
-      Due to maintenance, this service is temporarily unavailable.
+        Due to maintenance, this service is temporarily unavailable.
     </p>
     <p>We're sorry for the inconvenience !</p>
     <p class="error-hint">Hint: do not close the tab - the requested page will show up in a few seconds.</p>
-  </div>
-  </body>
-  <script>
-    fetch("/config").then(res => {
-      if (res.ok) {
-        return res.json();
-      }
-      throw new Error("Gateway down")
-    }).then(json => {
-      if (json.stylesheet){
-        var styleSheet = document.createElement("link")
-        styleSheet.href = json.stylesheet
-        styleSheet.rel = "stylesheet"
-        document.head.appendChild(styleSheet)
-      }
-    })
-  </script>
+</div>
+</body>
 </html>

--- a/gateway/src/main/resources/templates/error/501.html
+++ b/gateway/src/main/resources/templates/error/501.html
@@ -1,38 +1,24 @@
 <html>
 <head>
-  <meta http-equiv="content-type" content="text/html; charset=utf-8" />
-  <meta http-equiv="cache-control" content="no-cache" />
-  <meta http-equiv="pragma" content="no-cache" />
-  <meta name="robots" content="none" />
-  <meta name="googlebot" content="noarchive" />
-  <meta http-equiv="refresh" content="5">
-  <title>Site in maintenance</title>
-  <link href="login/error.css" rel="stylesheet"/>
+    <meta http-equiv="content-type" content="text/html; charset=utf-8"/>
+    <meta http-equiv="cache-control" content="no-cache"/>
+    <meta http-equiv="pragma" content="no-cache"/>
+    <meta name="robots" content="none"/>
+    <meta name="googlebot" content="noarchive"/>
+    <meta http-equiv="refresh" content="5">
+    <title>Site in maintenance</title>
+    <link href="login/error.css" rel="stylesheet"/>
+    <script src="login/getConfig.js"></script>
 </head>
 <body lang=EN>
 <div id="wrapper">
-  <div class="error-code">500</div>
-  <p class="error-desc">Site in maintenance</p>
-  <p>
-    Due to maintenance, this service is temporarily unavailable.
-  </p>
-  <p>We're sorry for the inconvenience !</p>
-  <p class="error-hint">Hint: do not close the tab - the requested page will show up in a few seconds.</p>
+    <div class="error-code">500</div>
+    <p class="error-desc">Site in maintenance</p>
+    <p>
+        Due to maintenance, this service is temporarily unavailable.
+    </p>
+    <p>We're sorry for the inconvenience !</p>
+    <p class="error-hint">Hint: do not close the tab - the requested page will show up in a few seconds.</p>
 </div>
 </body>
-<script>
-  fetch("/config").then(res => {
-    if (res.ok) {
-      return res.json();
-    }
-    throw new Error("Gateway down")
-  }).then(json => {
-    if (json.stylesheet){
-      var styleSheet = document.createElement("link")
-      styleSheet.href = json.stylesheet
-      styleSheet.rel = "stylesheet"
-      document.head.appendChild(styleSheet)
-    }
-  })
-</script>
 </html>

--- a/gateway/src/main/resources/templates/error/501.html
+++ b/gateway/src/main/resources/templates/error/501.html
@@ -1,46 +1,38 @@
 <html>
-  <head>
-    <meta http-equiv="content-type" content="text/html; charset=utf-8" />
-    <meta http-equiv="cache-control" content="no-cache" />
-    <meta http-equiv="pragma" content="no-cache" />
-    <meta name="robots" content="none" />
-    <meta name="googlebot" content="noarchive" />
-    <title>Site in maintenance</title>
-    <style type="text/css">
-      body {
-        background-color:#e6e6e6;
-        font-family:Calibri;
-        text-align:center;
-      }
-      #wrapper {
-        background:#fff;
-        width:492px;
-        position:relative;
-        margin-left:auto;
-        margin-right:auto;
-        text-align:left;
-        border:3px solid #999;
-        overflow:hidden;
-	padding: 30px;
-        border-bottom-right-radius: 16px;
-        border-bottom-left-radius: 16px;
-      }
-      #wrapper p {
-        padding:5px;
-      }
-    </style>
-  </head>
-  <body lang=FR>
-    <div id="wrapper">
-      <img src="https://www.georchestra.org/public/logos/georchestra_logo.png" alt="geOrchestra" />
-      <p>
-        Due to maintenance, this service is temporarily unavailable.
-      </p>
-      <p>We're sorry for the inconvenience !</p>
-      <p>Hint: do not close the tab - the requested page will show up in a few seconds.</p>
-    </div>
-  </body>
-  <script>
-    window.setTimeout(function() {window.location.href = window.location.href}, 5000);
-  </script>
+<head>
+  <meta http-equiv="content-type" content="text/html; charset=utf-8" />
+  <meta http-equiv="cache-control" content="no-cache" />
+  <meta http-equiv="pragma" content="no-cache" />
+  <meta name="robots" content="none" />
+  <meta name="googlebot" content="noarchive" />
+  <meta http-equiv="refresh" content="5">
+  <title>Site in maintenance</title>
+  <link href="login/error.css" rel="stylesheet"/>
+</head>
+<body lang=EN>
+<div id="wrapper">
+  <div class="error-code">500</div>
+  <p class="error-desc">Site in maintenance</p>
+  <p>
+    Due to maintenance, this service is temporarily unavailable.
+  </p>
+  <p>We're sorry for the inconvenience !</p>
+  <p class="error-hint">Hint: do not close the tab - the requested page will show up in a few seconds.</p>
+</div>
+</body>
+<script>
+  fetch("/config").then(res => {
+    if (res.ok) {
+      return res.json();
+    }
+    throw new Error("Gateway down")
+  }).then(json => {
+    if (json.stylesheet){
+      var styleSheet = document.createElement("link")
+      styleSheet.href = json.stylesheet
+      styleSheet.rel = "stylesheet"
+      document.head.appendChild(styleSheet)
+    }
+  })
+</script>
 </html>

--- a/gateway/src/main/resources/templates/error/503.html
+++ b/gateway/src/main/resources/templates/error/503.html
@@ -1,38 +1,24 @@
 <html>
 <head>
-  <meta http-equiv="content-type" content="text/html; charset=utf-8" />
-  <meta http-equiv="cache-control" content="no-cache" />
-  <meta http-equiv="pragma" content="no-cache" />
-  <meta name="robots" content="none" />
-  <meta name="googlebot" content="noarchive" />
-  <meta http-equiv="refresh" content="5">
-  <title>Site in maintenance</title>
-  <link href="login/error.css" rel="stylesheet"/>
+    <meta http-equiv="content-type" content="text/html; charset=utf-8"/>
+    <meta http-equiv="cache-control" content="no-cache"/>
+    <meta http-equiv="pragma" content="no-cache"/>
+    <meta name="robots" content="none"/>
+    <meta name="googlebot" content="noarchive"/>
+    <meta http-equiv="refresh" content="5">
+    <title>Site in maintenance</title>
+    <link href="login/error.css" rel="stylesheet"/>
+    <script src="login/getConfig.js"></script>
 </head>
 <body lang=EN>
 <div id="wrapper">
-  <div class="error-code">500</div>
-  <p class="error-desc">Site in maintenance</p>
-  <p>
-    Due to maintenance, this service is temporarily unavailable.
-  </p>
-  <p>We're sorry for the inconvenience !</p>
-  <p class="error-hint">Hint: do not close the tab - the requested page will show up in a few seconds.</p>
+    <div class="error-code">500</div>
+    <p class="error-desc">Site in maintenance</p>
+    <p>
+        Due to maintenance, this service is temporarily unavailable.
+    </p>
+    <p>We're sorry for the inconvenience !</p>
+    <p class="error-hint">Hint: do not close the tab - the requested page will show up in a few seconds.</p>
 </div>
 </body>
-<script>
-  fetch("/config").then(res => {
-    if (res.ok) {
-      return res.json();
-    }
-    throw new Error("Gateway down")
-  }).then(json => {
-    if (json.stylesheet){
-      var styleSheet = document.createElement("link")
-      styleSheet.href = json.stylesheet
-      styleSheet.rel = "stylesheet"
-      document.head.appendChild(styleSheet)
-    }
-  })
-</script>
 </html>

--- a/gateway/src/main/resources/templates/error/503.html
+++ b/gateway/src/main/resources/templates/error/503.html
@@ -1,46 +1,38 @@
 <html>
-  <head>
-    <meta http-equiv="content-type" content="text/html; charset=utf-8" />
-    <meta http-equiv="cache-control" content="no-cache" />
-    <meta http-equiv="pragma" content="no-cache" />
-    <meta name="robots" content="none" />
-    <meta name="googlebot" content="noarchive" />
-    <title>Site in maintenance</title>
-    <style type="text/css">
-      body {
-        background-color:#e6e6e6;
-        font-family:Calibri;
-        text-align:center;
-      }
-      #wrapper {
-        background:#fff;
-        width:492px;
-        position:relative;
-        margin-left:auto;
-        margin-right:auto;
-        text-align:left;
-        border:3px solid #999;
-        overflow:hidden;
-	padding: 30px;
-        border-bottom-right-radius: 16px;
-        border-bottom-left-radius: 16px;
-      }
-      #wrapper p {
-        padding:5px;
-      }
-    </style>
-  </head>
-  <body lang=FR>
-    <div id="wrapper">
-      <img src="https://www.georchestra.org/public/logos/georchestra_logo.png" alt="geOrchestra" />
-      <p>
-        Due to maintenance, this service is temporarily unavailable.
-      </p>
-      <p>We're sorry for the inconvenience !</p>
-      <p>Hint: do not close the tab - the requested page will show up in a few seconds.</p>
-    </div>
-  </body>
-  <script>
-    window.setTimeout(function() {window.location.href = window.location.href}, 5000);
-  </script>
+<head>
+  <meta http-equiv="content-type" content="text/html; charset=utf-8" />
+  <meta http-equiv="cache-control" content="no-cache" />
+  <meta http-equiv="pragma" content="no-cache" />
+  <meta name="robots" content="none" />
+  <meta name="googlebot" content="noarchive" />
+  <meta http-equiv="refresh" content="5">
+  <title>Site in maintenance</title>
+  <link href="login/error.css" rel="stylesheet"/>
+</head>
+<body lang=EN>
+<div id="wrapper">
+  <div class="error-code">500</div>
+  <p class="error-desc">Site in maintenance</p>
+  <p>
+    Due to maintenance, this service is temporarily unavailable.
+  </p>
+  <p>We're sorry for the inconvenience !</p>
+  <p class="error-hint">Hint: do not close the tab - the requested page will show up in a few seconds.</p>
+</div>
+</body>
+<script>
+  fetch("/config").then(res => {
+    if (res.ok) {
+      return res.json();
+    }
+    throw new Error("Gateway down")
+  }).then(json => {
+    if (json.stylesheet){
+      var styleSheet = document.createElement("link")
+      styleSheet.href = json.stylesheet
+      styleSheet.rel = "stylesheet"
+      document.head.appendChild(styleSheet)
+    }
+  })
+</script>
 </html>


### PR DESCRIPTION
I'm not sure about the `/config` route. I did this way in order to let other applications to be able to retrieve config from the gateway.

Everything is customizable with the georchestraStylesheet set in default.properties from datadir.

Previews : 
![image](https://github.com/user-attachments/assets/8765a8a4-065c-41c4-ace8-5c9de40ef942)

![image](https://github.com/user-attachments/assets/5b4f7c20-c452-4b70-b273-faf295a0e4ad)

In blue : 
![image](https://github.com/user-attachments/assets/7dce93d4-aeda-49d9-b4c1-9828953fb482)

