### PR TITLE
avoid providing internal notes to /whoami endpoint (fixes #170)

### DIFF
--- a/gateway/src/main/java/org/georchestra/gateway/app/WhoamiController.java
+++ b/gateway/src/main/java/org/georchestra/gateway/app/WhoamiController.java
@@ -28,6 +28,7 @@ import org.georchestra.security.model.GeorchestraUser;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.server.ServerWebExchange;
 
@@ -93,6 +94,7 @@ public class WhoamiController {
      *         details
      */
     @GetMapping(path = "/whoami", produces = MediaType.APPLICATION_JSON_VALUE)
+    @ResponseBody
     public Mono<Map<String, Object>> whoami(Authentication principal, ServerWebExchange exchange) {
         GeorchestraUser user;
         try {
@@ -100,7 +102,13 @@ public class WhoamiController {
         } catch (DuplicatedEmailFoundException e) {
             user = null;
         }
+
         Map<String, Object> ret = new LinkedHashMap<>();
+        if (user != null) {
+            // notes is an internal field and should not be provided by the /whoami endpoint
+            // (see #170)
+            user.setNotes(null);
+        }
         ret.put("GeorchestraUser", user);
         if (principal == null) {
             ret.put("Authentication", null);

--- a/gateway/src/main/java/org/georchestra/gateway/security/oauth2/OAuth2Configuration.java
+++ b/gateway/src/main/java/org/georchestra/gateway/security/oauth2/OAuth2Configuration.java
@@ -289,6 +289,7 @@ public class OAuth2Configuration {
             httpClient = httpClient.proxyWithSystemProperties();
         }
         ExchangeFilterFunction handleJwtContentType = OpenIdHelper.transformJWTClientResponseToJSON();
-        return WebClient.builder().clientConnector(new ReactorClientHttpConnector(httpClient)).filter(handleJwtContentType).build();
+        return WebClient.builder().clientConnector(new ReactorClientHttpConnector(httpClient))
+                .filter(handleJwtContentType).build();
     }
 }

--- a/gateway/src/test/java/org/georchestra/gateway/security/ldap/extended/ExtendedLdapAuthenticationIT.java
+++ b/gateway/src/test/java/org/georchestra/gateway/security/ldap/extended/ExtendedLdapAuthenticationIT.java
@@ -70,4 +70,23 @@ public class ExtendedLdapAuthenticationIT {
                 .isEmpty();
     }
 
+    public @Test void testWhoamiNoNotesRevealed() {
+        testClient.get().uri("/whoami")//
+                .header("Authorization", "Basic dGVzdGFkbWluOnRlc3RhZG1pbg==") // testadmin:testadmin
+                .exchange()//
+                .expectStatus()//
+                .is2xxSuccessful()//
+                .expectBody()//
+                .jsonPath("$.GeorchestraUser.notes").isEmpty();
+    }
+
+    public @Test void testWhoamiNoAuth() {
+        testClient.get().uri("/whoami")//
+                .exchange()//
+                .expectStatus()//
+                .is2xxSuccessful()//
+                .expectBody()//
+                .jsonPath("$.GeorchestraUser").isEmpty();
+    }
+
 }


### PR DESCRIPTION
See mentioned issue #170 and related one (https://github.com/georchestra/georchestra/issues/4280). This PR aims to avoid having the /whoami endpoint revealing the "internal notes" field from the LDAP, as it is an internal note on the user and is not meant to be available from the endpoint.

Tests: 2 tests added, also making sure that the /whoami endpoint will work when not connected (`user` is null).


