### PR TITLE
Disable default spring security headers, allow spring cloud gateway to manage them

### DIFF
--- a/datadir/gateway/application.yaml
+++ b/datadir/gateway/application.yaml
@@ -1,0 +1,45 @@
+# Spring-boot/cloud application configuration, imported from gateway.yaml
+server:
+  forward-headers-strategy: FRAMEWORK
+  reactive:
+    session:
+      timeout: 1440m # 24h
+
+# The following sample configuration disables x-frame-options and x-content-type options response headers
+# It is a two step process, by one side, we need to remove the headers from downstream service responses,
+# by adding a RemoveResponseHeader default filter for each response header to remove.
+# On the other hand, the gateway's corresponding secure headers have to be disabled
+# (see spring.cloud.gateway.filter.secure-headers.disable.*)
+spring:
+  cloud:
+    gateway:
+      metrics.enabled: true
+      # Uncomment the following to allow cross-origin requests from any methods coming from anywhere.
+      # See https://docs.spring.io/spring-cloud-gateway/reference/spring-cloud-gateway/cors-configuration.html for more info.
+      #globalcors:
+      #  cors-configurations:
+      #    '[/**]':
+      #      allowedOrigins: "*"
+      #      allowedHeaders: "*"
+      #      allowedMethods: "*"
+      default-filters:
+      - SecureHeaders # add security-related HTTP headers to responses sent from the gateway to clients. See https://blog.appcanary.com/2017/http-security-headers.html
+      - TokenRelay # propagates OAuth2 access tokens from incoming requests to downstream services
+      - RemoveSecurityHeaders # removing incoming sec-* headers to prevent impresionation
+      - AddSecHeaders # append resolved sec-* headers to proxied requests based on the currently authenticated user
+      - PreserveHostHeader # ensure that the original Host header from the incoming HTTP request is preserved and passed along to the downstream service
+      - ApplicationError # use gateway's custom error pages when a downstream request returns an error code
+      - LoginParamRedirect # redirect to /login if the request contains a ?login query param and is not already authenticated
+      - RemoveResponseHeader=X-Content-Type-Options # remove unwanted response header from downstream services
+      - RemoveResponseHeader=X-Frame-Options # remove unwanted response header from downstream services
+      filter:
+        secure-headers:
+          disable: # NOTE: header names must be lower-case
+          - content-security-policy
+          - x-frame-options
+          - x-content-type-options
+          referrer-policy: strict-origin
+          enabled: true
+          frame-options: SAMEORIGIN
+          xss-protection-header: 0
+          #content-security-policy: script-src 'self' 'unsafe-eval'; object-src 'self';

--- a/datadir/gateway/gateway.yaml
+++ b/datadir/gateway/gateway.yaml
@@ -137,6 +137,11 @@ georchestra:
         access-rules:
         - intercept-url: /import/**
           anonymous: false
+      echo: 
+        target: http://echo:80/
+        access-rules:
+        - intercept-url: /import/**
+          anonymous: true
 
 ---
 # docker profile, sets backend services target URLs to match default docker-compose host names and ports
@@ -155,6 +160,7 @@ georchestra.gateway.services:
   import.target: http://import:80/
   mapfishapp.target: http://mapfishapp:8080/mapfishapp/
   mapstore.target: http://mapstore:8080/mapstore/
+  echo.target: http://echo:80
 
 ---
 spring.config.activate.on-profile: dev
@@ -182,3 +188,4 @@ georchestra.gateway.services:
   import.target: http://localhost:10012/
   atlas.target: http://localhost:8080/atlas/
   geowebcache.target: http://localhost:8080/geowebcache/
+  echo.target: http://localhost:10009

--- a/datadir/gateway/gateway.yaml
+++ b/datadir/gateway/gateway.yaml
@@ -2,7 +2,7 @@
 # configure target base URL's, headers and role based access, per service name.
 # Replaces security-proxy's targets-mapping.properties, headers-mapping.properties, and security-mappings.xml
 #
-spring.config.import: security.yaml, routes.yaml, roles-mappings.yaml
+spring.config.import: application.yaml, security.yaml, routes.yaml, roles-mappings.yaml
 
 georchestra:
   gateway:

--- a/datadir/gateway/routes.yaml
+++ b/datadir/gateway/routes.yaml
@@ -5,6 +5,10 @@ spring:
   cloud:
     gateway:
       routes:
+      - id: echo
+        uri: ${georchestra.gateway.services.echo.target}
+        predicates:
+        - Path=/echo
       - id: root
         uri: ${georchestra.gateway.services.header.target}
         predicates:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.1"
-
 volumes:
   postgresql_data:
   datadir:
@@ -91,3 +89,8 @@ services:
     ports:
       - 10007:8080
     
+  echo:
+    image: ealen/echo-server:latest
+    ports:
+      - 10009:80
+        

--- a/gateway/src/main/resources/application.yml
+++ b/gateway/src/main/resources/application.yml
@@ -107,16 +107,11 @@ georchestra:
           users:
             rdn: ${ldapUsersRdn:ou=users}
             searchFilter: ${ldapUserSearchFilter:(uid={0})}
-            pendingUsersSearchBaseDN: ou=pendingusers
-            protectedUsers: geoserver_privileged_user
           roles:
             rdn: ${ldapRolesRdn:ou=roles}
             searchFilter: ${ldapRolesSearchFilter:(member={0})}
-            protectedRoles: ADMINISTRATOR, EXTRACTORAPP, GN_.*, ORGADMIN, REFERENT, USER, SUPERUSER
           orgs:
             rdn: ${ldapOrgsRdn:ou=orgs}
-            orgTypes: Association,Company,NGO,Individual,Other
-            pendingOrgSearchBaseDN: ou=pendingorgs
 
 management:
   server:
@@ -141,9 +136,8 @@ management:
       show-details: always
   metrics:
     binders:
-      processor.enabled: true
-      uptime.enabled: true
-      jvm.enabled: true
+      process.enabled: true
+      start.time: true
     enable.all: true
     enable.jvm: true
     export:

--- a/gateway/src/main/resources/application.yml
+++ b/gateway/src/main/resources/application.yml
@@ -36,10 +36,8 @@ spring:
       enabled: true
       global-filter.websocket-routing.enabled: true
       metrics.enabled: true
-      # Uncomment the following to allow cross-origin requests from any methods
-      # coming from anywhere.
-      # See https://docs.spring.io/spring-cloud-gateway/reference/spring-cloud-gateway/cors-configuration.html
-      # for more infos.
+      # Uncomment the following to allow cross-origin requests from any methods coming from anywhere.
+      # See https://docs.spring.io/spring-cloud-gateway/reference/spring-cloud-gateway/cors-configuration.html for more info.
       #globalcors:
       #  cors-configurations:
       #    '[/**]':
@@ -48,21 +46,19 @@ spring:
       #      allowedMethods: "*"
 
       default-filters:
-      - SecureHeaders
-      - TokenRelay
-      - RemoveSecurityHeaders
-      # AddSecHeaders appends sec-* headers to proxied requests based on the currently authenticated user
-      - AddSecHeaders
-      - PreserveHostHeader
-      - ApplicationError
-      - LoginParamRedirect
+      - SecureHeaders # add security-related HTTP headers to responses sent from the gateway to clients. See https://blog.appcanary.com/2017/http-security-headers.html
+      - TokenRelay # propagates OAuth2 access tokens from incoming requests to downstream services
+      - RemoveSecurityHeaders # removing incoming sec-* headers to prevent impresionation
+      - AddSecHeaders # append resolved sec-* headers to proxied requests based on the currently authenticated user
+      - PreserveHostHeader # ensure that the original Host header from the incoming HTTP request is preserved and passed along to the downstream service
+      - ApplicationError # use gateway's custom error pages when a downstream request returns an error code
+      - LoginParamRedirect # redirect to /login if the request contains a ?login query param and is not already authenticated
       global-filter:
-        websocket-routing:
-          enabled: true
+        websocket-routing.enabled: true
       filter:
         secure-headers:
           enabled: true
-          disable:
+          disable: # NOTE: header names must be lower-case
           - content-security-policy
           frame-options: SAMEORIGIN
           xss-protection-header: 0
@@ -134,14 +130,6 @@ management:
       enabled: true
       probes.enabled: true
       show-details: always
-  metrics:
-    binders:
-      process.enabled: true
-      start.time: true
-    enable.all: true
-    enable.jvm: true
-    export:
-      atlas.enabled: false
 
 logging:
   level:

--- a/gateway/src/test/resources/application-createaccount.yml
+++ b/gateway/src/test/resources/application-createaccount.yml
@@ -33,16 +33,11 @@ georchestra:
           users:
             rdn: ou=users
             searchFilter: (uid={0})
-            pendingUsersSearchBaseDN: ou=pendingusers
-            protectedUsers: geoserver_privileged_user
           roles:
             rdn: ou=roles
             searchFilter: (member={0})
-            protectedRoles: ADMINISTRATOR, EXTRACTORAPP, GN_.*, ORGADMIN, REFERENT, USER, SUPERUSER
           orgs:
             rdn: ou=orgs
-            orgTypes: Association,Company,NGO,Individual,Other
-            pendingOrgSearchBaseDN: ou=pendingorgs
 
 spring:
   main:

--- a/gateway/src/test/resources/application-georheaders.yml
+++ b/gateway/src/test/resources/application-georheaders.yml
@@ -23,16 +23,11 @@ georchestra:
           users:
             rdn: ou=users
             searchFilter: (uid={0})
-            pendingUsersSearchBaseDN: ou=pendingusers
-            protectedUsers: geoserver_privileged_user
           roles:
             rdn: ou=roles
             searchFilter: (member={0})
-            protectedRoles: ADMINISTRATOR, EXTRACTORAPP, GN_.*, ORGADMIN, REFERENT, USER, SUPERUSER
           orgs:
             rdn: ou=orgs
-            orgTypes: Association,Company,NGO,Individual,Other
-            pendingOrgSearchBaseDN: ou=pendingorgs
     services:
       echo:
         target: http://${httpEchoHost}:${httpEchoPort}

--- a/gateway/src/test/resources/application-preauth.yml
+++ b/gateway/src/test/resources/application-preauth.yml
@@ -27,16 +27,11 @@ georchestra:
           users:
             rdn: ou=users
             searchFilter: (uid={0})
-            pendingUsersSearchBaseDN: ou=pendingusers
-            protectedUsers: geoserver_privileged_user
           roles:
             rdn: ou=roles
             searchFilter: (member={0})
-            protectedRoles: ADMINISTRATOR, EXTRACTORAPP, GN_.*, ORGADMIN, REFERENT, USER, SUPERUSER
           orgs:
             rdn: ou=orgs
-            orgTypes: Association,Company,NGO,Individual,Other
-            pendingOrgSearchBaseDN: ou=pendingorgs
 
 spring:
   main:

--- a/gateway/src/test/resources/application-rabbitmq.yml
+++ b/gateway/src/test/resources/application-rabbitmq.yml
@@ -27,16 +27,11 @@ georchestra:
           users:
             rdn: ou=users
             searchFilter: (uid={0})
-            pendingUsersSearchBaseDN: ou=pendingusers
-            protectedUsers: geoserver_privileged_user
           roles:
             rdn: ou=roles
             searchFilter: (member={0})
-            protectedRoles: ADMINISTRATOR, EXTRACTORAPP, GN_.*, ORGADMIN, REFERENT, USER, SUPERUSER
           orgs:
             rdn: ou=orgs
-            orgTypes: Association,Company,NGO,Individual,Other
-            pendingOrgSearchBaseDN: ou=pendingorgs
       events:
         rabbitmq:
           # Note usually enableRabbitmqEvents, rabbitmqHost, etc. come from georchestra's default.properties


### PR DESCRIPTION
This patch disables the Spring Boot default security headers in
`org.georchestra.gateway.security.GatewaySecurityConfiguration`.

The default Spring Boot security headers, and the Spring Cloud Gateway
security headers handling are two different things, and the former was
preventing the later from taking over the configuration.

The sample configuration in `datadir/application.yaml` disables x-frame-options and x-content-type options response headers.
It is a two step process, by one side, we need to remove the headers from downstream service responses,
by adding a RemoveResponseHeader default filter for each response header to remove.
On the other hand, the gateway's corresponding secure headers have to be disabled
(see spring.cloud.gateway.filter.secure-headers.disable.*)

For example:

```
spring:
  cloud:
    gateway:
      default-filters:
      - SecureHeaders # add security-related HTTP headers to responses sent from the gateway to clients. See https://blog.appcanary.com/2017/http-security-headers.html
      - TokenRelay # propagates OAuth2 access tokens from incoming requests to downstream services
      - RemoveSecurityHeaders # removing incoming sec-* headers to prevent impresionation
      - AddSecHeaders # append resolved sec-* headers to proxied requests based on the currently authenticated user
      - PreserveHostHeader # ensure that the original Host header from the incoming HTTP request is preserved and passed along to the downstream service
      - ApplicationError # use gateway's custom error pages when a downstream request returns an error code
      - LoginParamRedirect # redirect to /login if the request contains a ?login query param and is not already authenticated
      - RemoveResponseHeader=X-Content-Type-Options # remove unwanted response header from downstream services
      - RemoveResponseHeader=X-Frame-Options # remove unwanted response header from downstream services
      filter:
        secure-headers:
          enabled: true
          disable:
          # NOTE: header names must be lower-case
          - x-frame-options
          - x-content-type-options
```