### PR TITLE
chore: reduce Java warnings and improve code readability

### DIFF
--- a/gateway/src/main/java/org/georchestra/gateway/accounts/admin/AbstractAccountsManager.java
+++ b/gateway/src/main/java/org/georchestra/gateway/accounts/admin/AbstractAccountsManager.java
@@ -18,15 +18,16 @@
  */
 package org.georchestra.gateway.accounts.admin;
 
-import lombok.NonNull;
-import lombok.RequiredArgsConstructor;
+import java.util.Optional;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
 import org.georchestra.gateway.security.exceptions.DuplicatedEmailFoundException;
 import org.georchestra.security.model.GeorchestraUser;
 import org.springframework.context.ApplicationEventPublisher;
 
-import java.util.Optional;
-import java.util.concurrent.locks.ReadWriteLock;
-import java.util.concurrent.locks.ReentrantReadWriteLock;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 public abstract class AbstractAccountsManager implements AccountManager {

--- a/gateway/src/main/java/org/georchestra/gateway/accounts/admin/AccountManager.java
+++ b/gateway/src/main/java/org/georchestra/gateway/accounts/admin/AccountManager.java
@@ -18,13 +18,13 @@
  */
 package org.georchestra.gateway.accounts.admin;
 
+import java.util.Optional;
+
 import org.georchestra.gateway.security.GeorchestraUserMapper;
 import org.georchestra.gateway.security.ResolveGeorchestraUserGlobalFilter;
 import org.georchestra.security.model.GeorchestraUser;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.security.core.Authentication;
-
-import java.util.Optional;
 
 /**
  * @see CreateAccountUserCustomizer

--- a/gateway/src/main/java/org/georchestra/gateway/accounts/admin/CreateAccountUserCustomizer.java
+++ b/gateway/src/main/java/org/georchestra/gateway/accounts/admin/CreateAccountUserCustomizer.java
@@ -22,7 +22,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.WeakHashMap;
 
-import org.georchestra.ds.users.DuplicatedEmailException;
 import org.georchestra.gateway.security.GeorchestraUserCustomizerExtension;
 import org.georchestra.gateway.security.exceptions.DuplicatedEmailFoundException;
 import org.georchestra.security.model.GeorchestraUser;

--- a/gateway/src/main/java/org/georchestra/gateway/accounts/admin/ldap/LdapAccountsManager.java
+++ b/gateway/src/main/java/org/georchestra/gateway/accounts/admin/ldap/LdapAccountsManager.java
@@ -18,10 +18,10 @@
  */
 package org.georchestra.gateway.accounts.admin.ldap;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;
 import org.georchestra.ds.DataServiceException;
@@ -85,8 +85,8 @@ class LdapAccountsManager extends AbstractAccountsManager {
 
     private GeorchestraUser ensureRolesPrefixed(GeorchestraUser user) {
         List<String> roles = user.getRoles().stream().filter(Objects::nonNull)
-                .map(r -> r.startsWith("ROLE_") ? r : "ROLE_" + r).collect(Collectors.toList());
-        user.setRoles(roles);
+                .map(r -> r.startsWith("ROLE_") ? r : "ROLE_" + r).toList();
+        user.setRoles(new ArrayList<>(roles));
         return user;
     }
 
@@ -108,7 +108,7 @@ class LdapAccountsManager extends AbstractAccountsManager {
         } catch (IllegalStateException orgError) {
             log.error("Error when trying to create / update the organisation {}, reverting the account creation",
                     newAccount.getOrg(), orgError);
-            rollbackAccount(newAccount, newAccount.getOrg());
+            rollbackAccount(newAccount);
             throw orgError;
         }
 
@@ -208,7 +208,7 @@ class LdapAccountsManager extends AbstractAccountsManager {
         }
     }
 
-    private void rollbackAccount(Account newAccount, final String orgId) {
+    private void rollbackAccount(Account newAccount) {
         try {// roll-back account
             accountDao.delete(newAccount);
         } catch (NameNotFoundException | DataServiceException rollbackError) {

--- a/gateway/src/main/java/org/georchestra/gateway/accounts/events/rabbitmq/RabbitmqEventsListener.java
+++ b/gateway/src/main/java/org/georchestra/gateway/accounts/events/rabbitmq/RabbitmqEventsListener.java
@@ -22,10 +22,11 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
-import com.google.common.annotations.VisibleForTesting;
 import org.json.JSONObject;
 import org.springframework.amqp.core.Message;
 import org.springframework.amqp.core.MessageListener;
+
+import com.google.common.annotations.VisibleForTesting;
 
 import lombok.extern.slf4j.Slf4j;
 

--- a/gateway/src/main/java/org/georchestra/gateway/app/GeorchestraGatewayApplication.java
+++ b/gateway/src/main/java/org/georchestra/gateway/app/GeorchestraGatewayApplication.java
@@ -18,18 +18,14 @@
  */
 package org.georchestra.gateway.app;
 
-import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.tuple.Pair;
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+
 import org.georchestra.gateway.security.GeorchestraGatewaySecurityConfigProperties;
-import org.georchestra.gateway.security.GeorchestraGatewaySecurityConfigProperties.Server;
-import org.georchestra.gateway.security.GeorchestraUserMapper;
-import org.georchestra.gateway.security.exceptions.DuplicatedEmailFoundException;
-import org.georchestra.security.model.GeorchestraUser;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.autoconfigure.security.oauth2.client.OAuth2ClientProperties;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.gateway.route.RouteLocator;
@@ -38,127 +34,34 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.event.EventListener;
 import org.springframework.context.support.ReloadableResourceBundleMessageSource;
 import org.springframework.core.env.Environment;
-import org.springframework.core.io.ClassPathResource;
-import org.springframework.security.core.Authentication;
-import org.springframework.stereotype.Controller;
-import org.springframework.ui.Model;
 import org.springframework.util.unit.DataSize;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.ResponseBody;
-import org.springframework.web.server.ServerWebExchange;
-import reactor.core.publisher.Mono;
 
-import javax.annotation.PostConstruct;
-import java.io.File;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Paths;
-import java.util.HashMap;
-import java.util.LinkedHashMap;
-import java.util.Map;
-import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
 
-@Controller
 @Slf4j
 @SpringBootApplication
 @EnableConfigurationProperties(GeorchestraGatewaySecurityConfigProperties.class)
 public class GeorchestraGatewayApplication {
 
     private @Autowired RouteLocator routeLocator;
-    private @Autowired GeorchestraUserMapper userMapper;
-
-    private @Autowired(required = false) GeorchestraGatewaySecurityConfigProperties georchestraGatewaySecurityConfigProperties;
-
-    private boolean ldapEnabled = false;
-
-    private @Autowired(required = false) OAuth2ClientProperties oauth2ClientConfig;
-    private @Value("${georchestra.gateway.headerEnabled:true}") boolean headerEnabled;
-
-    // defined in georchestra datadir's default.properties
-    private @Value("${georchestraStylesheet:}") String georchestraStylesheet;
-    private @Value("${useLegacyHeader:false}") boolean useLegacyHeader;
-    private @Value("${headerUrl:/header/}") String headerUrl;
-    private @Value("${headerConfigFile:}") String headerConfigFile;
-    private @Value("${headerHeight:80}") int headerHeight;
-    private @Value("${logoUrl:}") String logoUrl;
-    private @Value("${headerScript:https://cdn.jsdelivr.net/gh/georchestra/header@dist/header.js}") String headerScript;
     private @Value("${spring.messages.basename:}") String messagesBasename;
 
     public static void main(String[] args) {
         SpringApplication.run(GeorchestraGatewayApplication.class, args);
     }
 
-    @PostConstruct
-    void initialize() {
-        if (georchestraGatewaySecurityConfigProperties != null) {
-            ldapEnabled = georchestraGatewaySecurityConfigProperties.getLdap().values().stream()
-                    .anyMatch((Server::isEnabled));
-        }
-    }
-
-    @GetMapping(path = "/whoami", produces = "application/json")
-    @ResponseBody
-    public Mono<Map<String, Object>> whoami(Authentication principal, ServerWebExchange exchange) {
-        GeorchestraUser user;
-        try {
-            user = Optional.ofNullable(principal).flatMap(userMapper::resolve).orElse(null);
-        } catch (DuplicatedEmailFoundException e) {
-            user = null;
-        }
-
-        Map<String, Object> ret = new LinkedHashMap<>();
-        ret.put("GeorchestraUser", user);
-        if (principal == null) {
-            ret.put("Authentication", null);
-        } else {
-            ret.put(principal.getClass().getCanonicalName(), principal);
-        }
-        return Mono.just(ret);
-    }
-
-    @GetMapping(path = "/logout")
-    public String logout(Model mdl) {
-        setHeaderAttributes(mdl);
-        return "logout";
-    }
-
-    @GetMapping(path = "/login")
-    public String loginPage(@RequestParam Map<String, String> allRequestParams, Model mdl) {
-        Map<String, Pair<String, String>> oauth2LoginLinks = new HashMap<>();
-        if (oauth2ClientConfig != null) {
-            oauth2ClientConfig.getRegistration().forEach((k, v) -> {
-                String clientName = Optional.ofNullable(v.getClientName()).orElse(k);
-
-                String providerPath = Paths.get("login/img/", k + ".png").toString();
-                String logo = new ClassPathResource("static/" + providerPath).exists() ? providerPath
-                        : "login/img/default.png";
-                oauth2LoginLinks.put("/oauth2/authorization/" + k, Pair.of(clientName, logo));
-            });
-        }
-
-        if (oauth2LoginLinks.size() == 1 && !ldapEnabled) {
-            return "redirect:" + oauth2LoginLinks.keySet().stream().findFirst().get();
-        }
-
-        setHeaderAttributes(mdl);
-        mdl.addAttribute("ldapEnabled", ldapEnabled);
-        mdl.addAttribute("oauth2LoginLinks", oauth2LoginLinks);
-        boolean expired = "expired_password".equals(allRequestParams.get("error"));
-        mdl.addAttribute("passwordExpired", expired);
-        boolean invalidCredentials = "invalid_credentials".equals(allRequestParams.get("error"));
-        mdl.addAttribute("invalidCredentials", invalidCredentials);
-        boolean duplicateAccount = "duplicate_account".equals(allRequestParams.get("error"));
-        mdl.addAttribute("duplicateAccount", duplicateAccount);
-        return "login";
-    }
-
-    @GetMapping(path = "/style-config", produces = "application/json")
-    @ResponseBody
-    public Mono<Map<String, Object>> styleConfig() {
-        Map<String, Object> ret = new LinkedHashMap<>();
-        ret.put("stylesheet", georchestraStylesheet);
-        ret.put("logo", logoUrl);
-        return Mono.just(ret);
+    /**
+     * REVISIT: why do we need to define this bean in the Application class and not
+     * in a configuration that depends on whether rabbit is enabled?
+     */
+    @Bean
+    MessageSource messageSource() {
+        ReloadableResourceBundleMessageSource messageSource = new ReloadableResourceBundleMessageSource();
+        messageSource.setBasenames(("classpath:messages/login," + messagesBasename).split(","));
+        messageSource.setCacheSeconds(600);
+        messageSource.setUseCodeAsDefaultMessage(true);
+        messageSource.setDefaultEncoding(StandardCharsets.UTF_8.name());
+        return messageSource;
     }
 
     @EventListener(ApplicationReadyEvent.class)
@@ -171,44 +74,23 @@ public class GeorchestraGatewayApplication {
         String app = env.getProperty("spring.application.name");
         String instanceId = env.getProperty("info.instance-id");
         int cpus = Runtime.getRuntime().availableProcessors();
-        String maxMem;
-        {
-            DataSize maxMemBytes = DataSize.ofBytes(Runtime.getRuntime().maxMemory());
-            double value = maxMemBytes.toKilobytes() / 1024d;
-            String unit = "MB";
-            if (maxMemBytes.toGigabytes() > 0) {
-                value = value / 1024d;
-                unit = "GB";
-            }
-            maxMem = String.format("%.2f %s", value, unit);
-        }
+        String maxMem = getMaxMem();
+
         Long routeCount = routeLocator.getRoutes().count().block();
         log.info("{} ready. Data dir: {}. Routes: {}. Instance-id: {}, cpus: {}, max memory: {}", app, datadir,
                 routeCount, instanceId, cpus, maxMem);
     }
 
-    /**
-     * REVISIT: why do we need to define this bean in the Application class and not
-     * in a configuration that depends on whether rabbit is enabled?
-     */
-    @Bean
-    public MessageSource messageSource() {
-        ReloadableResourceBundleMessageSource messageSource = new ReloadableResourceBundleMessageSource();
-        messageSource.setBasenames(("classpath:messages/login," + messagesBasename).split(","));
-        messageSource.setCacheSeconds(600);
-        messageSource.setUseCodeAsDefaultMessage(true);
-        messageSource.setDefaultEncoding(StandardCharsets.UTF_8.name());
-        return messageSource;
-    }
-
-    private void setHeaderAttributes(Model mdl) {
-        mdl.addAttribute("georchestraStylesheet", georchestraStylesheet);
-        mdl.addAttribute("useLegacyHeader", useLegacyHeader);
-        mdl.addAttribute("headerUrl", headerUrl);
-        mdl.addAttribute("headerHeight", headerHeight);
-        mdl.addAttribute("logoUrl", logoUrl);
-        mdl.addAttribute("headerConfigFile", headerConfigFile);
-        mdl.addAttribute("headerEnabled", headerEnabled);
-        mdl.addAttribute("headerScript", headerScript);
+    private String getMaxMem() {
+        String maxMem;
+        DataSize maxMemBytes = DataSize.ofBytes(Runtime.getRuntime().maxMemory());
+        double value = maxMemBytes.toKilobytes() / 1024d;
+        String unit = "MB";
+        if (maxMemBytes.toGigabytes() > 0) {
+            value = value / 1024d;
+            unit = "GB";
+        }
+        maxMem = String.format("%.2f %s", value, unit);
+        return maxMem;
     }
 }

--- a/gateway/src/main/java/org/georchestra/gateway/app/LoginLogoutController.java
+++ b/gateway/src/main/java/org/georchestra/gateway/app/LoginLogoutController.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright (C) 2021 by the geOrchestra PSC
+ *
+ * This file is part of geOrchestra.
+ *
+ * geOrchestra is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * geOrchestra is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * geOrchestra.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.georchestra.gateway.app;
+
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import javax.annotation.PostConstruct;
+
+import org.apache.commons.lang3.tuple.Pair;
+import org.georchestra.gateway.security.GeorchestraGatewaySecurityConfigProperties;
+import org.georchestra.gateway.security.GeorchestraGatewaySecurityConfigProperties.Server;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.security.oauth2.client.OAuth2ClientProperties;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class LoginLogoutController {
+
+    private @Autowired(required = false) GeorchestraGatewaySecurityConfigProperties georchestraGatewaySecurityConfigProperties;
+
+    private boolean ldapEnabled;
+
+    private @Autowired(required = false) OAuth2ClientProperties oauth2ClientConfig;
+    private @Value("${georchestra.gateway.headerEnabled:true}") boolean headerEnabled;
+
+    // defined in georchestra datadir's default.properties
+    private @Value("${georchestraStylesheet:}") String georchestraStylesheet;
+    private @Value("${useLegacyHeader:false}") boolean useLegacyHeader;
+    private @Value("${headerUrl:/header/}") String headerUrl;
+    private @Value("${headerConfigFile:}") String headerConfigFile;
+    private @Value("${headerHeight:80}") int headerHeight;
+    private @Value("${logoUrl:}") String logoUrl;
+    private @Value("${headerScript:https://cdn.jsdelivr.net/gh/georchestra/header@dist/header.js}") String headerScript;
+
+    @PostConstruct
+    void initialize() {
+        if (georchestraGatewaySecurityConfigProperties != null) {
+            ldapEnabled = georchestraGatewaySecurityConfigProperties.getLdap().values().stream()
+                    .anyMatch((Server::isEnabled));
+        }
+    }
+
+    @GetMapping(path = "/logout")
+    public String logout(Model mdl) {
+        setHeaderAttributes(mdl);
+        return "logout";
+    }
+
+    @GetMapping(path = "/login")
+    public String loginPage(@RequestParam Map<String, String> allRequestParams, Model mdl) {
+        Map<String, Pair<String, String>> oauth2LoginLinks = new HashMap<>();
+        if (oauth2ClientConfig != null) {
+            oauth2ClientConfig.getRegistration().forEach((k, v) -> {
+                String clientName = Optional.ofNullable(v.getClientName()).orElse(k);
+
+                String providerPath = Paths.get("login/img/", k + ".png").toString();
+                String logo = new ClassPathResource("static/" + providerPath).exists() ? providerPath
+                        : "login/img/default.png";
+                oauth2LoginLinks.put("/oauth2/authorization/" + k, Pair.of(clientName, logo));
+            });
+        }
+
+        if (oauth2LoginLinks.size() == 1 && !ldapEnabled) {
+            return "redirect:" + oauth2LoginLinks.keySet().stream().findFirst().orElseThrow();
+        }
+
+        setHeaderAttributes(mdl);
+        mdl.addAttribute("ldapEnabled", ldapEnabled);
+        mdl.addAttribute("oauth2LoginLinks", oauth2LoginLinks);
+        boolean expired = "expired_password".equals(allRequestParams.get("error"));
+        mdl.addAttribute("passwordExpired", expired);
+        boolean invalidCredentials = "invalid_credentials".equals(allRequestParams.get("error"));
+        mdl.addAttribute("invalidCredentials", invalidCredentials);
+        boolean duplicateAccount = "duplicate_account".equals(allRequestParams.get("error"));
+        mdl.addAttribute("duplicateAccount", duplicateAccount);
+        return "login";
+    }
+
+    private void setHeaderAttributes(Model mdl) {
+        mdl.addAttribute("georchestraStylesheet", georchestraStylesheet);
+        mdl.addAttribute("useLegacyHeader", useLegacyHeader);
+        mdl.addAttribute("headerUrl", headerUrl);
+        mdl.addAttribute("headerHeight", headerHeight);
+        mdl.addAttribute("logoUrl", logoUrl);
+        mdl.addAttribute("headerConfigFile", headerConfigFile);
+        mdl.addAttribute("headerEnabled", headerEnabled);
+        mdl.addAttribute("headerScript", headerScript);
+    }
+}

--- a/gateway/src/main/java/org/georchestra/gateway/app/StyleConfigController.java
+++ b/gateway/src/main/java/org/georchestra/gateway/app/StyleConfigController.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2021 by the geOrchestra PSC
+ *
+ * This file is part of geOrchestra.
+ *
+ * geOrchestra is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * geOrchestra is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * geOrchestra.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.georchestra.gateway.app;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import reactor.core.publisher.Mono;
+
+@RestController
+public class StyleConfigController {
+
+    private String georchestraStylesheet;
+    private String logoUrl;
+
+    /**
+     * @param georchestraStylesheet defined in georchestra datadir's
+     *                              default.properties
+     * @param logoUrl               defined in georchestra datadir's
+     *                              default.properties
+     */
+    public StyleConfigController(@Value("${georchestraStylesheet:}") String georchestraStylesheet,
+            @Value("${logoUrl:}") String logoUrl) {
+        this.georchestraStylesheet = georchestraStylesheet;
+        this.logoUrl = logoUrl;
+    }
+
+    @GetMapping(path = "/style-config", produces = MediaType.APPLICATION_JSON_VALUE)
+    public Mono<Map<String, Object>> styleConfig() {
+
+        Map<String, Object> ret = new LinkedHashMap<>();
+        ret.put("stylesheet", georchestraStylesheet);
+        ret.put("logo", logoUrl);
+        return Mono.just(ret);
+
+    }
+}

--- a/gateway/src/main/java/org/georchestra/gateway/app/WhoamiController.java
+++ b/gateway/src/main/java/org/georchestra/gateway/app/WhoamiController.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2021 by the geOrchestra PSC
+ *
+ * This file is part of geOrchestra.
+ *
+ * geOrchestra is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * geOrchestra is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * geOrchestra.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.georchestra.gateway.app;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import org.georchestra.gateway.security.GeorchestraUserMapper;
+import org.georchestra.gateway.security.exceptions.DuplicatedEmailFoundException;
+import org.georchestra.security.model.GeorchestraUser;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ServerWebExchange;
+
+import reactor.core.publisher.Mono;
+
+@RestController
+public class WhoamiController {
+
+    private GeorchestraUserMapper userMapper;
+
+    public WhoamiController(GeorchestraUserMapper userMapper) {
+        this.userMapper = userMapper;
+    }
+
+    @GetMapping(path = "/whoami", produces = MediaType.APPLICATION_JSON_VALUE)
+    public Mono<Map<String, Object>> whoami(Authentication principal, ServerWebExchange exchange) {
+        GeorchestraUser user;
+        try {
+            user = Optional.ofNullable(principal).flatMap(userMapper::resolve).orElse(null);
+        } catch (DuplicatedEmailFoundException e) {
+            user = null;
+        }
+
+        Map<String, Object> ret = new LinkedHashMap<>();
+        ret.put("GeorchestraUser", user);
+        if (principal == null) {
+            ret.put("Authentication", null);
+        } else {
+            ret.put(principal.getClass().getCanonicalName(), principal);
+        }
+        return Mono.just(ret);
+    }
+}

--- a/gateway/src/main/java/org/georchestra/gateway/autoconfigure/app/FiltersAutoConfiguration.java
+++ b/gateway/src/main/java/org/georchestra/gateway/autoconfigure/app/FiltersAutoConfiguration.java
@@ -60,16 +60,19 @@ public class FiltersAutoConfiguration {
      * Custom gateway predicate factory to support matching by regular expressions
      * on both name and value of query parameters
      */
-    public @Bean RegExpQueryRoutePredicateFactory regExpQueryRoutePredicateFactory() {
+    @Bean
+    RegExpQueryRoutePredicateFactory regExpQueryRoutePredicateFactory() {
         return new RegExpQueryRoutePredicateFactory();
     }
 
     /** Allows to enable routes only if a given spring profile is enabled */
-    public @Bean RouteProfileGatewayFilterFactory routeProfileGatewayFilterFactory() {
+    @Bean
+    RouteProfileGatewayFilterFactory routeProfileGatewayFilterFactory() {
         return new RouteProfileGatewayFilterFactory();
     }
 
-    public @Bean StripBasePathGatewayFilterFactory stripBasePathGatewayFilterFactory() {
+    @Bean
+    StripBasePathGatewayFilterFactory stripBasePathGatewayFilterFactory() {
         return new StripBasePathGatewayFilterFactory();
     }
 

--- a/gateway/src/main/java/org/georchestra/gateway/autoconfigure/app/RoutePredicateFactoriesAutoConfiguration.java
+++ b/gateway/src/main/java/org/georchestra/gateway/autoconfigure/app/RoutePredicateFactoriesAutoConfiguration.java
@@ -25,7 +25,8 @@ import org.springframework.context.annotation.Bean;
 @AutoConfiguration
 public class RoutePredicateFactoriesAutoConfiguration {
 
-    public @Bean QueryParamRoutePredicateFactory queryParamRoutePredicateFactory() {
+    @Bean
+    QueryParamRoutePredicateFactory queryParamRoutePredicateFactory() {
         return new QueryParamRoutePredicateFactory();
     }
 }

--- a/gateway/src/main/java/org/georchestra/gateway/autoconfigure/security/AtLeastOneLdapDatasourceEnabledCondition.java
+++ b/gateway/src/main/java/org/georchestra/gateway/autoconfigure/security/AtLeastOneLdapDatasourceEnabledCondition.java
@@ -25,7 +25,6 @@ import java.util.Set;
 import java.util.function.Predicate;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.georchestra.gateway.security.GeorchestraGatewaySecurityConfigProperties;
@@ -89,7 +88,7 @@ class AtLeastOneLdapDatasourceEnabledCondition extends SpringBootCondition {
         Set<String> names = new HashSet<>();
         for (String p : propertyNames) {
             String value = environment.getProperty(p);
-            if (Boolean.valueOf(value)) {
+            if (Boolean.parseBoolean(value)) {
                 Matcher matcher = pattern.matcher(p);
                 if (matcher.matches()) {
                     String name = matcher.group(1);
@@ -110,7 +109,7 @@ class AtLeastOneLdapDatasourceEnabledCondition extends SpringBootCondition {
                 .map(EnumerablePropertySource::getPropertyNames)//
                 .flatMap(Stream::of)//
                 .filter(filter)//
-                .collect(Collectors.toList());
+                .toList();
     }
 
 }

--- a/gateway/src/main/java/org/georchestra/gateway/filter/headers/RemoveHeadersGatewayFilterFactory.java
+++ b/gateway/src/main/java/org/georchestra/gateway/filter/headers/RemoveHeadersGatewayFilterFactory.java
@@ -90,7 +90,7 @@ public class RemoveHeadersGatewayFilterFactory extends AbstractGatewayFilterFact
 
         private @Getter String regEx;
 
-        private transient Pattern compiled;
+        private Pattern compiled;
 
         public RegExConfig(String regEx) {
             setRegEx(regEx);

--- a/gateway/src/main/java/org/georchestra/gateway/filter/headers/providers/GeorchestraUserHeadersContributor.java
+++ b/gateway/src/main/java/org/georchestra/gateway/filter/headers/providers/GeorchestraUserHeadersContributor.java
@@ -18,6 +18,21 @@
  */
 package org.georchestra.gateway.filter.headers.providers;
 
+import static org.georchestra.commons.security.SecurityHeaders.SEC_ADDRESS;
+import static org.georchestra.commons.security.SecurityHeaders.SEC_EMAIL;
+import static org.georchestra.commons.security.SecurityHeaders.SEC_EXTERNAL_AUTHENTICATION;
+import static org.georchestra.commons.security.SecurityHeaders.SEC_FIRSTNAME;
+import static org.georchestra.commons.security.SecurityHeaders.SEC_LASTNAME;
+import static org.georchestra.commons.security.SecurityHeaders.SEC_LASTUPDATED;
+import static org.georchestra.commons.security.SecurityHeaders.SEC_LDAP_REMAINING_DAYS;
+import static org.georchestra.commons.security.SecurityHeaders.SEC_NOTES;
+import static org.georchestra.commons.security.SecurityHeaders.SEC_ORG;
+import static org.georchestra.commons.security.SecurityHeaders.SEC_ROLES;
+import static org.georchestra.commons.security.SecurityHeaders.SEC_TEL;
+import static org.georchestra.commons.security.SecurityHeaders.SEC_TITLE;
+import static org.georchestra.commons.security.SecurityHeaders.SEC_USERID;
+import static org.georchestra.commons.security.SecurityHeaders.SEC_USERNAME;
+
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Consumer;
@@ -29,8 +44,6 @@ import org.georchestra.security.model.GeorchestraUser;
 import org.springframework.http.HttpHeaders;
 import org.springframework.web.server.ServerWebExchange;
 
-import static org.georchestra.commons.security.SecurityHeaders.*;
-
 /**
  * Contributes user-related {@literal sec-*} request headers.
  * 
@@ -40,34 +53,32 @@ import static org.georchestra.commons.security.SecurityHeaders.*;
 public class GeorchestraUserHeadersContributor extends HeaderContributor {
 
     public @Override Consumer<HttpHeaders> prepare(ServerWebExchange exchange) {
-        return headers -> {
-            GeorchestraTargetConfig.getTarget(exchange)//
-                    .map(GeorchestraTargetConfig::headers)//
-                    .ifPresent(mappings -> {
-                        Optional<GeorchestraUser> user = GeorchestraUsers.resolve(exchange);
-                        add(headers, SEC_USERID, mappings.getUserid(), user.map(GeorchestraUser::getId));
-                        add(headers, SEC_USERNAME, mappings.getUsername(), user.map(GeorchestraUser::getUsername));
-                        add(headers, SEC_ORG, mappings.getOrg(), user.map(GeorchestraUser::getOrganization));
-                        add(headers, SEC_EMAIL, mappings.getEmail(), user.map(GeorchestraUser::getEmail));
-                        add(headers, SEC_FIRSTNAME, mappings.getFirstname(), user.map(GeorchestraUser::getFirstName));
-                        add(headers, SEC_LASTNAME, mappings.getLastname(), user.map(GeorchestraUser::getLastName));
-                        add(headers, SEC_TEL, mappings.getTel(), user.map(GeorchestraUser::getTelephoneNumber));
+        return headers -> GeorchestraTargetConfig.getTarget(exchange)//
+                .map(GeorchestraTargetConfig::headers)//
+                .ifPresent(mappings -> {
+                    Optional<GeorchestraUser> user = GeorchestraUsers.resolve(exchange);
+                    add(headers, SEC_USERID, mappings.getUserid(), user.map(GeorchestraUser::getId));
+                    add(headers, SEC_USERNAME, mappings.getUsername(), user.map(GeorchestraUser::getUsername));
+                    add(headers, SEC_ORG, mappings.getOrg(), user.map(GeorchestraUser::getOrganization));
+                    add(headers, SEC_EMAIL, mappings.getEmail(), user.map(GeorchestraUser::getEmail));
+                    add(headers, SEC_FIRSTNAME, mappings.getFirstname(), user.map(GeorchestraUser::getFirstName));
+                    add(headers, SEC_LASTNAME, mappings.getLastname(), user.map(GeorchestraUser::getLastName));
+                    add(headers, SEC_TEL, mappings.getTel(), user.map(GeorchestraUser::getTelephoneNumber));
 
-                        List<String> roles = user.map(GeorchestraUser::getRoles).orElse(List.of());
+                    List<String> roles = user.map(GeorchestraUser::getRoles).orElse(List.of());
 
-                        add(headers, SEC_ROLES, mappings.getRoles(), roles);
+                    add(headers, SEC_ROLES, mappings.getRoles(), roles);
 
-                        add(headers, SEC_LASTUPDATED, mappings.getLastUpdated(),
-                                user.map(GeorchestraUser::getLastUpdated));
-                        add(headers, SEC_ADDRESS, mappings.getAddress(), user.map(GeorchestraUser::getPostalAddress));
-                        add(headers, SEC_TITLE, mappings.getTitle(), user.map(GeorchestraUser::getTitle));
-                        add(headers, SEC_NOTES, mappings.getNotes(), user.map(GeorchestraUser::getNotes));
-                        add(headers, SEC_LDAP_REMAINING_DAYS, Optional
-                                .of(user.isPresent() && user.get().getLdapWarn() != null && user.get().getLdapWarn()),
-                                user.map(GeorchestraUser::getLdapRemainingDays));
-                        add(headers, SEC_EXTERNAL_AUTHENTICATION, Optional.of(user.isPresent()),
-                                String.valueOf(user.isPresent() && user.get().getIsExternalAuth()));
-                    });
-        };
+                    add(headers, SEC_LASTUPDATED, mappings.getLastUpdated(), user.map(GeorchestraUser::getLastUpdated));
+                    add(headers, SEC_ADDRESS, mappings.getAddress(), user.map(GeorchestraUser::getPostalAddress));
+                    add(headers, SEC_TITLE, mappings.getTitle(), user.map(GeorchestraUser::getTitle));
+                    add(headers, SEC_NOTES, mappings.getNotes(), user.map(GeorchestraUser::getNotes));
+                    add(headers, SEC_LDAP_REMAINING_DAYS,
+                            Optional.of(
+                                    user.isPresent() && user.get().getLdapWarn() != null && user.get().getLdapWarn()),
+                            user.map(GeorchestraUser::getLdapRemainingDays));
+                    add(headers, SEC_EXTERNAL_AUTHENTICATION, Optional.of(user.isPresent()),
+                            String.valueOf(user.isPresent() && user.get().getIsExternalAuth()));
+                });
     }
 }

--- a/gateway/src/main/java/org/georchestra/gateway/security/CustomAccessDeniedHandler.java
+++ b/gateway/src/main/java/org/georchestra/gateway/security/CustomAccessDeniedHandler.java
@@ -4,6 +4,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.web.server.authorization.ServerAccessDeniedHandler;
 import org.springframework.web.server.ServerWebExchange;
+
 import reactor.core.publisher.Mono;
 
 public class CustomAccessDeniedHandler implements ServerAccessDeniedHandler {

--- a/gateway/src/main/java/org/georchestra/gateway/security/GeorchestraGatewaySecurityConfigProperties.java
+++ b/gateway/src/main/java/org/georchestra/gateway/security/GeorchestraGatewaySecurityConfigProperties.java
@@ -21,7 +21,6 @@ package org.georchestra.gateway.security;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import javax.validation.Valid;
@@ -192,12 +191,12 @@ public class GeorchestraGatewaySecurityConfigProperties implements Validator {
     @Override
     public void validate(Object target, Errors errors) {
         GeorchestraGatewaySecurityConfigProperties config = (GeorchestraGatewaySecurityConfigProperties) target;
-        Map<String, Server> ldap = config.getLdap();
-        if (ldap == null || ldap.isEmpty()) {
+        Map<String, Server> ldapConfig = config.getLdap();
+        if (ldapConfig == null || ldapConfig.isEmpty()) {
             return;
         }
         LdapConfigPropertiesValidations validations = new LdapConfigPropertiesValidations();
-        ldap.forEach((name, serverConfig) -> validations.validate(name, serverConfig, errors));
+        ldapConfig.forEach((name, serverConfig) -> validations.validate(name, serverConfig, errors));
     }
 
     public List<LdapServerConfig> simpleEnabled() {
@@ -205,8 +204,7 @@ public class GeorchestraGatewaySecurityConfigProperties implements Validator {
         return entries()//
                 .filter(e -> e.getValue().isEnabled())//
                 .filter(e -> !e.getValue().isExtended())//
-                .map(e -> builder.asBasicLdapConfig(e.getKey(), e.getValue()))//
-                .collect(Collectors.toList());
+                .map(e -> builder.asBasicLdapConfig(e.getKey(), e.getValue())).toList();
     }
 
     public List<ExtendedLdapConfig> extendedEnabled() {
@@ -216,7 +214,7 @@ public class GeorchestraGatewaySecurityConfigProperties implements Validator {
                 .filter(e -> !e.getValue().isActiveDirectory())//
                 .filter(e -> e.getValue().isExtended())//
                 .map(e -> builder.asExtendedLdapConfig(e.getKey(), e.getValue()))//
-                .collect(Collectors.toList());
+                .toList();
     }
 
     private Stream<Entry<String, Server>> entries() {

--- a/gateway/src/main/java/org/georchestra/gateway/security/GeorchestraUserMapper.java
+++ b/gateway/src/main/java/org/georchestra/gateway/security/GeorchestraUserMapper.java
@@ -21,7 +21,6 @@ package org.georchestra.gateway.security;
 import java.util.List;
 import java.util.Optional;
 
-import org.georchestra.ds.users.DuplicatedEmailException;
 import org.georchestra.gateway.model.GeorchestraUsers;
 import org.georchestra.gateway.security.exceptions.DuplicatedEmailFoundException;
 import org.georchestra.security.model.GeorchestraUser;

--- a/gateway/src/main/java/org/georchestra/gateway/security/ResolveGeorchestraUserGlobalFilter.java
+++ b/gateway/src/main/java/org/georchestra/gateway/security/ResolveGeorchestraUserGlobalFilter.java
@@ -18,23 +18,21 @@
  */
 package org.georchestra.gateway.security;
 
-import org.apache.commons.lang3.tuple.Pair;
+import java.net.URI;
+
 import org.georchestra.gateway.model.GeorchestraOrganizations;
 import org.georchestra.gateway.model.GeorchestraTargetConfig;
 import org.georchestra.gateway.model.GeorchestraUsers;
 import org.georchestra.gateway.security.exceptions.DuplicatedEmailFoundException;
 import org.georchestra.gateway.security.ldap.extended.ExtendedGeorchestraUser;
 import org.georchestra.security.model.GeorchestraUser;
-import org.springframework.cloud.gateway.filter.GatewayFilterChain;
 import org.georchestra.security.model.Organization;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.server.reactive.ServerHttpResponse;
+import org.springframework.cloud.gateway.filter.GatewayFilterChain;
 import org.springframework.cloud.gateway.filter.GlobalFilter;
 import org.springframework.cloud.gateway.filter.RouteToRequestUrlFilter;
 import org.springframework.cloud.gateway.route.Route;
 import org.springframework.core.Ordered;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.server.DefaultServerRedirectStrategy;
 import org.springframework.security.web.server.ServerRedirectStrategy;
 import org.springframework.web.server.ServerWebExchange;
@@ -44,9 +42,6 @@ import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import reactor.core.publisher.Mono;
-
-import java.net.URI;
-import java.util.Optional;
 
 /**
  * A {@link GlobalFilter} that resolves the {@link GeorchestraUser} from the

--- a/gateway/src/main/java/org/georchestra/gateway/security/RolesMappingsUserCustomizer.java
+++ b/gateway/src/main/java/org/georchestra/gateway/security/RolesMappingsUserCustomizer.java
@@ -74,7 +74,7 @@ public class RolesMappingsUserCustomizer implements GeorchestraUserCustomizerExt
                 .stream()//
                 .map(e -> new Matcher(toPattern(e.getKey()), e.getValue()))//
                 .peek(m -> log.info("Loaded role mapping {}", m))//
-                .collect(Collectors.toList());
+                .toList();
     }
 
     static Pattern toPattern(String role) {
@@ -88,7 +88,7 @@ public class RolesMappingsUserCustomizer implements GeorchestraUserCustomizerExt
         Set<String> additionalRoles = computeAdditionalRoles(mappedUser.getRoles());
         if (!additionalRoles.isEmpty()) {
             additionalRoles.addAll(mappedUser.getRoles());
-            mappedUser.setRoles(new ArrayList<>(additionalRoles));
+            mappedUser.setRoles(new ArrayList<>(additionalRoles));// mutable
         }
         return mappedUser;
     }
@@ -107,7 +107,7 @@ public class RolesMappingsUserCustomizer implements GeorchestraUserCustomizerExt
     private List<String> computeAdditionalRoles(@NonNull String authenticatedRole) {
 
         List<String> roles = rolesMappings.stream().filter(m -> m.matches(authenticatedRole))
-                .map(Matcher::getExtraRoles).flatMap(List::stream).collect(Collectors.toList());
+                .map(Matcher::getExtraRoles).flatMap(List::stream).toList();
 
         log.info("Computed additional roles for {}: {}", authenticatedRole, roles);
         return roles;

--- a/gateway/src/main/java/org/georchestra/gateway/security/accessrules/AccessRulesCustomizer.java
+++ b/gateway/src/main/java/org/georchestra/gateway/security/accessrules/AccessRulesCustomizer.java
@@ -20,7 +20,6 @@ package org.georchestra.gateway.security.accessrules;
 
 import java.util.List;
 import java.util.Objects;
-import java.util.stream.Collectors;
 
 import org.georchestra.gateway.model.GatewayConfigProperties;
 import org.georchestra.gateway.model.RoleBasedAccessRule;
@@ -125,7 +124,7 @@ public class AccessRulesCustomizer implements ServerHttpSecurityCustomizer {
     }
 
     private List<String> resolveRoles(List<String> antPatterns, List<String> allowedRoles) {
-        return allowedRoles.stream().map(this::ensureRolePrefix).collect(Collectors.toList());
+        return allowedRoles.stream().map(this::ensureRolePrefix).toList();
     }
 
     @VisibleForTesting

--- a/gateway/src/main/java/org/georchestra/gateway/security/ldap/LdapAuthenticationConfiguration.java
+++ b/gateway/src/main/java/org/georchestra/gateway/security/ldap/LdapAuthenticationConfiguration.java
@@ -19,7 +19,6 @@
 package org.georchestra.gateway.security.ldap;
 
 import java.util.List;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.georchestra.gateway.security.GeorchestraGatewaySecurityConfigProperties;
@@ -91,13 +90,12 @@ public class LdapAuthenticationConfiguration {
     }
 
     @Bean
-    public ServerHttpSecurityCustomizer ldapHttpBasicLoginFormEnablerExtension() {
+    ServerHttpSecurityCustomizer ldapHttpBasicLoginFormEnablerExtension() {
         return new LDAPAuthenticationCustomizer();
     }
 
     @Bean
-    public AuthenticationWebFilter ldapAuthenticationWebFilter(
-            ReactiveAuthenticationManager ldapAuthenticationManager) {
+    AuthenticationWebFilter ldapAuthenticationWebFilter(ReactiveAuthenticationManager ldapAuthenticationManager) {
 
         AuthenticationWebFilter ldapAuthFilter = new AuthenticationWebFilter(ldapAuthenticationManager);
         ldapAuthFilter.setRequiresAuthenticationMatcher(ServerWebExchangeMatchers.pathMatchers("/auth/login"));
@@ -105,11 +103,11 @@ public class LdapAuthenticationConfiguration {
     }
 
     @Bean
-    public ReactiveAuthenticationManager ldapAuthenticationManager(List<BasicLdapAuthenticationProvider> basic,
+    ReactiveAuthenticationManager ldapAuthenticationManager(List<BasicLdapAuthenticationProvider> basic,
             List<GeorchestraLdapAuthenticationProvider> extended) {
 
         List<AuthenticationProvider> flattened = Stream.concat(basic.stream(), extended.stream())
-                .map(AuthenticationProvider.class::cast).collect(Collectors.toList());
+                .map(AuthenticationProvider.class::cast).toList();
 
         if (flattened.isEmpty())
             return null;

--- a/gateway/src/main/java/org/georchestra/gateway/security/ldap/basic/BasicLdapAuthenticatedUserMapper.java
+++ b/gateway/src/main/java/org/georchestra/gateway/security/ldap/basic/BasicLdapAuthenticatedUserMapper.java
@@ -19,10 +19,10 @@
 
 package org.georchestra.gateway.security.ldap.basic;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 import org.georchestra.gateway.security.GeorchestraUserMapperExtension;
 import org.georchestra.security.api.UsersApi;
@@ -60,10 +60,9 @@ public class BasicLdapAuthenticatedUserMapper implements GeorchestraUserMapperEx
 
         GeorchestraUser user = new GeorchestraUser();
         user.setUsername(username);
-        user.setRoles(roles);
+        user.setRoles(new ArrayList<>(roles));//mutable
 
-        if (principal instanceof Person) {
-            Person person = (Person) principal;
+        if (principal instanceof Person person) {
             String description = person.getDescription();
             String givenName = person.getGivenName();
             String telephoneNumber = person.getTelephoneNumber();
@@ -75,6 +74,6 @@ public class BasicLdapAuthenticatedUserMapper implements GeorchestraUserMapperEx
     }
 
     protected List<String> resolveRoles(Collection<? extends GrantedAuthority> authorities) {
-        return authorities.stream().map(GrantedAuthority::getAuthority).collect(Collectors.toList());
+        return authorities.stream().map(GrantedAuthority::getAuthority).toList();
     }
 }

--- a/gateway/src/main/java/org/georchestra/gateway/security/ldap/basic/BasicLdapAuthenticationConfiguration.java
+++ b/gateway/src/main/java/org/georchestra/gateway/security/ldap/basic/BasicLdapAuthenticationConfiguration.java
@@ -19,10 +19,9 @@
 package org.georchestra.gateway.security.ldap.basic;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
-import org.georchestra.gateway.security.ServerHttpSecurityCustomizer;
 import org.georchestra.gateway.security.GeorchestraGatewaySecurityConfigProperties;
+import org.georchestra.gateway.security.ServerHttpSecurityCustomizer;
 import org.georchestra.gateway.security.ldap.extended.ExtendedLdapAuthenticationConfiguration;
 import org.springframework.beans.factory.BeanCreationException;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -71,7 +70,7 @@ import lombok.extern.slf4j.Slf4j;
 public class BasicLdapAuthenticationConfiguration {
 
     @Bean
-    public BasicLdapAuthenticatedUserMapper ldapAuthenticatedUserMapper(List<LdapServerConfig> enabledConfigs) {
+    BasicLdapAuthenticatedUserMapper ldapAuthenticatedUserMapper(List<LdapServerConfig> enabledConfigs) {
         return enabledConfigs.isEmpty() ? null : new BasicLdapAuthenticatedUserMapper();
     }
 
@@ -82,7 +81,7 @@ public class BasicLdapAuthenticationConfiguration {
 
     @Bean
     List<BasicLdapAuthenticationProvider> ldapAuthenticationProviders(List<LdapServerConfig> configs) {
-        return configs.stream().map(this::createLdapProvider).collect(Collectors.toList());
+        return configs.stream().map(this::createLdapProvider).toList();
     }
 
     private BasicLdapAuthenticationProvider createLdapProvider(LdapServerConfig config) {

--- a/gateway/src/main/java/org/georchestra/gateway/security/ldap/basic/LdapAuthenticatorProviderBuilder.java
+++ b/gateway/src/main/java/org/georchestra/gateway/security/ldap/basic/LdapAuthenticatorProviderBuilder.java
@@ -30,7 +30,6 @@ import org.springframework.security.core.authority.mapping.SimpleAuthorityMapper
 import org.springframework.security.ldap.authentication.BindAuthenticator;
 import org.springframework.security.ldap.search.FilterBasedLdapUserSearch;
 import org.springframework.security.ldap.userdetails.DefaultLdapAuthoritiesPopulator;
-import org.springframework.security.ldap.userdetails.LdapUserDetailsMapper;
 
 import lombok.Setter;
 import lombok.experimental.Accessors;

--- a/gateway/src/main/java/org/georchestra/gateway/security/ldap/extended/DemultiplexingUsersApi.java
+++ b/gateway/src/main/java/org/georchestra/gateway/security/ldap/extended/DemultiplexingUsersApi.java
@@ -19,7 +19,6 @@
 
 package org.georchestra.gateway.security.ldap.extended;
 
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Objects;

--- a/gateway/src/main/java/org/georchestra/gateway/security/ldap/extended/ExtendedGeorchestraUser.java
+++ b/gateway/src/main/java/org/georchestra/gateway/security/ldap/extended/ExtendedGeorchestraUser.java
@@ -5,7 +5,6 @@ import org.georchestra.security.model.Organization;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
-import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;

--- a/gateway/src/main/java/org/georchestra/gateway/security/ldap/extended/ExtendedLdapAuthenticationConfiguration.java
+++ b/gateway/src/main/java/org/georchestra/gateway/security/ldap/extended/ExtendedLdapAuthenticationConfiguration.java
@@ -25,20 +25,23 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 import org.georchestra.ds.orgs.OrgsDao;
 import org.georchestra.ds.orgs.OrgsDaoImpl;
 import org.georchestra.ds.roles.RoleDao;
 import org.georchestra.ds.roles.RoleDaoImpl;
 import org.georchestra.ds.roles.RoleProtected;
-import org.georchestra.ds.security.*;
+import org.georchestra.ds.security.OrganizationMapperImpl;
+import org.georchestra.ds.security.OrganizationsApiImpl;
+import org.georchestra.ds.security.UserMapper;
+import org.georchestra.ds.security.UserMapperImpl;
+import org.georchestra.ds.security.UsersApiImpl;
 import org.georchestra.ds.users.AccountDao;
 import org.georchestra.ds.users.AccountDaoImpl;
 import org.georchestra.ds.users.UserRule;
-import org.georchestra.gateway.security.GeorchestraUserMapperExtension;
 import org.georchestra.gateway.security.GeorchestraGatewaySecurityConfigProperties;
 import org.georchestra.gateway.security.GeorchestraGatewaySecurityConfigProperties.Server;
+import org.georchestra.gateway.security.GeorchestraUserMapperExtension;
 import org.georchestra.gateway.security.ldap.basic.LdapAuthenticatorProviderBuilder;
 import org.georchestra.security.api.OrganizationsApi;
 import org.georchestra.security.api.UsersApi;
@@ -78,7 +81,7 @@ public class ExtendedLdapAuthenticationConfiguration {
 
     @Bean
     List<GeorchestraLdapAuthenticationProvider> extendedLdapAuthenticationProviders(List<ExtendedLdapConfig> configs) {
-        return configs.stream().map(this::createLdapProvider).collect(Collectors.toList());
+        return configs.stream().map(this::createLdapProvider).toList();
     }
 
     private GeorchestraLdapAuthenticationProvider createLdapProvider(ExtendedLdapConfig config) {

--- a/gateway/src/main/java/org/georchestra/gateway/security/ldap/extended/GeorchestraLdapAuthenticatedUserMapper.java
+++ b/gateway/src/main/java/org/georchestra/gateway/security/ldap/extended/GeorchestraLdapAuthenticatedUserMapper.java
@@ -19,10 +19,9 @@
 
 package org.georchestra.gateway.security.ldap.extended;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.georchestra.gateway.security.GeorchestraUserMapperExtension;
@@ -84,9 +83,8 @@ class GeorchestraLdapAuthenticatedUserMapper implements GeorchestraUserMapperExt
 
         Stream<String> userRoles = user.getRoles().stream().map(this::normalize);
 
-        List<String> roles = Stream.concat(authorityRoleNames, userRoles).distinct().collect(Collectors.toList());
-
-        user.setRoles(roles);
+        List<String> roles = Stream.concat(authorityRoleNames, userRoles).distinct().toList();
+        user.setRoles(new ArrayList<>(roles));// mutable
         if (principal.getTimeBeforeExpiration() < Integer.MAX_VALUE) {
             user.setLdapWarn(true);
             user.setLdapRemainingDays(String.valueOf(principal.getTimeBeforeExpiration() / (60 * 60 * 24)));

--- a/gateway/src/main/java/org/georchestra/gateway/security/oauth2/OAuth2UserMapper.java
+++ b/gateway/src/main/java/org/georchestra/gateway/security/oauth2/OAuth2UserMapper.java
@@ -19,13 +19,13 @@
 
 package org.georchestra.gateway.security.oauth2;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
 
 import org.georchestra.gateway.security.GeorchestraUserMapperExtension;
 import org.georchestra.security.model.GeorchestraUser;
@@ -94,20 +94,19 @@ public class OAuth2UserMapper implements GeorchestraUserMapperExtension {
          */
         apply(user::setUsername, login, userName);
         apply(user::setEmail, (String) attributes.get("email"));
-        user.setRoles(roles);
+        user.setRoles(new ArrayList<>(roles));// mutable
 
         return Optional.of(user);
     }
 
     protected List<String> resolveRoles(Collection<? extends GrantedAuthority> authorities) {
-        List<String> roles = authorities.stream().map(GrantedAuthority::getAuthority).filter(scope -> {
+        return authorities.stream().map(GrantedAuthority::getAuthority).filter(scope -> {
             if (scope.startsWith("ROLE_SCOPE_") || scope.startsWith("SCOPE_")) {
                 logger().debug("Excluding granted authority {}", scope);
                 return false;
             }
             return true;
-        }).collect(Collectors.toList());
-        return roles;
+        }).toList();
     }
 
     protected void apply(Consumer<String> setter, String... candidates) {

--- a/gateway/src/main/java/org/georchestra/gateway/security/preauth/HeaderPreauthConfigProperties.java
+++ b/gateway/src/main/java/org/georchestra/gateway/security/preauth/HeaderPreauthConfigProperties.java
@@ -18,8 +18,6 @@
  */
 package org.georchestra.gateway.security.preauth;
 
-import java.util.List;
-
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 import lombok.Data;

--- a/gateway/src/main/java/org/georchestra/gateway/security/preauth/PreauthAuthenticationManager.java
+++ b/gateway/src/main/java/org/georchestra/gateway/security/preauth/PreauthAuthenticationManager.java
@@ -18,16 +18,15 @@
  */
 package org.georchestra.gateway.security.preauth;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import lombok.RequiredArgsConstructor;
 import org.georchestra.commons.security.SecurityHeaders;
 import org.georchestra.security.model.GeorchestraUser;
-import org.ldaptive.io.Base64;
 import org.springframework.http.HttpHeaders;
 import org.springframework.security.authentication.ReactiveAuthenticationManager;
 import org.springframework.security.core.Authentication;
@@ -84,8 +83,7 @@ public class PreauthAuthenticationManager implements ReactiveAuthenticationManag
     public static boolean isPreAuthenticated(ServerWebExchange exchange) {
         HttpHeaders requestHeaders = exchange.getRequest().getHeaders();
         final String preAuthHeader = requestHeaders.getFirst(PREAUTH_HEADER_NAME);
-        final boolean preAuthenticated = "true".equalsIgnoreCase(preAuthHeader);
-        return preAuthenticated;
+        return Boolean.parseBoolean(preAuthHeader);
     }
 
     public static GeorchestraUser map(Map<String, String> requestHeaders) {
@@ -102,7 +100,7 @@ public class PreauthAuthenticationManager implements ReactiveAuthenticationManag
                 .map(roles -> Stream
                         .concat(Stream.of("ROLE_USER"), Stream.of(roles.split(";")).filter(StringUtils::hasText))
                         .distinct())
-                .orElse(Stream.of("ROLE_USER")).collect(Collectors.toList());
+                .orElse(Stream.of("ROLE_USER")).toList();
 
         GeorchestraUser user = new GeorchestraUser();
         user.setUsername(username);
@@ -110,7 +108,7 @@ public class PreauthAuthenticationManager implements ReactiveAuthenticationManag
         user.setFirstName(firstName);
         user.setLastName(lastName);
         user.setOrganization(org);
-        user.setRoles(roleNames);
+        user.setRoles(new ArrayList<>(roleNames));// mutable
         user.setOAuth2Provider(provider);
         user.setOAuth2Uid(providerId);
         // TODO rename oauth2 fields to a more generic name : externalProvider ?

--- a/gateway/src/main/java/org/georchestra/gateway/security/preauth/PreauthenticatedUserMapperExtension.java
+++ b/gateway/src/main/java/org/georchestra/gateway/security/preauth/PreauthenticatedUserMapperExtension.java
@@ -21,7 +21,6 @@ package org.georchestra.gateway.security.preauth;
 import java.util.Map;
 import java.util.Optional;
 
-import lombok.RequiredArgsConstructor;
 import org.georchestra.gateway.security.GeorchestraUserMapperExtension;
 import org.georchestra.security.model.GeorchestraUser;
 import org.springframework.security.core.Authentication;

--- a/gateway/src/test/java/org/georchestra/gateway/accounts/admin/CreateAccountUserCustomizerIT.java
+++ b/gateway/src/test/java/org/georchestra/gateway/accounts/admin/CreateAccountUserCustomizerIT.java
@@ -1,10 +1,14 @@
 package org.georchestra.gateway.accounts.admin;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.Map;
+
 import org.georchestra.ds.orgs.OrgsDao;
-import org.georchestra.ds.users.Account;
 import org.georchestra.ds.users.AccountDao;
 import org.georchestra.gateway.app.GeorchestraGatewayApplication;
-import org.georchestra.gateway.security.preauth.HeaderPreauthConfigProperties;
 import org.georchestra.testcontainers.ldap.GeorchestraLdapContainer;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.AfterAll;
@@ -13,16 +17,11 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.context.ApplicationContext;
 import org.springframework.ldap.NameNotFoundException;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.test.web.reactive.server.WebTestClient;
-
-import java.util.Map;
-
-import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Integration tests for {@link CreateAccountUserCustomizer}.
@@ -33,7 +32,6 @@ import static org.junit.jupiter.api.Assertions.*;
 public class CreateAccountUserCustomizerIT {
     private @Autowired WebTestClient testClient;
 
-    private @Autowired ApplicationContext context;
     private @Autowired AccountDao accountDao;
 
     private @Autowired OrgsDao orgsDao;
@@ -101,7 +99,8 @@ public class CreateAccountUserCustomizerIT {
         return spec;
     }
 
-    public @Test void testPreauthenticatedHeadersAccess() throws Exception {
+    @Test
+    void testPreauthenticatedHeadersAccess() throws Exception {
         prepareWebTestClientHeaders(testClient.get(), NOT_EXISTING_ACCOUNT_HEADERS).uri("/whoami")//
                 .exchange()//
                 .expectStatus()//
@@ -113,7 +112,8 @@ public class CreateAccountUserCustomizerIT {
         assertNotNull(accountDao.findByUID("pmartin"));
     }
 
-    public @Test void testPreauthenticatedHeadersAccessCreateOrg() throws Exception {
+    @Test
+    void testPreauthenticatedHeadersAccessCreateOrg() throws Exception {
         assertThrows(NameNotFoundException.class, () -> accountDao.findByUID("pmartin2"));
         prepareWebTestClientHeaders(testClient.get(), ANOTHER_NOT_EXISTING_ACCOUNT_HEADERS).uri("/whoami")//
                 .exchange()//
@@ -131,7 +131,8 @@ public class CreateAccountUserCustomizerIT {
         assertNotNull(orgsDao.findByCommonName("NEWORG"));
     }
 
-    public @Test void testPreauthenticatedHeadersAccessUpdateOrg() throws Exception {
+    @Test
+    void testPreauthenticatedHeadersAccessUpdateOrg() throws Exception {
         assertThrows(NameNotFoundException.class, () -> accountDao.findByUID("pmartin3"));
         prepareWebTestClientHeaders(testClient.get(), ANOTHER_NOT_EXISTING_ACCOUNT_HEADERS_EXISTING_ORG)//
                 .uri("/whoami")//
@@ -145,10 +146,11 @@ public class CreateAccountUserCustomizerIT {
         // Make sure the account has been created
         assertNotNull(accountDao.findByUID("pmartin3"));
         // And the PSC organization contains our newly created user
-        assertNotNull(orgsDao.findByCommonName("PSC").getMembers().contains("pmartin3"));
+        assertThat(orgsDao.findByCommonName("PSC").getMembers()).contains("pmartin3");
     }
 
-    public @Test void testPreauthenticatedHeadersAccessExistingAccount() throws Exception {
+    @Test
+    void testPreauthenticatedHeadersAccessExistingAccount() throws Exception {
         // the account should already exist before issuing the request
         assertNotNull(accountDao.findByUID("testadmin"));
         prepareWebTestClientHeaders(testClient.get(), EXISTING_ADMIN_ACCOUNT_HEADERS).uri("/whoami")//
@@ -166,7 +168,8 @@ public class CreateAccountUserCustomizerIT {
                         "ROLE_EMAILPROXY"));
     }
 
-    public @Test void testPreauthenticatedHeadersWithOrgNotNullButEmpty() throws Exception {
+    @Test
+    void testPreauthenticatedHeadersWithOrgNotNullButEmpty() {
         prepareWebTestClientHeaders(testClient.get(), NON_EXISTING_USER_WITH_ORG_EMPTY_HEADERS).uri("/whoami")//
                 .exchange()//
                 .expectStatus()//

--- a/gateway/src/test/java/org/georchestra/gateway/accounts/admin/ldap/GeorchestraLdapAccessConfigurationTest.java
+++ b/gateway/src/test/java/org/georchestra/gateway/accounts/admin/ldap/GeorchestraLdapAccessConfigurationTest.java
@@ -18,6 +18,8 @@
  */
 package org.georchestra.gateway.accounts.admin.ldap;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.georchestra.ds.orgs.OrgsDao;
 import org.georchestra.ds.users.AccountDao;
 import org.georchestra.gateway.security.ldap.extended.ExtendedLdapAuthenticationConfiguration;
@@ -25,14 +27,13 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.context.annotation.UserConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 public class GeorchestraLdapAccessConfigurationTest {
 
     private ApplicationContextRunner runner = new ApplicationContextRunner().withConfiguration(UserConfigurations
             .of(GeorchestraLdapAccountManagementConfiguration.class, ExtendedLdapAuthenticationConfiguration.class));
 
-    public @Test void accountsAndRolesDaoRelatedBeansAreAvailable() {
+    @Test
+    void accountsAndRolesDaoRelatedBeansAreAvailable() {
         runner.withPropertyValues(""//
         // Georchestra extended LDAP default config
                 , "georchestra.gateway.security.ldap.default.enabled: true" //
@@ -53,7 +54,8 @@ public class GeorchestraLdapAccessConfigurationTest {
         });
     }
 
-    public @Test void contextShouldFailIfCreateNonExistingTrueButNoDefaultExtendedLdap() {
+    @Test
+    void contextShouldFailIfCreateNonExistingTrueButNoDefaultExtendedLdap() {
         runner.withPropertyValues(""//
                 , "georchestra.gateway.security.ldap.default.enabled: false" //
                 , "georchestra.gateway.security.create-non-existing-users-in-l-d-a-p: true" //

--- a/gateway/src/test/java/org/georchestra/gateway/app/GeorchestraGatewayApplicationTests.java
+++ b/gateway/src/test/java/org/georchestra/gateway/app/GeorchestraGatewayApplicationTests.java
@@ -46,9 +46,10 @@ import org.springframework.http.HttpStatus;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.TestPropertySources;
 import org.springframework.test.web.reactive.server.WebTestClient;
 import org.springframework.web.server.ServerWebExchange;
+
+import reactor.core.publisher.Mono;
 
 @SpringBootTest(properties = "georchestra.datadir=src/test/resources/test-datadir", webEnvironment = WebEnvironment.MOCK)
 @AutoConfigureWebTestClient(timeout = "PT200S")
@@ -58,9 +59,10 @@ class GeorchestraGatewayApplicationTests {
     private @Autowired Environment env;
     private @Autowired RouteLocator routeLocator;
 
-    private @Autowired GeorchestraGatewayApplication application;
     private @Autowired WebTestClient testClient;
 
+    private @Autowired WhoamiController whoamiController;
+    private @Autowired StyleConfigController configController;
     private @Autowired ApplicationContext context;
 
     @Test
@@ -94,7 +96,7 @@ class GeorchestraGatewayApplicationTests {
         Authentication auth = new GeorchestraUserNamePasswordAuthenticationToken("test", orig);
         ServerWebExchange exch = Mockito.mock(ServerWebExchange.class);
 
-        Map<String, Object> ret = application.whoami(auth, exch).block();
+        Map<String, Object> ret = whoamiController.whoami(auth, exch).block();
 
         GeorchestraUserNamePasswordAuthenticationToken toTest = (GeorchestraUserNamePasswordAuthenticationToken) ret
                 .get("org.georchestra.gateway.security.ldap.extended.GeorchestraUserNamePasswordAuthenticationToken");
@@ -121,5 +123,13 @@ class GeorchestraGatewayApplicationTests {
         testClient.get().uri("/path/to/unavailable/service")//
                 .header("Host", "localhost")//
                 .exchange().expectStatus().isEqualTo(HttpStatus.SERVICE_UNAVAILABLE);
+    }
+
+    @Test
+    void testStyleConfigController() {
+        Mono<Map<String, Object>> response = configController.styleConfig();
+        assertThat(response).isNotNull();
+        Map<String, Object> config = response.block();
+        assertThat(config).containsKey("stylesheet").containsKey("logo");
     }
 }

--- a/gateway/src/test/java/org/georchestra/gateway/autoconfigure/accounts/RabbitmqEventsAutoConfigurationTest.java
+++ b/gateway/src/test/java/org/georchestra/gateway/autoconfigure/accounts/RabbitmqEventsAutoConfigurationTest.java
@@ -2,8 +2,6 @@ package org.georchestra.gateway.autoconfigure.accounts;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.assertj.core.api.InstanceOfAssertFactories;
-import org.assertj.core.api.InstanceOfAssertFactory;
 import org.georchestra.gateway.accounts.events.rabbitmq.RabbitmqAccountCreatedEventSender;
 import org.georchestra.gateway.accounts.events.rabbitmq.RabbitmqEventsConfiguration;
 import org.junit.jupiter.api.Test;

--- a/gateway/src/test/java/org/georchestra/gateway/autoconfigure/security/HeaderPreAuthenticationAutoConfigurationTest.java
+++ b/gateway/src/test/java/org/georchestra/gateway/autoconfigure/security/HeaderPreAuthenticationAutoConfigurationTest.java
@@ -12,7 +12,8 @@ public class HeaderPreAuthenticationAutoConfigurationTest {
     private ApplicationContextRunner runner = new ApplicationContextRunner()
             .withConfiguration(AutoConfigurations.of(HeaderPreAuthenticationAutoConfiguration.class));
 
-    public @Test void resolveHttpHeadersGeorchestraUserFilterIsAvailable() {
+    @Test
+    void resolveHttpHeadersGeorchestraUserFilterIsAvailable() {
         runner.withPropertyValues(""//
                 , "georchestra.gateway.security.header-authentication.enabled: true" //
         ).run(context -> {
@@ -21,7 +22,8 @@ public class HeaderPreAuthenticationAutoConfigurationTest {
         });
     }
 
-    public @Test void resolveHttpHeadersGeorchestraUserFilterIsUnavailable() {
+    @Test
+    void resolveHttpHeadersGeorchestraUserFilterIsUnavailable() {
         runner.withPropertyValues(""//
                 , "georchestra.gateway.security.header-authentication.enabled: false" //
         ).run(context -> {

--- a/gateway/src/test/java/org/georchestra/gateway/autoconfigure/security/LdapSecurityAutoConfigurationTest.java
+++ b/gateway/src/test/java/org/georchestra/gateway/autoconfigure/security/LdapSecurityAutoConfigurationTest.java
@@ -21,9 +21,9 @@ package org.georchestra.gateway.autoconfigure.security;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import org.georchestra.gateway.security.GeorchestraGatewaySecurityConfigProperties;
 import org.georchestra.gateway.security.ldap.LdapAuthenticationConfiguration;
 import org.georchestra.gateway.security.ldap.LdapAuthenticationConfiguration.LDAPAuthenticationCustomizer;
-import org.georchestra.gateway.security.GeorchestraGatewaySecurityConfigProperties;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;

--- a/gateway/src/test/java/org/georchestra/gateway/filter/global/LoginParamRedirectGatewayFilterFactoryTest.java
+++ b/gateway/src/test/java/org/georchestra/gateway/filter/global/LoginParamRedirectGatewayFilterFactoryTest.java
@@ -30,7 +30,6 @@ import static org.mockito.Mockito.when;
 
 import java.util.List;
 
-import org.georchestra.gateway.autoconfigure.app.FiltersAutoConfiguration;
 import org.georchestra.gateway.filter.global.LoginParamRedirectGatewayFilterFactory.LoginParamRedirectGatewayFilter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;

--- a/gateway/src/test/java/org/georchestra/gateway/filter/headers/providers/GeorchestraUserHeadersContributorTest.java
+++ b/gateway/src/test/java/org/georchestra/gateway/filter/headers/providers/GeorchestraUserHeadersContributorTest.java
@@ -19,7 +19,18 @@
 
 package org.georchestra.gateway.filter.headers.providers;
 
-import static org.georchestra.commons.security.SecurityHeaders.*;
+import static org.georchestra.commons.security.SecurityHeaders.SEC_ADDRESS;
+import static org.georchestra.commons.security.SecurityHeaders.SEC_EMAIL;
+import static org.georchestra.commons.security.SecurityHeaders.SEC_EXTERNAL_AUTHENTICATION;
+import static org.georchestra.commons.security.SecurityHeaders.SEC_FIRSTNAME;
+import static org.georchestra.commons.security.SecurityHeaders.SEC_LASTNAME;
+import static org.georchestra.commons.security.SecurityHeaders.SEC_NOTES;
+import static org.georchestra.commons.security.SecurityHeaders.SEC_ORG;
+import static org.georchestra.commons.security.SecurityHeaders.SEC_ROLES;
+import static org.georchestra.commons.security.SecurityHeaders.SEC_TEL;
+import static org.georchestra.commons.security.SecurityHeaders.SEC_TITLE;
+import static org.georchestra.commons.security.SecurityHeaders.SEC_USERID;
+import static org.georchestra.commons.security.SecurityHeaders.SEC_USERNAME;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;

--- a/gateway/src/test/java/org/georchestra/gateway/model/HeaderMappingsTest.java
+++ b/gateway/src/test/java/org/georchestra/gateway/model/HeaderMappingsTest.java
@@ -19,7 +19,6 @@
 package org.georchestra.gateway.model;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
 
 import org.junit.jupiter.api.Test;
 

--- a/gateway/src/test/java/org/georchestra/gateway/security/DefaultVsCustomGeorchestraHeadersConfigIT.java
+++ b/gateway/src/test/java/org/georchestra/gateway/security/DefaultVsCustomGeorchestraHeadersConfigIT.java
@@ -26,7 +26,6 @@ import org.springframework.test.web.reactive.server.WebTestClient;
 import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
 import com.github.tomakehurst.wiremock.junit5.WireMockTest;
 import com.github.tomakehurst.wiremock.stubbing.ServeEvent;
-import com.google.common.base.Optional;
 
 @SpringBootTest(classes = GeorchestraGatewayApplication.class)
 @WireMockTest

--- a/gateway/src/test/java/org/georchestra/gateway/security/ResolveGeorchestraUserGlobalFilterIT.java
+++ b/gateway/src/test/java/org/georchestra/gateway/security/ResolveGeorchestraUserGlobalFilterIT.java
@@ -1,10 +1,14 @@
 package org.georchestra.gateway.security;
 
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.util.List;
+import java.util.Optional;
+
 import org.georchestra.gateway.accounts.admin.CreateAccountUserCustomizer;
 import org.georchestra.gateway.app.GeorchestraGatewayApplication;
 import org.georchestra.gateway.filter.headers.providers.JsonPayloadHeadersContributor;
 import org.georchestra.gateway.model.GatewayConfigProperties;
-import org.georchestra.gateway.model.HeaderMappings;
 import org.georchestra.gateway.security.preauth.PreauthAuthenticationManager;
 import org.georchestra.testcontainers.ldap.GeorchestraLdapContainer;
 import org.junit.jupiter.api.AfterAll;
@@ -20,12 +24,6 @@ import org.springframework.test.web.reactive.server.WebTestClient;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.utility.DockerImageName;
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.Optional;
-
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-
 @SpringBootTest(classes = GeorchestraGatewayApplication.class)
 @AutoConfigureWebTestClient(timeout = "PT200S")
 @ActiveProfiles("georheaders")
@@ -39,7 +37,8 @@ public class ResolveGeorchestraUserGlobalFilterIT {
 
     private @Autowired ApplicationContext context;
 
-    public static GenericContainer httpEcho = new GenericContainer(DockerImageName.parse("ealen/echo-server")) {
+    @SuppressWarnings("rawtypes")
+    public static GenericContainer<?> httpEcho = new GenericContainer(DockerImageName.parse("ealen/echo-server")) {
         @Override
         protected void doStart() {
             super.doStart();
@@ -62,7 +61,8 @@ public class ResolveGeorchestraUserGlobalFilterIT {
         httpEcho.stop();
     }
 
-    public @Test void testReceivedHeadersAsJson() {
+    @Test
+    void testReceivedHeadersAsJson() {
         gatewayConfig.getDefaultHeaders().setJsonUser(Optional.of(true));
         gatewayConfig.getDefaultHeaders().setJsonOrganization(Optional.of(true));
         assertNotNull(context.getBean(JsonPayloadHeadersContributor.class));
@@ -77,7 +77,8 @@ public class ResolveGeorchestraUserGlobalFilterIT {
                 .jsonPath(".request.headers.sec-user").exists().jsonPath(".request.headers.sec-organization").exists();
     }
 
-    public @Test void testJsonUserNoOrganization() {
+    @Test
+    void testJsonUserNoOrganization() {
         gatewayConfig.getDefaultHeaders().setJsonUser(Optional.of(true));
         gatewayConfig.getDefaultHeaders().setJsonOrganization(Optional.of(false));
 
@@ -93,7 +94,8 @@ public class ResolveGeorchestraUserGlobalFilterIT {
 
     }
 
-    public @Test void testNoJsonUserJsonOrganization() {
+    @Test
+    void testNoJsonUserJsonOrganization() {
         gatewayConfig.getDefaultHeaders().setJsonUser(Optional.of(false));
         gatewayConfig.getDefaultHeaders().setJsonOrganization(Optional.of(true));
 
@@ -108,7 +110,8 @@ public class ResolveGeorchestraUserGlobalFilterIT {
                 .jsonPath(".request.headers.sec-organization").exists();
     }
 
-    public @Test void testSecOrgnamePresent() {
+    @Test
+    void testSecOrgnamePresent() {
         testClient.get().uri("/echo/")//
                 .header("Host", "localhost")//
                 .header("Authorization", "Basic dGVzdGFkbWluOnRlc3RhZG1pbg==") // testadmin:testadmin

--- a/gateway/src/test/java/org/georchestra/gateway/security/accessrules/AccessRulesCustomizerIT.java
+++ b/gateway/src/test/java/org/georchestra/gateway/security/accessrules/AccessRulesCustomizerIT.java
@@ -128,7 +128,8 @@ class AccessRulesCustomizerIT {
      * }
      * </pre>
      */
-    public @Test void testSimpleMapping_anonymous() {
+    @Test
+    void testSimpleMapping_anonymous() {
         mockService.stubFor(get(urlMatching("/header(/.*)?"))//
                 .withHeader("sec-proxy", equalTo("true"))//
                 .willReturn(ok()));
@@ -150,7 +151,8 @@ class AccessRulesCustomizerIT {
      *     anonymous: false
      * }
      */
-    public @Test void testService_unauthorized_if_not_logged_in_and_requires_any_authenticated_user() {
+    @Test
+    void testService_unauthorized_if_not_logged_in_and_requires_any_authenticated_user() {
         mockService.stubFor(get(urlMatching("/import(/.*)?")).willReturn(noContent()));
 
         testClient.get().uri("/import")//
@@ -172,7 +174,8 @@ class AccessRulesCustomizerIT {
      * }
      */
     @WithMockUser(authorities = { "ROLE_DOESNTMATTER" })
-    public @Test void testService_requires_any_authenticated_user() {
+    @Test
+    void testService_requires_any_authenticated_user() {
         mockService.stubFor(get(urlMatching("/import(/.*)?")).willReturn(ok()));
 
         testClient.get().uri("/import")//
@@ -196,7 +199,8 @@ class AccessRulesCustomizerIT {
      * }
      */
     @WithMockUser(authorities = { "ROLE_USER", "ROLE_EDITOR" })
-    public @Test void testService_requires_specific_role_forbidden_for_non_matching_roles() {
+    @Test
+    void testService_requires_specific_role_forbidden_for_non_matching_roles() {
         mockService.stubFor(get(urlMatching("/analytics(/.*)?")).willReturn(ok()));
 
         testClient.get().uri("/analytics")//
@@ -218,7 +222,8 @@ class AccessRulesCustomizerIT {
      * }
      */
     @WithMockUser(authorities = { "ROLE_USER", "ROLE_ORGADMIN" })
-    public @Test void testService_requires_specific_role_allowed_for_matching_roles() {
+    @Test
+    void testService_requires_specific_role_allowed_for_matching_roles() {
         mockService.stubFor(get(urlMatching("/analytics(/.*)?")).willReturn(ok()));
 
         testClient.get().uri("/analytics")//
@@ -241,7 +246,8 @@ class AccessRulesCustomizerIT {
      *     allowed-roles: SUPERUSER,ORGADMIN
      * }
      */
-    public @Test void testService_unauthorized_if_not_logged_in_and_requires_role() {
+    @Test
+    void testService_unauthorized_if_not_logged_in_and_requires_role() {
         mockService.stubFor(get(urlMatching("/analytics(/.*)?")).willReturn(ok()));
 
         testClient.get().uri("/analytics")//

--- a/gateway/src/test/java/org/georchestra/gateway/security/ldap/LdapConfigPropertiesValidationsTest.java
+++ b/gateway/src/test/java/org/georchestra/gateway/security/ldap/LdapConfigPropertiesValidationsTest.java
@@ -49,14 +49,16 @@ class LdapConfigPropertiesValidationsTest {
     private ApplicationContextRunner runner = new ApplicationContextRunner()
             .withUserConfiguration(EnableConfigProps.class);
 
-    public @Test void no_ldap_configs() {
+    @Test
+    void no_ldap_configs() {
         runner.run(context -> {
             assertThat(context).hasSingleBean(GeorchestraGatewaySecurityConfigProperties.class);
             assertThat(context.getBean(GeorchestraGatewaySecurityConfigProperties.class).getLdap()).isEmpty();
         });
     }
 
-    public @Test void no_ldap_enabled() {
+    @Test
+    void no_ldap_enabled() {
         runner.withPropertyValues(//
                 "georchestra.gateway.security.ldap.ldap1.enabled: false" //
                 , "georchestra.gateway.security.ldap.ldap2.enabled: false" //
@@ -70,7 +72,8 @@ class LdapConfigPropertiesValidationsTest {
         });
     }
 
-    public @Test void validates_common_url_is_mandatory_if_enabled() {
+    @Test
+    void validates_common_url_is_mandatory_if_enabled() {
         runner.withPropertyValues(""//
                 , "georchestra.gateway.security.ldap.basic1.enabled: true" //
                 , "georchestra.gateway.security.ldap.basic1.url:" //
@@ -89,7 +92,8 @@ class LdapConfigPropertiesValidationsTest {
         });
     }
 
-    public @Test void validates_common_url_not_set_does_not_fail_if_not_enabled() {
+    @Test
+    void validates_common_url_not_set_does_not_fail_if_not_enabled() {
         runner.withPropertyValues(""//
                 , "georchestra.gateway.security.ldap.basic1.enabled: false" //
                 , "georchestra.gateway.security.ldap.basic1.url:" //
@@ -98,7 +102,8 @@ class LdapConfigPropertiesValidationsTest {
         });
     }
 
-    public @Test void validates_basic_and_extended_baseDn_is_mandatory() {
+    @Test
+    void validates_basic_and_extended_baseDn_is_mandatory() {
         runner.withPropertyValues(""//
         // Basic LDAP config
                 , "georchestra.gateway.security.ldap.ldap1.enabled: true" //
@@ -116,7 +121,8 @@ class LdapConfigPropertiesValidationsTest {
         });
     }
 
-    public @Test void validates_basic_and_extended_users_rdn_is_mandatory() {
+    @Test
+    void validates_basic_and_extended_users_rdn_is_mandatory() {
         runner.withPropertyValues(""//
         // Basic LDAP config
                 , "georchestra.gateway.security.ldap.ldap1.enabled: true" //
@@ -137,7 +143,8 @@ class LdapConfigPropertiesValidationsTest {
         });
     }
 
-    public @Test void validates_basic_and_extended_users_searchFilter_is_mandatory() {
+    @Test
+    void validates_basic_and_extended_users_searchFilter_is_mandatory() {
         runner.withPropertyValues(""//
         // Basic LDAP config
                 , "georchestra.gateway.security.ldap.ldap1.enabled: true" //
@@ -160,7 +167,8 @@ class LdapConfigPropertiesValidationsTest {
         });
     }
 
-    public @Test void validates_basic_and_extended_roles_rdn_is_mandatory() {
+    @Test
+    void validates_basic_and_extended_roles_rdn_is_mandatory() {
         runner.withPropertyValues(""//
         // Basic LDAP config
                 , "georchestra.gateway.security.ldap.ldap1.enabled: true" //
@@ -185,7 +193,8 @@ class LdapConfigPropertiesValidationsTest {
         });
     }
 
-    public @Test void validates_basic_and_extended_roles_searchFilter_is_mandatory() {
+    @Test
+    void validates_basic_and_extended_roles_searchFilter_is_mandatory() {
         runner.withPropertyValues(""//
         // Basic LDAP config
                 , "georchestra.gateway.security.ldap.ldap1.enabled: true" //
@@ -212,7 +221,8 @@ class LdapConfigPropertiesValidationsTest {
         });
     }
 
-    public @Test void validates_extended_orgs_rdn_is_mandatory() {
+    @Test
+    void validates_extended_orgs_rdn_is_mandatory() {
         runner.withPropertyValues(""//
                 , "georchestra.gateway.security.ldap.extended1.enabled: true" //
                 , "georchestra.gateway.security.ldap.extended1.extended: true" //
@@ -230,7 +240,8 @@ class LdapConfigPropertiesValidationsTest {
         });
     }
 
-    public @Test void valid_single_config_basic() {
+    @Test
+    void valid_single_config_basic() {
         runner.withPropertyValues(""//
         // Basic LDAP config
                 , "georchestra.gateway.security.ldap.ldap1.enabled: true" //
@@ -259,7 +270,8 @@ class LdapConfigPropertiesValidationsTest {
         });
     }
 
-    public @Test void valid_single_config_extended() {
+    @Test
+    void valid_single_config_extended() {
         runner.withPropertyValues(""//
         // Basic LDAP config
                 , "georchestra.gateway.security.ldap.ldap1.enabled: true" //
@@ -291,7 +303,8 @@ class LdapConfigPropertiesValidationsTest {
         });
     }
 
-    public @Test void valid_multiple_configs() {
+    @Test
+    void valid_multiple_configs() {
         runner.withPropertyValues(""//
         // Basic LDAP config
                 , "georchestra.gateway.security.ldap.ldap1.enabled: true" //

--- a/gateway/src/test/java/org/georchestra/gateway/security/ldap/basic/BasicLdapAuthenticationConfigurationTest.java
+++ b/gateway/src/test/java/org/georchestra/gateway/security/ldap/basic/BasicLdapAuthenticationConfigurationTest.java
@@ -38,7 +38,8 @@ class BasicLdapAuthenticationConfigurationTest {
             .withConfiguration(UserConfigurations.of(BasicLdapAuthenticationConfiguration.class));
 
     @SuppressWarnings("unchecked")
-    public @Test void contextContributions_empty_config() {
+    @Test
+    void contextContributions_empty_config() {
         runner.run(context -> {
             assertThat(context).hasNotFailed();
             assertThat(context).getBean("enabledSimpleLdapConfigs").isInstanceOf(List.class);
@@ -51,7 +52,8 @@ class BasicLdapAuthenticationConfigurationTest {
     }
 
     @SuppressWarnings("unchecked")
-    public @Test void contextContributions_single_config() {
+    @Test
+    void contextContributions_single_config() {
         runner.withPropertyValues(""//
         // Basic LDAP config
                 , "georchestra.gateway.security.ldap.ldap1.enabled: true" //
@@ -77,7 +79,8 @@ class BasicLdapAuthenticationConfigurationTest {
     }
 
     @SuppressWarnings("unchecked")
-    public @Test void contextContributions_multiple_configs() {
+    @Test
+    void contextContributions_multiple_configs() {
         runner.withPropertyValues(""//
         // Basic LDAP config
                 , "georchestra.gateway.security.ldap.ldap1.enabled: true" //

--- a/gateway/src/test/java/org/georchestra/gateway/security/ldap/basic/BasicLdapAuthenticationIT.java
+++ b/gateway/src/test/java/org/georchestra/gateway/security/ldap/basic/BasicLdapAuthenticationIT.java
@@ -31,7 +31,8 @@ public class BasicLdapAuthenticationIT {
         ldap.stop();
     }
 
-    public @Test void testWhoamiNoPasswordRevealed() {
+    @Test
+    void testWhoamiNoPasswordRevealed() {
         testClient.get().uri("/whoami")//
                 .header("Authorization", "Basic dGVzdGFkbWluOnRlc3RhZG1pbg==") // testadmin:testadmin
                 .exchange()//

--- a/gateway/src/test/java/org/georchestra/gateway/security/ldap/extended/ExtendedLdapAuthenticationConfigurationTest.java
+++ b/gateway/src/test/java/org/georchestra/gateway/security/ldap/extended/ExtendedLdapAuthenticationConfigurationTest.java
@@ -39,7 +39,8 @@ class ExtendedLdapAuthenticationConfigurationTest {
             .withConfiguration(UserConfigurations.of(ExtendedLdapAuthenticationConfiguration.class));
 
     @SuppressWarnings("unchecked")
-    public @Test void contextContributions_empty_config() {
+    @Test
+    void contextContributions_empty_config() {
         runner.run(context -> {
             assertThat(context).hasNotFailed();
             assertThat(context).getBean("enabledExtendedLdapConfigs").isInstanceOf(List.class);
@@ -54,7 +55,8 @@ class ExtendedLdapAuthenticationConfigurationTest {
     }
 
     @SuppressWarnings("unchecked")
-    public @Test void contextContributions_single_config() {
+    @Test
+    void contextContributions_single_config() {
         runner.withPropertyValues(""//
                 , "georchestra.gateway.security.ldap.ldap1.enabled: true" //
                 , "georchestra.gateway.security.ldap.ldap1.extended: true" //
@@ -82,7 +84,8 @@ class ExtendedLdapAuthenticationConfigurationTest {
     }
 
     @SuppressWarnings("unchecked")
-    public @Test void contextContributions_multiple_configs() {
+    @Test
+    void contextContributions_multiple_configs() {
         runner.withPropertyValues(""//
                 , "georchestra.gateway.security.ldap.ldap1.enabled: true" //
                 , "georchestra.gateway.security.ldap.ldap1.extended: true" //

--- a/gateway/src/test/java/org/georchestra/gateway/security/ldap/extended/ExtendedLdapAuthenticationIT.java
+++ b/gateway/src/test/java/org/georchestra/gateway/security/ldap/extended/ExtendedLdapAuthenticationIT.java
@@ -1,8 +1,6 @@
 package org.georchestra.gateway.security.ldap.extended;
 
 import org.georchestra.gateway.app.GeorchestraGatewayApplication;
-import org.georchestra.gateway.filter.headers.providers.JsonPayloadHeadersContributor;
-import org.georchestra.gateway.model.GatewayConfigProperties;
 import org.georchestra.testcontainers.ldap.GeorchestraLdapContainer;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -10,19 +8,10 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.context.ApplicationContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.test.web.reactive.server.WebTestClient;
-import org.springframework.web.context.WebApplicationContext;
-import org.testcontainers.containers.GenericContainer;
-import org.testcontainers.utility.DockerImageName;
-
-import java.util.Arrays;
-import java.util.Optional;
-
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 @SpringBootTest(classes = GeorchestraGatewayApplication.class)
 @ActiveProfiles({ "createaccount" })
@@ -46,7 +35,8 @@ public class ExtendedLdapAuthenticationIT {
         registry.add("testcontainers.georchestra.ldap.port", ldap::getMappedLdapPort);
     }
 
-    public @Test void testWhoami() {
+    @Test
+    void testWhoami() {
         testClient.get().uri("/whoami")//
                 .header("Authorization", "Basic dGVzdGFkbWluOnRlc3RhZG1pbg==") // testadmin:testadmin
                 .exchange()//
@@ -56,7 +46,8 @@ public class ExtendedLdapAuthenticationIT {
                 .jsonPath("$.GeorchestraUser.username").isEqualTo("testadmin");
     }
 
-    public @Test void testWhoamiUsingEmail() {
+    @Test
+    void testWhoamiUsingEmail() {
         testClient.get().uri("/whoami")//
                 .header("Authorization", "Basic cHNjK3Rlc3RhZG1pbkBnZW9yY2hlc3RyYS5vcmc6dGVzdGFkbWlu") // psc+testadmin@georchestra.org:testadmin
                 .exchange()//
@@ -66,7 +57,8 @@ public class ExtendedLdapAuthenticationIT {
                 .jsonPath("$.GeorchestraUser.username").isEqualTo("testadmin");
     }
 
-    public @Test void testWhoamiNoPasswordRevealed() {
+    @Test
+    void testWhoamiNoPasswordRevealed() {
         testClient.get().uri("/whoami")//
                 .header("Authorization", "Basic dGVzdGFkbWluOnRlc3RhZG1pbg==") // testadmin:testadmin
                 .exchange()//

--- a/gateway/src/test/java/org/georchestra/gateway/security/preauth/HeaderPreAuthenticationConfigurationIT.java
+++ b/gateway/src/test/java/org/georchestra/gateway/security/preauth/HeaderPreAuthenticationConfigurationIT.java
@@ -50,7 +50,8 @@ public class HeaderPreAuthenticationConfigurationIT {
         return spec;
     }
 
-    public @Test void test_preauthenticatedHeadersAccess() {
+    @Test
+    void test_preauthenticatedHeadersAccess() {
         assertNotNull(context.getBean(PreauthGatewaySecurityCustomizer.class));
         assertNotNull(context.getBean(PreauthenticatedUserMapperExtension.class));
 
@@ -62,7 +63,8 @@ public class HeaderPreAuthenticationConfigurationIT {
                 .isNotEmpty();
     }
 
-    public @Test void test_preauthenticatedHeadersAccess_case_insensitive() {
+    @Test
+    void test_preauthenticatedHeadersAccess_case_insensitive() {
         assertNotNull(context.getBean(PreauthGatewaySecurityCustomizer.class));
         assertNotNull(context.getBean(PreauthenticatedUserMapperExtension.class));
 
@@ -75,7 +77,8 @@ public class HeaderPreAuthenticationConfigurationIT {
                 .isNotEmpty();
     }
 
-    public @Test void test_preauthenticatedHeadersAccess_isAuthenticated() {
+    @Test
+    void test_preauthenticatedHeadersAccess_isAuthenticated() {
         assertNotNull(context.getBean(PreauthGatewaySecurityCustomizer.class));
         assertNotNull(context.getBean(PreauthenticatedUserMapperExtension.class));
 


### PR DESCRIPTION
- Replaced deprecated `Collectors.toList()` with `Stream.toList()`
- Removed unnecessary imports and unused fields
- Converted redundant explicit types to inferred types (e.g., `var`, pattern matching)
- Simplified boolean parsing and redundant assignments
- Extracted helper methods to improve maintainability
- Adjusted annotations (`@Test`, `@Bean`) for better consistency
- Ensured mutable lists where necessary (`new ArrayList<>()`)
- Refactored controllers into dedicated classes (`LoginLogoutController`, `WhoamiController`, `StyleConfigController`)

These changes collectively reduce compilation warnings and enhance overall code clarity in the `georchestra-gateway` project.