### PR TITLE
Upgrade to Spring Boot 3.4 and Spring Cloud 2024

### DIFF
--- a/gateway/pom.xml
+++ b/gateway/pom.xml
@@ -13,6 +13,7 @@
     <java.version>21</java.version>
     <imageTag>${project.version}</imageTag>
     <spring-boot.build-image.imageName>georchestra/gateway:${imageTag}</spring-boot.build-image.imageName>
+    <mockito.version>5.14.2</mockito.version>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -206,14 +207,16 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
           <configuration>
-            <argLine>@{argLine} -XX:+EnableDynamicAgentLoading</argLine>
+            <argLine>-javaagent:${settings.localRepository}/org/mockito/mockito-core/${mockito.version}/mockito-core-${mockito.version}.jar
+            -Xshare:off</argLine>
           </configuration>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-failsafe-plugin</artifactId>
           <configuration>
-            <argLine>@{argLine} -XX:+EnableDynamicAgentLoading</argLine>
+            <argLine>-javaagent:${settings.localRepository}/org/mockito/mockito-core/${mockito.version}/mockito-core-${mockito.version}.jar
+            -Xshare:off</argLine>
           </configuration>
         </plugin>
       </plugins>

--- a/gateway/pom.xml
+++ b/gateway/pom.xml
@@ -363,7 +363,6 @@
             <path>
               <groupId>org.springframework.boot</groupId>
               <artifactId>spring-boot-configuration-processor</artifactId>
-              <version>2.7.12</version>
             </path>
             <path>
               <groupId>org.projectlombok</groupId>

--- a/gateway/pom.xml
+++ b/gateway/pom.xml
@@ -17,10 +17,22 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
-        <groupId>com.github.tomakehurst</groupId>
-        <artifactId>wiremock-jre8</artifactId>
-        <!-- override provided version 2.26.3 -->
-        <version>2.35.2</version>
+        <!-- https://wiremock.org/docs/spring-boot/ -->
+        <groupId>org.wiremock.integrations</groupId>
+        <artifactId>wiremock-spring-boot</artifactId>
+        <version>3.9.0</version>
+        <exclusions>
+          <exclusion>
+            <artifactId>wiremock-jetty12</artifactId>
+            <groupId>org.wiremock</groupId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>org.wiremock</groupId>
+        <artifactId>wiremock-standalone</artifactId>
+        <version>3.12.1</version>
+        <scope>test</scope>
       </dependency>
     </dependencies>
   </dependencyManagement>
@@ -86,8 +98,7 @@
     </dependency>
     <dependency>
       <!-- Annotation processor that generates metadata about classes annotated with @ConfigurationProperties. -->
-      <!-- This metadata is used by IDEs to provide auto-completion and documentation for the properties when editing application.properties 
-        and application.yaml -->
+      <!-- This metadata is used by IDEs to provide auto-completion and documentation for the properties when editing application.properties and application.yaml -->
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-configuration-processor</artifactId>
       <optional>true</optional>
@@ -111,8 +122,13 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.github.tomakehurst</groupId>
-      <artifactId>wiremock-jre8</artifactId>
+      <groupId>org.wiremock.integrations</groupId>
+      <artifactId>wiremock-spring-boot</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.wiremock</groupId>
+      <artifactId>wiremock-standalone</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -120,9 +136,9 @@
       <artifactId>spring-security-test</artifactId>
       <scope>test</scope>
     </dependency>
-    <!-- ldaptive-netscape dependecy is added to include netscape.ldap.ber.stream.BERTagDecoder
-      class required in org.springframework.security.ldap.ppolicy.PasswordPolicyResponseControl class.
-      Dependency required to handle password policy errors received from LDAP.-->
+    <!-- ldaptive-netscape dependecy is added to include netscape.ldap.ber.stream.BERTagDecoder class required
+    in org.springframework.security.ldap.ppolicy.PasswordPolicyResponseControl class.
+    Dependency required to handle password policy errors received from LDAP.-->
     <dependency>
       <groupId>org.ldaptive</groupId>
       <artifactId>ldaptive-netscape</artifactId>
@@ -174,12 +190,6 @@
   <build>
     <pluginManagement>
       <plugins>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-failsafe-plugin</artifactId>
-          <!-- override provided version 2.22.2 -->
-          <version>3.1.2</version>
-        </plugin>
         <plugin>
           <groupId>org.jacoco</groupId>
           <artifactId>jacoco-maven-plugin</artifactId>

--- a/gateway/pom.xml
+++ b/gateway/pom.xml
@@ -20,7 +20,7 @@
         <groupId>com.github.tomakehurst</groupId>
         <artifactId>wiremock-jre8</artifactId>
         <!-- override provided version 2.26.3 -->
-        <version>2.35.1</version>
+        <version>2.35.2</version>
       </dependency>
     </dependencies>
   </dependencyManagement>
@@ -28,6 +28,16 @@
     <dependency>
       <groupId>org.georchestra</groupId>
       <artifactId>georchestra-ldap-account-management</artifactId>
+      <exclusions>
+        <exclusion>
+          <artifactId>junit</artifactId>
+          <groupId>junit</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>junit-vintage-engine</artifactId>
+          <groupId>org.junit.vintage</groupId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
@@ -135,6 +145,12 @@
       <groupId>org.georchestra</groupId>
       <artifactId>georchestra-testcontainers</artifactId>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <artifactId>junit-vintage-engine</artifactId>
+          <groupId>org.junit.vintage</groupId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>io.jsonwebtoken</groupId>
@@ -162,7 +178,7 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-failsafe-plugin</artifactId>
           <!-- override provided version 2.22.2 -->
-          <version>3.0.0-M6</version>
+          <version>3.1.2</version>
         </plugin>
         <plugin>
           <groupId>org.jacoco</groupId>

--- a/gateway/pom.xml
+++ b/gateway/pom.xml
@@ -167,7 +167,7 @@
         <plugin>
           <groupId>org.jacoco</groupId>
           <artifactId>jacoco-maven-plugin</artifactId>
-          <version>0.8.11</version>
+          <version>0.8.12</version>
         </plugin>
       </plugins>
     </pluginManagement>
@@ -343,6 +343,11 @@
               <groupId>org.projectlombok</groupId>
               <artifactId>lombok</artifactId>
               <version>${lombok.version}</version>
+            </path>
+            <path>
+              <groupId>org.projectlombok</groupId>
+              <artifactId>lombok-mapstruct-binding</artifactId>
+              <version>0.2.0</version>
             </path>
           </annotationProcessorPaths>
         </configuration>

--- a/gateway/pom.xml
+++ b/gateway/pom.xml
@@ -120,6 +120,13 @@
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>
+      <exclusions>
+        <!-- Exclude vaadin JSON to avoid conflict with org.json:json -->
+        <exclusion>
+          <artifactId>android-json</artifactId>
+          <groupId>com.vaadin.external.google</groupId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.wiremock.integrations</groupId>
@@ -194,6 +201,20 @@
           <groupId>org.jacoco</groupId>
           <artifactId>jacoco-maven-plugin</artifactId>
           <version>0.8.12</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <configuration>
+            <argLine>@{argLine} -XX:+EnableDynamicAgentLoading</argLine>
+          </configuration>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-failsafe-plugin</artifactId>
+          <configuration>
+            <argLine>@{argLine} -XX:+EnableDynamicAgentLoading</argLine>
+          </configuration>
         </plugin>
       </plugins>
     </pluginManagement>

--- a/gateway/src/main/java/org/georchestra/gateway/accounts/admin/ldap/GeorchestraLdapAccountManagementConfiguration.java
+++ b/gateway/src/main/java/org/georchestra/gateway/accounts/admin/ldap/GeorchestraLdapAccountManagementConfiguration.java
@@ -105,7 +105,7 @@ public class GeorchestraLdapAccountManagementConfiguration {
      */
     @Bean
     LdapContextSource singleContextSource(GeorchestraGatewaySecurityConfigProperties config) {
-        ExtendedLdapConfig ldapConfig = config.extendedEnabled().get(0);
+        ExtendedLdapConfig ldapConfig = config.extendedEnabled().getFirst();
         LdapContextSource singleContextSource = new LdapContextSource();
         singleContextSource.setUrl(ldapConfig.getUrl());
         singleContextSource.setBase(ldapConfig.getBaseDn());
@@ -156,7 +156,7 @@ public class GeorchestraLdapAccountManagementConfiguration {
     RoleDao roleDao(LdapTemplate ldapTemplate, GeorchestraGatewaySecurityConfigProperties config) {
         RoleDaoImpl impl = new RoleDaoImpl();
         impl.setLdapTemplate(ldapTemplate);
-        impl.setRoleSearchBaseDN(config.extendedEnabled().get(0).getRolesRdn());
+        impl.setRoleSearchBaseDN(config.extendedEnabled().getFirst().getRolesRdn());
         return impl;
     }
 
@@ -171,7 +171,7 @@ public class GeorchestraLdapAccountManagementConfiguration {
     OrgsDao orgsDao(LdapTemplate ldapTemplate, GeorchestraGatewaySecurityConfigProperties config) {
         OrgsDaoImpl impl = new OrgsDaoImpl();
         impl.setLdapTemplate(ldapTemplate);
-        ExtendedLdapConfig ldapConfig = config.extendedEnabled().get(0);
+        ExtendedLdapConfig ldapConfig = config.extendedEnabled().getFirst();
         impl.setBasePath(ldapConfig.getBaseDn());
         impl.setOrgSearchBaseDN(ldapConfig.getOrgsRdn());
         impl.setPendingOrgSearchBaseDN(ldapConfig.getPendingOrgsRdn());
@@ -188,7 +188,7 @@ public class GeorchestraLdapAccountManagementConfiguration {
      */
     @Bean
     AccountDao accountDao(LdapTemplate ldapTemplate, GeorchestraGatewaySecurityConfigProperties config) {
-        ExtendedLdapConfig ldapConfig = config.extendedEnabled().get(0);
+        ExtendedLdapConfig ldapConfig = config.extendedEnabled().getFirst();
         AccountDaoImpl impl = new AccountDaoImpl(ldapTemplate);
         impl.setBasePath(ldapConfig.getBaseDn());
         impl.setUserSearchBaseDN(ldapConfig.getUsersRdn());

--- a/gateway/src/main/java/org/georchestra/gateway/accounts/admin/ldap/LdapAccountsManager.java
+++ b/gateway/src/main/java/org/georchestra/gateway/accounts/admin/ldap/LdapAccountsManager.java
@@ -23,7 +23,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
-import jakarta.annotation.Nullable;
 import org.apache.commons.lang3.StringUtils;
 import org.georchestra.ds.DataServiceException;
 import org.georchestra.ds.DuplicatedCommonNameException;
@@ -47,6 +46,7 @@ import org.georchestra.security.model.GeorchestraUser;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.ldap.NameNotFoundException;
 
+import jakarta.annotation.Nullable;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 

--- a/gateway/src/main/java/org/georchestra/gateway/accounts/admin/ldap/LdapAccountsManager.java
+++ b/gateway/src/main/java/org/georchestra/gateway/accounts/admin/ldap/LdapAccountsManager.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
+import jakarta.annotation.Nullable;
 import org.apache.commons.lang3.StringUtils;
 import org.georchestra.ds.DataServiceException;
 import org.georchestra.ds.DuplicatedCommonNameException;
@@ -290,9 +291,9 @@ class LdapAccountsManager extends AbstractAccountsManager {
         String phone = "";
         String title = "";
         String description = "";
-        final @javax.annotation.Nullable String oAuth2Provider = preAuth.getOAuth2Provider();
-        final @javax.annotation.Nullable String oAuth2Uid = preAuth.getOAuth2Uid();
-        final @javax.annotation.Nullable String oAuth2OrgId = preAuth.getOAuth2OrgId();
+        final @Nullable String oAuth2Provider = preAuth.getOAuth2Provider();
+        final @Nullable String oAuth2Uid = preAuth.getOAuth2Uid();
+        final @Nullable String oAuth2OrgId = preAuth.getOAuth2OrgId();
 
         Account newAccount = AccountFactory.createBrief(username, password, firstName, lastName, email, phone, title,
                 description, oAuth2Provider, oAuth2Uid);

--- a/gateway/src/main/java/org/georchestra/gateway/app/GeorchestraGatewayApplication.java
+++ b/gateway/src/main/java/org/georchestra/gateway/app/GeorchestraGatewayApplication.java
@@ -145,6 +145,6 @@ public class GeorchestraGatewayApplication {
             value = value / 1024d;
             unit = "GB";
         }
-        return String.format("%.2f %s", value, unit);
+        return "%.2f %s".formatted(value, unit);
     }
 }

--- a/gateway/src/main/java/org/georchestra/gateway/app/LoginLogoutController.java
+++ b/gateway/src/main/java/org/georchestra/gateway/app/LoginLogoutController.java
@@ -23,8 +23,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
-import jakarta.annotation.PostConstruct;
-
 import org.apache.commons.lang3.tuple.Pair;
 import org.georchestra.gateway.security.GeorchestraGatewaySecurityConfigProperties;
 import org.georchestra.gateway.security.GeorchestraGatewaySecurityConfigProperties.Server;
@@ -36,6 +34,8 @@ import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+
+import jakarta.annotation.PostConstruct;
 
 /**
  * Controller handling login and logout views for the geOrchestra gateway.

--- a/gateway/src/main/java/org/georchestra/gateway/app/LoginLogoutController.java
+++ b/gateway/src/main/java/org/georchestra/gateway/app/LoginLogoutController.java
@@ -23,7 +23,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
-import javax.annotation.PostConstruct;
+import jakarta.annotation.PostConstruct;
 
 import org.apache.commons.lang3.tuple.Pair;
 import org.georchestra.gateway.security.GeorchestraGatewaySecurityConfigProperties;

--- a/gateway/src/main/java/org/georchestra/gateway/app/LoginLogoutController.java
+++ b/gateway/src/main/java/org/georchestra/gateway/app/LoginLogoutController.java
@@ -18,7 +18,7 @@
  */
 package org.georchestra.gateway.app;
 
-import java.nio.file.Paths;
+import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -144,7 +144,7 @@ public class LoginLogoutController {
         if (oauth2ClientConfig != null) {
             oauth2ClientConfig.getRegistration().forEach((key, value) -> {
                 String clientName = Optional.ofNullable(value.getClientName()).orElse(key);
-                String providerPath = Paths.get("login/img/", key + ".png").toString();
+                String providerPath = Path.of("login/img/", key + ".png").toString();
                 String logo = new ClassPathResource("static/" + providerPath).exists() ? providerPath
                         : "login/img/default.png";
                 oauth2LoginLinks.put("/oauth2/authorization/" + key, Pair.of(clientName, logo));

--- a/gateway/src/main/java/org/georchestra/gateway/autoconfigure/accounts/GeorchestraLdapAccountsCreationAutoConfiguration.java
+++ b/gateway/src/main/java/org/georchestra/gateway/autoconfigure/accounts/GeorchestraLdapAccountsCreationAutoConfiguration.java
@@ -20,14 +20,13 @@ package org.georchestra.gateway.autoconfigure.accounts;
 
 import java.util.List;
 
-import jakarta.annotation.PostConstruct;
-
 import org.georchestra.gateway.accounts.admin.ldap.GeorchestraLdapAccountManagementConfiguration;
 import org.georchestra.gateway.security.ldap.extended.ExtendedLdapAuthenticationConfiguration;
 import org.georchestra.gateway.security.ldap.extended.ExtendedLdapConfig;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.context.annotation.Import;
 
+import jakarta.annotation.PostConstruct;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 

--- a/gateway/src/main/java/org/georchestra/gateway/autoconfigure/accounts/GeorchestraLdapAccountsCreationAutoConfiguration.java
+++ b/gateway/src/main/java/org/georchestra/gateway/autoconfigure/accounts/GeorchestraLdapAccountsCreationAutoConfiguration.java
@@ -20,7 +20,7 @@ package org.georchestra.gateway.autoconfigure.accounts;
 
 import java.util.List;
 
-import javax.annotation.PostConstruct;
+import jakarta.annotation.PostConstruct;
 
 import org.georchestra.gateway.accounts.admin.ldap.GeorchestraLdapAccountManagementConfiguration;
 import org.georchestra.gateway.security.ldap.extended.ExtendedLdapAuthenticationConfiguration;

--- a/gateway/src/main/java/org/georchestra/gateway/autoconfigure/security/LdapSecurityAutoConfiguration.java
+++ b/gateway/src/main/java/org/georchestra/gateway/autoconfigure/security/LdapSecurityAutoConfiguration.java
@@ -18,12 +18,11 @@
  */
 package org.georchestra.gateway.autoconfigure.security;
 
-import jakarta.annotation.PostConstruct;
-
 import org.georchestra.gateway.security.ldap.LdapAuthenticationConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.context.annotation.Import;
 
+import jakarta.annotation.PostConstruct;
 import lombok.extern.slf4j.Slf4j;
 
 /**

--- a/gateway/src/main/java/org/georchestra/gateway/autoconfigure/security/LdapSecurityAutoConfiguration.java
+++ b/gateway/src/main/java/org/georchestra/gateway/autoconfigure/security/LdapSecurityAutoConfiguration.java
@@ -18,7 +18,7 @@
  */
 package org.georchestra.gateway.autoconfigure.security;
 
-import javax.annotation.PostConstruct;
+import jakarta.annotation.PostConstruct;
 
 import org.georchestra.gateway.security.ldap.LdapAuthenticationConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfiguration;

--- a/gateway/src/main/java/org/georchestra/gateway/autoconfigure/security/OAuth2SecurityAutoConfiguration.java
+++ b/gateway/src/main/java/org/georchestra/gateway/autoconfigure/security/OAuth2SecurityAutoConfiguration.java
@@ -18,14 +18,13 @@
  */
 package org.georchestra.gateway.autoconfigure.security;
 
-import jakarta.annotation.PostConstruct;
-
 import org.georchestra.gateway.security.oauth2.OAuth2Configuration;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 
+import jakarta.annotation.PostConstruct;
 import lombok.extern.slf4j.Slf4j;
 
 /**

--- a/gateway/src/main/java/org/georchestra/gateway/autoconfigure/security/OAuth2SecurityAutoConfiguration.java
+++ b/gateway/src/main/java/org/georchestra/gateway/autoconfigure/security/OAuth2SecurityAutoConfiguration.java
@@ -18,7 +18,7 @@
  */
 package org.georchestra.gateway.autoconfigure.security;
 
-import javax.annotation.PostConstruct;
+import jakarta.annotation.PostConstruct;
 
 import org.georchestra.gateway.security.oauth2.OAuth2Configuration;
 import org.springframework.boot.autoconfigure.AutoConfiguration;

--- a/gateway/src/main/java/org/georchestra/gateway/filter/global/ApplicationErrorGatewayFilterFactory.java
+++ b/gateway/src/main/java/org/georchestra/gateway/filter/global/ApplicationErrorGatewayFilterFactory.java
@@ -26,7 +26,7 @@ import org.springframework.cloud.gateway.filter.factory.AbstractGatewayFilterFac
 import org.springframework.cloud.gateway.filter.factory.GatewayFilterFactory;
 import org.springframework.core.Ordered;
 import org.springframework.http.HttpMethod;
-import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.http.MediaType;
 import org.springframework.http.server.reactive.ServerHttpRequest;
 import org.springframework.http.server.reactive.ServerHttpResponse;
@@ -163,8 +163,8 @@ public class ApplicationErrorGatewayFilterFactory extends AbstractGatewayFilterF
      * @return {@code true} if the method is idempotent, {@code false} otherwise
      */
     boolean methodIsIdempotent(HttpMethod method) {
-        return switch (method) {
-        case GET, HEAD, OPTIONS, TRACE -> true;
+        return switch (method.name()) {
+        case "GET", "HEAD", "OPTIONS", "TRACE" -> true;
         default -> false;
         };
     }
@@ -203,7 +203,7 @@ public class ApplicationErrorGatewayFilterFactory extends AbstractGatewayFilterF
          * or 5xx range, allowing the gateway to apply custom error handling.
          */
         private void checkStatusCode() {
-            HttpStatus statusCode = getStatusCode();
+            HttpStatusCode statusCode = getStatusCode();
             log.debug("native status code: {}", statusCode);
             if (statusCode.is4xxClientError() || statusCode.is5xxServerError()) {
                 log.debug("Conveying {} response status", statusCode);

--- a/gateway/src/main/java/org/georchestra/gateway/filter/headers/CookieAffinityGatewayFilterFactory.java
+++ b/gateway/src/main/java/org/georchestra/gateway/filter/headers/CookieAffinityGatewayFilterFactory.java
@@ -18,7 +18,7 @@
  */
 package org.georchestra.gateway.filter.headers;
 
-import javax.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotEmpty;
 
 import org.georchestra.gateway.filter.global.ResolveTargetGlobalFilter;
 import org.springframework.cloud.gateway.filter.GatewayFilter;

--- a/gateway/src/main/java/org/georchestra/gateway/filter/headers/CookieAffinityGatewayFilterFactory.java
+++ b/gateway/src/main/java/org/georchestra/gateway/filter/headers/CookieAffinityGatewayFilterFactory.java
@@ -18,8 +18,6 @@
  */
 package org.georchestra.gateway.filter.headers;
 
-import jakarta.validation.constraints.NotEmpty;
-
 import org.georchestra.gateway.filter.global.ResolveTargetGlobalFilter;
 import org.springframework.cloud.gateway.filter.GatewayFilter;
 import org.springframework.cloud.gateway.filter.GatewayFilterChain;
@@ -29,6 +27,7 @@ import org.springframework.http.ResponseCookie;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.server.ServerWebExchange;
 
+import jakarta.validation.constraints.NotEmpty;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;

--- a/gateway/src/main/java/org/georchestra/gateway/handler/predicate/QueryParamRoutePredicateFactory.java
+++ b/gateway/src/main/java/org/georchestra/gateway/handler/predicate/QueryParamRoutePredicateFactory.java
@@ -22,12 +22,12 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.function.Predicate;
 
-import jakarta.validation.constraints.NotEmpty;
-
 import org.springframework.cloud.gateway.handler.predicate.AbstractRoutePredicateFactory;
 import org.springframework.cloud.gateway.handler.predicate.GatewayPredicate;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.server.ServerWebExchange;
+
+import jakarta.validation.constraints.NotEmpty;
 
 /**
  * A route predicate factory that evaluates whether an HTTP request contains a

--- a/gateway/src/main/java/org/georchestra/gateway/handler/predicate/QueryParamRoutePredicateFactory.java
+++ b/gateway/src/main/java/org/georchestra/gateway/handler/predicate/QueryParamRoutePredicateFactory.java
@@ -93,7 +93,7 @@ public class QueryParamRoutePredicateFactory
 
             @Override
             public String toString() {
-                return String.format("Query: param=%s", config.getParam());
+                return "Query: param=%s".formatted(config.getParam());
             }
         };
     }

--- a/gateway/src/main/java/org/georchestra/gateway/handler/predicate/QueryParamRoutePredicateFactory.java
+++ b/gateway/src/main/java/org/georchestra/gateway/handler/predicate/QueryParamRoutePredicateFactory.java
@@ -22,7 +22,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.function.Predicate;
 
-import javax.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotEmpty;
 
 import org.springframework.cloud.gateway.handler.predicate.AbstractRoutePredicateFactory;
 import org.springframework.cloud.gateway.handler.predicate.GatewayPredicate;

--- a/gateway/src/main/java/org/georchestra/gateway/security/GatewaySecurityConfiguration.java
+++ b/gateway/src/main/java/org/georchestra/gateway/security/GatewaySecurityConfiguration.java
@@ -32,7 +32,6 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.reactive.EnableWebFluxSecurity;
 import org.springframework.security.config.web.server.ServerHttpSecurity;
-import org.springframework.security.config.web.server.ServerHttpSecurity.LogoutSpec;
 import org.springframework.security.web.server.SecurityWebFilterChain;
 import org.springframework.security.web.server.authentication.logout.RedirectServerLogoutSuccessHandler;
 import org.springframework.security.web.server.authentication.logout.ServerLogoutSuccessHandler;
@@ -130,11 +129,11 @@ public class GatewaySecurityConfiguration {
         RedirectServerLogoutSuccessHandler defaultRedirect = new RedirectServerLogoutSuccessHandler();
         defaultRedirect.setLogoutSuccessUrl(URI.create(georchestraLogoutUrl));
 
-        LogoutSpec logoutSpec = http.formLogin(login -> login.loginPage("/login")).logout(logout -> logout
+        ServerHttpSecurity logoutSpec = http.formLogin(login -> login.loginPage("/login")).logout(logout -> logout
                 .requiresLogout(ServerWebExchangeMatchers.pathMatchers(HttpMethod.GET, "/logout"))
                 .logoutSuccessHandler(oidcLogoutSuccessHandler != null ? oidcLogoutSuccessHandler : defaultRedirect));
 
-        return logoutSpec.and().build();
+        return logoutSpec.build();
     }
 
     /**

--- a/gateway/src/main/java/org/georchestra/gateway/security/GatewaySecurityConfiguration.java
+++ b/gateway/src/main/java/org/georchestra/gateway/security/GatewaySecurityConfiguration.java
@@ -112,13 +112,13 @@ public class GatewaySecurityConfiguration {
 
         log.info("Initializing security filter chain...");
 
-        http.csrf().disable();
-        http.headers().disable();
-        http.exceptionHandling().accessDeniedHandler(new CustomAccessDeniedHandler());
+        http.csrf(csrf -> csrf.disable());
+        http.headers(headers -> headers.disable());
+        http.exceptionHandling(handling -> handling.accessDeniedHandler(new CustomAccessDeniedHandler()));
 
-        http.formLogin()
+        http.formLogin(login -> login
                 .authenticationFailureHandler(new ExtendedRedirectServerAuthenticationFailureHandler("login?error"))
-                .loginPage("/login");
+                .loginPage("/login"));
 
         sortedCustomizers(customizers).forEach(customizer -> {
             log.debug("Applying security customizer {}", customizer.getName());
@@ -130,9 +130,9 @@ public class GatewaySecurityConfiguration {
         RedirectServerLogoutSuccessHandler defaultRedirect = new RedirectServerLogoutSuccessHandler();
         defaultRedirect.setLogoutSuccessUrl(URI.create(georchestraLogoutUrl));
 
-        LogoutSpec logoutSpec = http.formLogin().loginPage("/login").and().logout()
+        LogoutSpec logoutSpec = http.formLogin(login -> login.loginPage("/login")).logout(logout -> logout
                 .requiresLogout(ServerWebExchangeMatchers.pathMatchers(HttpMethod.GET, "/logout"))
-                .logoutSuccessHandler(oidcLogoutSuccessHandler != null ? oidcLogoutSuccessHandler : defaultRedirect);
+                .logoutSuccessHandler(oidcLogoutSuccessHandler != null ? oidcLogoutSuccessHandler : defaultRedirect));
 
         return logoutSpec.and().build();
     }

--- a/gateway/src/main/java/org/georchestra/gateway/security/GatewaySecurityConfiguration.java
+++ b/gateway/src/main/java/org/georchestra/gateway/security/GatewaySecurityConfiguration.java
@@ -26,10 +26,13 @@ import java.util.stream.Stream;
 import org.georchestra.gateway.model.GatewayConfigProperties;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
+import org.springframework.security.authentication.ReactiveAuthenticationManager;
+import org.springframework.security.authentication.ReactiveAuthenticationManagerAdapter;
 import org.springframework.security.config.annotation.web.reactive.EnableWebFluxSecurity;
 import org.springframework.security.config.web.server.ServerHttpSecurity;
 import org.springframework.security.web.server.SecurityWebFilterChain;
@@ -105,15 +108,36 @@ public class GatewaySecurityConfiguration {
      * @return the configured {@link SecurityWebFilterChain}
      * @throws Exception if an error occurs during configuration
      */
+    /**
+     * Creates a default authentication manager when none is provided. This is
+     * necessary in Spring Boot 3 to ensure the security filter chain can be
+     * created.
+     * 
+     * @return a default ReactiveAuthenticationManager
+     */
+    @Bean
+    @ConditionalOnMissingBean(ReactiveAuthenticationManager.class)
+    ReactiveAuthenticationManager defaultAuthenticationManager() {
+        log.info("Creating default authentication manager");
+        return new ReactiveAuthenticationManagerAdapter(authentication -> {
+            // This is a fallback that simply rejects all authentications
+            return null;
+        });
+    }
+
     @Bean
     SecurityWebFilterChain securityWebFilterChain(ServerHttpSecurity http,
-            List<ServerHttpSecurityCustomizer> customizers) throws Exception {
+            List<ServerHttpSecurityCustomizer> customizers, ReactiveAuthenticationManager authenticationManager)
+            throws Exception {
 
         log.info("Initializing security filter chain...");
 
         http.csrf(csrf -> csrf.disable());
         http.headers(headers -> headers.disable());
         http.exceptionHandling(handling -> handling.accessDeniedHandler(new CustomAccessDeniedHandler()));
+
+        // Set the authentication manager
+        http.authenticationManager(authenticationManager);
 
         http.formLogin(login -> login
                 .authenticationFailureHandler(new ExtendedRedirectServerAuthenticationFailureHandler("login?error"))

--- a/gateway/src/main/java/org/georchestra/gateway/security/GeorchestraGatewaySecurityConfigProperties.java
+++ b/gateway/src/main/java/org/georchestra/gateway/security/GeorchestraGatewaySecurityConfigProperties.java
@@ -23,8 +23,6 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.stream.Stream;
 
-import javax.validation.Valid;
-
 import org.georchestra.gateway.security.ldap.LdapConfigBuilder;
 import org.georchestra.gateway.security.ldap.LdapConfigPropertiesValidations;
 import org.georchestra.gateway.security.ldap.basic.LdapServerConfig;
@@ -34,6 +32,7 @@ import org.springframework.validation.Errors;
 import org.springframework.validation.Validator;
 import org.springframework.validation.annotation.Validated;
 
+import jakarta.validation.Valid;
 import lombok.Data;
 import lombok.Generated;
 import lombok.Setter;

--- a/gateway/src/main/java/org/georchestra/gateway/security/RolesMappingsUserCustomizer.java
+++ b/gateway/src/main/java/org/georchestra/gateway/security/RolesMappingsUserCustomizer.java
@@ -104,7 +104,7 @@ public class RolesMappingsUserCustomizer implements GeorchestraUserCustomizerExt
 
         @Override
         public String toString() {
-            return String.format("%s -> %s", pattern.pattern(), extraRoles);
+            return "%s -> %s".formatted(pattern.pattern(), extraRoles);
         }
     }
 

--- a/gateway/src/main/java/org/georchestra/gateway/security/accessrules/AccessRulesCustomizer.java
+++ b/gateway/src/main/java/org/georchestra/gateway/security/accessrules/AccessRulesCustomizer.java
@@ -18,6 +18,8 @@
  */
 package org.georchestra.gateway.security.accessrules;
 
+import static org.springframework.security.config.Customizer.withDefaults;
+
 import java.util.List;
 import java.util.Objects;
 
@@ -64,7 +66,7 @@ public class AccessRulesCustomizer implements ServerHttpSecurityCustomizer {
     public void customize(ServerHttpSecurity http) {
         log.info("Configuring proxied applications access rules...");
 
-        AuthorizeExchangeSpec authorizeExchange = http.authorizeExchange();
+        AuthorizeExchangeSpec authorizeExchange = http.authorizeExchange(withDefaults());
 
         // Apply service-specific rules before global rules.
         // This ensures that service-specific paths take precedence over general rules.

--- a/gateway/src/main/java/org/georchestra/gateway/security/accessrules/AccessRulesCustomizer.java
+++ b/gateway/src/main/java/org/georchestra/gateway/security/accessrules/AccessRulesCustomizer.java
@@ -18,8 +18,6 @@
  */
 package org.georchestra.gateway.security.accessrules;
 
-import static org.springframework.security.config.Customizer.withDefaults;
-
 import java.util.List;
 import java.util.Objects;
 
@@ -66,7 +64,7 @@ public class AccessRulesCustomizer implements ServerHttpSecurityCustomizer {
     public void customize(ServerHttpSecurity http) {
         log.info("Configuring proxied applications access rules...");
 
-        AuthorizeExchangeSpec authorizeExchange = http.authorizeExchange(withDefaults());
+        AuthorizeExchangeSpec authorizeExchange = http.authorizeExchange();
 
         // Apply service-specific rules before global rules.
         // This ensures that service-specific paths take precedence over general rules.

--- a/gateway/src/main/java/org/georchestra/gateway/security/ldap/LdapAuthenticationConfiguration.java
+++ b/gateway/src/main/java/org/georchestra/gateway/security/ldap/LdapAuthenticationConfiguration.java
@@ -18,6 +18,8 @@
  */
 package org.georchestra.gateway.security.ldap;
 
+import static org.springframework.security.config.Customizer.withDefaults;
+
 import java.util.List;
 import java.util.stream.Stream;
 
@@ -55,8 +57,8 @@ import lombok.extern.slf4j.Slf4j;
  * </p>
  * <p>
  * As a result, the {@link ServerHttpSecurity} will have HTTP Basic
- * authentication enabled, as well as {@link ServerHttpSecurity#formLogin() form
- * login}.
+ * authentication enabled, as well as
+ * {@link ServerHttpSecurity#formLogin(withDefaults()) form login}.
  * </p>
  * <p>
  * Upon successful authentication, an {@link Authentication} instance will be
@@ -96,7 +98,7 @@ public class LdapAuthenticationConfiguration {
          */
         public @Override void customize(ServerHttpSecurity http) {
             log.info("Enabling HTTP Basic authentication support for LDAP");
-            http.httpBasic().and().formLogin();
+            http.httpBasic(withDefaults()).formLogin(withDefaults());
         }
     }
 

--- a/gateway/src/main/java/org/georchestra/gateway/security/ldap/LdapConfigPropertiesValidations.java
+++ b/gateway/src/main/java/org/georchestra/gateway/security/ldap/LdapConfigPropertiesValidations.java
@@ -18,7 +18,6 @@
  */
 package org.georchestra.gateway.security.ldap;
 
-import static java.lang.String.format;
 import static org.springframework.validation.ValidationUtils.rejectIfEmptyOrWhitespace;
 
 import org.georchestra.gateway.security.GeorchestraGatewaySecurityConfigProperties.Server;
@@ -61,7 +60,7 @@ public class LdapConfigPropertiesValidations {
         }
 
         // Ensure the LDAP URL is defined
-        final String url = format("ldap.[%s].url", name);
+        final String url = "ldap.[%s].url".formatted(name);
         rejectIfEmptyOrWhitespace(errors, url, "", "LDAP URL is required (e.g., ldap://my.ldap.com:389)");
 
         // Validate base LDAP configuration
@@ -88,16 +87,16 @@ public class LdapConfigPropertiesValidations {
      * @param errors the validation error object
      */
     private void validateSimpleLdap(String name, Server config, Errors errors) {
-        rejectIfEmptyOrWhitespace(errors, format("ldap.[%s].baseDn", name), "",
+        rejectIfEmptyOrWhitespace(errors, "ldap.[%s].baseDn".formatted(name), "",
                 "LDAP base DN is required (e.g., dc=georchestra,dc=org)");
 
-        rejectIfEmptyOrWhitespace(errors, format("ldap.[%s].users.rdn", name), "",
+        rejectIfEmptyOrWhitespace(errors, "ldap.[%s].users.rdn".formatted(name), "",
                 "LDAP users RDN (Relative Distinguished Name) is required (e.g., ou=users,dc=georchestra,dc=org)");
 
-        rejectIfEmptyOrWhitespace(errors, format("ldap.[%s].roles.rdn", name), "",
+        rejectIfEmptyOrWhitespace(errors, "ldap.[%s].roles.rdn".formatted(name), "",
                 "Roles Relative Distinguished Name is required (e.g., ou=roles)");
 
-        rejectIfEmptyOrWhitespace(errors, format("ldap.[%s].roles.searchFilter", name), "",
+        rejectIfEmptyOrWhitespace(errors, "ldap.[%s].roles.searchFilter".formatted(name), "",
                 "Roles search filter is required (e.g., (member={0}))");
     }
 
@@ -109,7 +108,7 @@ public class LdapConfigPropertiesValidations {
      * @param errors the validation error object
      */
     private void validateUsersSearchFilterMandatory(String name, Errors errors) {
-        rejectIfEmptyOrWhitespace(errors, format("ldap.[%s].users.searchFilter", name), "",
+        rejectIfEmptyOrWhitespace(errors, "ldap.[%s].users.searchFilter".formatted(name), "",
                 "LDAP users search filter is required for standard LDAP configurations (e.g., (uid={0})), "
                         + "but optional for Active Directory (e.g., (&(objectClass=user)(userPrincipalName={0})))");
     }
@@ -122,7 +121,7 @@ public class LdapConfigPropertiesValidations {
      * @param errors the validation error object
      */
     private void validateGeorchestraExtensions(String name, Server config, Errors errors) {
-        rejectIfEmptyOrWhitespace(errors, format("ldap.[%s].orgs.rdn", name), "",
+        rejectIfEmptyOrWhitespace(errors, "ldap.[%s].orgs.rdn".formatted(name), "",
                 "Organizations search base RDN is required if 'extended' is true (e.g., ou=orgs)");
     }
 

--- a/gateway/src/main/java/org/georchestra/gateway/security/ldap/extended/GeorchestraUserNamePasswordAuthenticationToken.java
+++ b/gateway/src/main/java/org/georchestra/gateway/security/ldap/extended/GeorchestraUserNamePasswordAuthenticationToken.java
@@ -18,6 +18,7 @@
  */
 package org.georchestra.gateway.security.ldap.extended;
 
+import java.io.Serial;
 import java.util.Collection;
 
 import org.georchestra.security.api.UsersApi;
@@ -45,6 +46,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class GeorchestraUserNamePasswordAuthenticationToken implements Authentication {
 
+    @Serial
     private static final long serialVersionUID = 1L;
 
     /**

--- a/gateway/src/main/java/org/georchestra/gateway/security/oauth2/OAuth2Configuration.java
+++ b/gateway/src/main/java/org/georchestra/gateway/security/oauth2/OAuth2Configuration.java
@@ -18,6 +18,8 @@
  */
 package org.georchestra.gateway.security.oauth2;
 
+import static org.springframework.security.config.Customizer.withDefaults;
+
 import java.lang.reflect.Field;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
@@ -87,7 +89,7 @@ public class OAuth2Configuration {
         @Override
         public void customize(ServerHttpSecurity http) {
             log.info("Enabling authentication support using an OAuth 2.0 and/or OpenID Connect 1.0 Provider");
-            http.oauth2Login();
+            http.oauth2Login(withDefaults());
         }
     }
 

--- a/gateway/src/main/java/org/georchestra/gateway/security/oauth2/OpenIdConnectCustomClaimsConfigProperties.java
+++ b/gateway/src/main/java/org/georchestra/gateway/security/oauth2/OpenIdConnectCustomClaimsConfigProperties.java
@@ -346,7 +346,7 @@ public @Data class OpenIdConnectCustomClaimsConfigProperties {
                 return List.of();
             }
 
-            final List<?> list = (matched instanceof List) ? (List<?>) matched : List.of(matched);
+            final List<?> list = (matched instanceof List<?> l) ? l : List.of(matched);
 
             return IntStream.range(0, list.size()).mapToObj(list::get).filter(Objects::nonNull)
                     .map(value -> validateValueIsString(jsonPathExpression, value)).toList();
@@ -364,8 +364,7 @@ public @Data class OpenIdConnectCustomClaimsConfigProperties {
             if (value instanceof String val) {
                 return val;
             }
-            throw new IllegalStateException(String.format(
-                    "The JSONPath expression %s evaluates to %s instead of String. Value: %s",
+            throw new IllegalStateException("The JSONPath expression %s evaluates to %s instead of String. Value: %s".formatted(
                     jsonPathExpression, value.getClass().getCanonicalName(), value));
         }
     }

--- a/gateway/src/main/java/org/geoserver/cloud/gateway/filter/RouteProfileGatewayFilterFactory.java
+++ b/gateway/src/main/java/org/geoserver/cloud/gateway/filter/RouteProfileGatewayFilterFactory.java
@@ -10,7 +10,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-import javax.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotEmpty;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cloud.gateway.filter.GatewayFilter;

--- a/gateway/src/main/java/org/geoserver/cloud/gateway/filter/RouteProfileGatewayFilterFactory.java
+++ b/gateway/src/main/java/org/geoserver/cloud/gateway/filter/RouteProfileGatewayFilterFactory.java
@@ -10,8 +10,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-import jakarta.validation.constraints.NotEmpty;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cloud.gateway.filter.GatewayFilter;
 import org.springframework.cloud.gateway.filter.GatewayFilterChain;
@@ -22,6 +20,7 @@ import org.springframework.util.StringUtils;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.server.ServerWebExchange;
 
+import jakarta.validation.constraints.NotEmpty;
 import lombok.Data;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;

--- a/gateway/src/main/java/org/geoserver/cloud/gateway/predicate/RegExpQueryRoutePredicateFactory.java
+++ b/gateway/src/main/java/org/geoserver/cloud/gateway/predicate/RegExpQueryRoutePredicateFactory.java
@@ -11,7 +11,7 @@ import java.util.Set;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
 
-import javax.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotEmpty;
 
 import org.springframework.cloud.gateway.handler.predicate.AbstractRoutePredicateFactory;
 import org.springframework.cloud.gateway.handler.predicate.GatewayPredicate;

--- a/gateway/src/main/java/org/geoserver/cloud/gateway/predicate/RegExpQueryRoutePredicateFactory.java
+++ b/gateway/src/main/java/org/geoserver/cloud/gateway/predicate/RegExpQueryRoutePredicateFactory.java
@@ -133,7 +133,7 @@ public class RegExpQueryRoutePredicateFactory
          */
         @Override
         public String toString() {
-            return String.format("Query: param regexp='%s' value regexp='%s'", config.getParamRegexp(),
+            return "Query: param regexp='%s' value regexp='%s'".formatted(config.getParamRegexp(),
                     config.getValueRegexp());
         }
     }

--- a/gateway/src/main/java/org/geoserver/cloud/gateway/predicate/RegExpQueryRoutePredicateFactory.java
+++ b/gateway/src/main/java/org/geoserver/cloud/gateway/predicate/RegExpQueryRoutePredicateFactory.java
@@ -11,8 +11,6 @@ import java.util.Set;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
 
-import jakarta.validation.constraints.NotEmpty;
-
 import org.springframework.cloud.gateway.handler.predicate.AbstractRoutePredicateFactory;
 import org.springframework.cloud.gateway.handler.predicate.GatewayPredicate;
 import org.springframework.cloud.gateway.handler.predicate.QueryRoutePredicateFactory;
@@ -20,6 +18,7 @@ import org.springframework.util.StringUtils;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.server.ServerWebExchange;
 
+import jakarta.validation.constraints.NotEmpty;
 import lombok.Data;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;

--- a/gateway/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/gateway/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,9 @@
+org.georchestra.gateway.autoconfigure.accounts.GeorchestraLdapAccountsCreationAutoConfiguration
+org.georchestra.gateway.autoconfigure.accounts.RabbitmqEventsAutoConfiguration
+org.georchestra.gateway.autoconfigure.app.ErrorCustomizerAutoConfiguration
+org.georchestra.gateway.autoconfigure.app.FiltersAutoConfiguration
+org.georchestra.gateway.autoconfigure.app.RoutePredicateFactoriesAutoConfiguration
+org.georchestra.gateway.autoconfigure.security.HeaderPreAuthenticationAutoConfiguration
+org.georchestra.gateway.autoconfigure.security.LdapSecurityAutoConfiguration
+org.georchestra.gateway.autoconfigure.security.OAuth2SecurityAutoConfiguration
+org.georchestra.gateway.autoconfigure.security.WebSecurityAutoConfiguration

--- a/gateway/src/test/java/org/georchestra/gateway/filter/headers/providers/JsonPayloadHeadersContributorTest.java
+++ b/gateway/src/test/java/org/georchestra/gateway/filter/headers/providers/JsonPayloadHeadersContributorTest.java
@@ -124,7 +124,7 @@ class JsonPayloadHeadersContributorTest {
 
         List<String> val = target.get(headerName);
         assertNotNull(val);
-        String base64Ecnoded = val.get(0);
+        String base64Ecnoded = val.getFirst();
         String json = SecurityHeaders.decode(base64Ecnoded);
         Object decoded = new ObjectMapper().readValue(json, object.getClass());
         assertEquals(object, decoded);

--- a/gateway/src/test/java/org/georchestra/gateway/rabbitmq/SendMessageRabbitmqIT.java
+++ b/gateway/src/test/java/org/georchestra/gateway/rabbitmq/SendMessageRabbitmqIT.java
@@ -84,8 +84,7 @@ public class SendMessageRabbitmqIT {
                 .withEnv("smtpPort", String.valueOf(smtp.getMappedPort(SMTPPORT))).withLogToStdOut();
 
         console.start();
-        System.setProperty("georchestra.console.url",
-                String.format("http://localhost:%d", console.getMappedConsolePort()));
+        System.setProperty("georchestra.console.url", "http://localhost:%d".formatted(console.getMappedConsolePort()));
     }
 
     public static @AfterAll void shutDownContainers() {

--- a/gateway/src/test/java/org/georchestra/gateway/security/accessrules/AccessRulesCustomizerIT.java
+++ b/gateway/src/test/java/org/georchestra/gateway/security/accessrules/AccessRulesCustomizerIT.java
@@ -111,7 +111,7 @@ class AccessRulesCustomizerIT {
         WireMockRuntimeInfo runtimeInfo = mockService.getRuntimeInfo();
         String httpBaseUrl = runtimeInfo.getHttpBaseUrl();
         String proxiedURI = URI.create(httpBaseUrl + "/" + targetBaseURI).normalize().toString();
-        String propertyName = String.format("georchestra.gateway.services.%s.target", serviceName);
+        String propertyName = "georchestra.gateway.services.%s.target".formatted(serviceName);
         registry.add(propertyName, () -> proxiedURI);
         log.debug("overridden dynamic target {}={}", propertyName, proxiedURI);
     }

--- a/gateway/src/test/java/org/georchestra/gateway/security/accessrules/AccessRulesCustomizerTest.java
+++ b/gateway/src/test/java/org/georchestra/gateway/security/accessrules/AccessRulesCustomizerTest.java
@@ -32,6 +32,7 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.springframework.security.config.Customizer.withDefaults;
 
 import java.util.List;
 import java.util.Map;
@@ -74,7 +75,7 @@ class AccessRulesCustomizerTest {
     @Test
     void testCustomize_empty_config() {
         customizer.customize(http);
-        verify(http, atLeastOnce()).authorizeExchange();
+        verify(http, atLeastOnce()).authorizeExchange(withDefaults());
         verifyNoMoreInteractions(http);
     }
 
@@ -107,7 +108,7 @@ class AccessRulesCustomizerTest {
 
     @Test
     void testApplyRule_EmptyInterceptUrls() {
-        AuthorizeExchangeSpec spec = http.authorizeExchange();
+        AuthorizeExchangeSpec spec = http.authorizeExchange(withDefaults());
         RoleBasedAccessRule rule = rule().setAnonymous(true);
 
         assertThrows(IllegalArgumentException.class, () -> customizer.apply(spec, rule),
@@ -116,7 +117,7 @@ class AccessRulesCustomizerTest {
 
     @Test
     void testApplyRule_AuthorizeExchangeWithAntPatterns() {
-        AuthorizeExchangeSpec spec = http.authorizeExchange();
+        AuthorizeExchangeSpec spec = http.authorizeExchange(withDefaults());
 
         RoleBasedAccessRule rule = rule("/test/**", "/page1");
         customizer = spy(customizer);
@@ -127,7 +128,7 @@ class AccessRulesCustomizerTest {
 
     @Test
     void testApplyRule_anonymous() {
-        AuthorizeExchangeSpec spec = http.authorizeExchange();
+        AuthorizeExchangeSpec spec = http.authorizeExchange(withDefaults());
 
         RoleBasedAccessRule rule = rule("/test/**", "/page1").setAnonymous(true);
         customizer = spy(customizer);
@@ -139,7 +140,7 @@ class AccessRulesCustomizerTest {
 
     @Test
     void testApplyRule_anonymous_has_precedence_over_roles_list() {
-        AuthorizeExchangeSpec spec = http.authorizeExchange();
+        AuthorizeExchangeSpec spec = http.authorizeExchange(withDefaults());
 
         RoleBasedAccessRule rule = rule("/test/**", "/page1").setAnonymous(true).setAllowedRoles(List.of("ROLE_ADMIN"));
         customizer = spy(customizer);
@@ -153,7 +154,7 @@ class AccessRulesCustomizerTest {
 
     @Test
     void testApplyRule_authenticated() {
-        AuthorizeExchangeSpec spec = http.authorizeExchange();
+        AuthorizeExchangeSpec spec = http.authorizeExchange(withDefaults());
 
         RoleBasedAccessRule rule = rule("/test/**", "/page1").setAnonymous(false);
         customizer = spy(customizer);
@@ -165,7 +166,7 @@ class AccessRulesCustomizerTest {
 
     @Test
     void testApplyRule_roles() {
-        AuthorizeExchangeSpec spec = http.authorizeExchange();
+        AuthorizeExchangeSpec spec = http.authorizeExchange(withDefaults());
 
         List<String> roles = List.of("ROLE_ADMIN", "ROLE_TESTER");
         RoleBasedAccessRule rule = rule("/test/**", "/page1").setAllowedRoles(roles);
@@ -178,7 +179,7 @@ class AccessRulesCustomizerTest {
 
     @Test
     void testApplyRule_roles_prefix_added_if_missing() {
-        AuthorizeExchangeSpec spec = http.authorizeExchange();
+        AuthorizeExchangeSpec spec = http.authorizeExchange(withDefaults());
 
         List<String> roles = List.of("ADMIN", "TESTER");
         List<String> expected = List.of("ROLE_ADMIN", "ROLE_TESTER");
@@ -192,7 +193,7 @@ class AccessRulesCustomizerTest {
 
     @Test
     void testApplyRule_forbidden() {
-        AuthorizeExchangeSpec spec = http.authorizeExchange();
+        AuthorizeExchangeSpec spec = http.authorizeExchange(withDefaults());
         RoleBasedAccessRule rule = rule("/test/**", "/page1").setForbidden(true);
         customizer = spy(customizer);
         customizer.apply(spec, rule);

--- a/gateway/src/test/java/org/georchestra/gateway/security/accessrules/AccessRulesCustomizerTest.java
+++ b/gateway/src/test/java/org/georchestra/gateway/security/accessrules/AccessRulesCustomizerTest.java
@@ -32,7 +32,6 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.springframework.security.config.Customizer.withDefaults;
 
 import java.util.List;
 import java.util.Map;
@@ -75,7 +74,7 @@ class AccessRulesCustomizerTest {
     @Test
     void testCustomize_empty_config() {
         customizer.customize(http);
-        verify(http, atLeastOnce()).authorizeExchange(withDefaults());
+        verify(http, atLeastOnce()).authorizeExchange();
         verifyNoMoreInteractions(http);
     }
 
@@ -108,7 +107,7 @@ class AccessRulesCustomizerTest {
 
     @Test
     void testApplyRule_EmptyInterceptUrls() {
-        AuthorizeExchangeSpec spec = http.authorizeExchange(withDefaults());
+        AuthorizeExchangeSpec spec = http.authorizeExchange();
         RoleBasedAccessRule rule = rule().setAnonymous(true);
 
         assertThrows(IllegalArgumentException.class, () -> customizer.apply(spec, rule),
@@ -117,7 +116,7 @@ class AccessRulesCustomizerTest {
 
     @Test
     void testApplyRule_AuthorizeExchangeWithAntPatterns() {
-        AuthorizeExchangeSpec spec = http.authorizeExchange(withDefaults());
+        AuthorizeExchangeSpec spec = http.authorizeExchange();
 
         RoleBasedAccessRule rule = rule("/test/**", "/page1");
         customizer = spy(customizer);
@@ -128,7 +127,7 @@ class AccessRulesCustomizerTest {
 
     @Test
     void testApplyRule_anonymous() {
-        AuthorizeExchangeSpec spec = http.authorizeExchange(withDefaults());
+        AuthorizeExchangeSpec spec = http.authorizeExchange();
 
         RoleBasedAccessRule rule = rule("/test/**", "/page1").setAnonymous(true);
         customizer = spy(customizer);
@@ -140,7 +139,7 @@ class AccessRulesCustomizerTest {
 
     @Test
     void testApplyRule_anonymous_has_precedence_over_roles_list() {
-        AuthorizeExchangeSpec spec = http.authorizeExchange(withDefaults());
+        AuthorizeExchangeSpec spec = http.authorizeExchange();
 
         RoleBasedAccessRule rule = rule("/test/**", "/page1").setAnonymous(true).setAllowedRoles(List.of("ROLE_ADMIN"));
         customizer = spy(customizer);
@@ -154,7 +153,7 @@ class AccessRulesCustomizerTest {
 
     @Test
     void testApplyRule_authenticated() {
-        AuthorizeExchangeSpec spec = http.authorizeExchange(withDefaults());
+        AuthorizeExchangeSpec spec = http.authorizeExchange();
 
         RoleBasedAccessRule rule = rule("/test/**", "/page1").setAnonymous(false);
         customizer = spy(customizer);
@@ -166,7 +165,7 @@ class AccessRulesCustomizerTest {
 
     @Test
     void testApplyRule_roles() {
-        AuthorizeExchangeSpec spec = http.authorizeExchange(withDefaults());
+        AuthorizeExchangeSpec spec = http.authorizeExchange();
 
         List<String> roles = List.of("ROLE_ADMIN", "ROLE_TESTER");
         RoleBasedAccessRule rule = rule("/test/**", "/page1").setAllowedRoles(roles);
@@ -179,7 +178,7 @@ class AccessRulesCustomizerTest {
 
     @Test
     void testApplyRule_roles_prefix_added_if_missing() {
-        AuthorizeExchangeSpec spec = http.authorizeExchange(withDefaults());
+        AuthorizeExchangeSpec spec = http.authorizeExchange();
 
         List<String> roles = List.of("ADMIN", "TESTER");
         List<String> expected = List.of("ROLE_ADMIN", "ROLE_TESTER");
@@ -193,7 +192,7 @@ class AccessRulesCustomizerTest {
 
     @Test
     void testApplyRule_forbidden() {
-        AuthorizeExchangeSpec spec = http.authorizeExchange(withDefaults());
+        AuthorizeExchangeSpec spec = http.authorizeExchange();
         RoleBasedAccessRule rule = rule("/test/**", "/page1").setForbidden(true);
         customizer = spy(customizer);
         customizer.apply(spec, rule);

--- a/gateway/src/test/java/org/georchestra/gateway/security/accessrules/AccessRulesCustomizerTest.java
+++ b/gateway/src/test/java/org/georchestra/gateway/security/accessrules/AccessRulesCustomizerTest.java
@@ -99,7 +99,7 @@ class AccessRulesCustomizerTest {
         doNothing().when(customizer).apply(any(), any());
         customizer.customize(http);
         verify(customizer, times(4)).apply(any(), ruleCaptor.capture());
-        assertSame(service1Rule1, ruleCaptor.getAllValues().get(0));
+        assertSame(service1Rule1, ruleCaptor.getAllValues().getFirst());
         assertSame(service1Rule2, ruleCaptor.getAllValues().get(1));
         assertSame(global1, ruleCaptor.getAllValues().get(2));
         assertSame(global2, ruleCaptor.getAllValues().get(3));

--- a/gateway/src/test/java/org/georchestra/gateway/security/ldap/LdapConfigPropertiesValidationsTest.java
+++ b/gateway/src/test/java/org/georchestra/gateway/security/ldap/LdapConfigPropertiesValidationsTest.java
@@ -258,7 +258,7 @@ class LdapConfigPropertiesValidationsTest {
             assertThat(config.simpleEnabled()).hasSize(1);
             assertThat(config.extendedEnabled()).isEmpty();
 
-            LdapServerConfig basic = config.simpleEnabled().get(0);
+            LdapServerConfig basic = config.simpleEnabled().getFirst();
             assertThat(basic).hasFieldOrPropertyWithValue("name", "ldap1");
             assertThat(basic).hasFieldOrPropertyWithValue("enabled", true);
             assertThat(basic).hasFieldOrPropertyWithValue("url", "ldap://ldap1.test.com:839");
@@ -290,7 +290,7 @@ class LdapConfigPropertiesValidationsTest {
             assertThat(config.simpleEnabled()).isEmpty();
             assertThat(config.extendedEnabled()).hasSize(1);
 
-            ExtendedLdapConfig extended = config.extendedEnabled().get(0);
+            ExtendedLdapConfig extended = config.extendedEnabled().getFirst();
             assertThat(extended).hasFieldOrPropertyWithValue("name", "ldap1");
             assertThat(extended).hasFieldOrPropertyWithValue("enabled", true);
             assertThat(extended).hasFieldOrPropertyWithValue("url", "ldap://ldap1.test.com:839");

--- a/gateway/src/test/java/org/georchestra/gateway/security/preauth/PreauthGatewaySecurityCustomizerIT.java
+++ b/gateway/src/test/java/org/georchestra/gateway/security/preauth/PreauthGatewaySecurityCustomizerIT.java
@@ -48,7 +48,7 @@ class PreauthGatewaySecurityCustomizerIT {
         WireMockRuntimeInfo runtimeInfo = mockService.getRuntimeInfo();
         String httpBaseUrl = runtimeInfo.getHttpBaseUrl();
         String proxiedURI = URI.create(httpBaseUrl + "/" + "test").normalize().toString();
-        String propertyName = String.format("georchestra.gateway.services.%s.target", "test");
+        String propertyName = "georchestra.gateway.services.%s.target".formatted("test");
         registry.add(propertyName, () -> proxiedURI);
         registry.add("spring.cloud.gateway.routes[0].id", () -> "test");
         registry.add("spring.cloud.gateway.routes[0].uri", () -> proxiedURI);

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,6 @@
     <imageTag>${project.version}</imageTag>
     <spring-boot.build-image.imageName>georchestra/gateway:${imageTag}</spring-boot.build-image.imageName>
     <lombok.version>1.18.36</lombok.version>
-    <logback.version>1.2.13</logback.version>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -146,5 +145,5 @@
         </plugin>
       </plugins>
     </pluginManagement>
- </build>
+  </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.0.13</version>
+    <version>3.1.12</version>
     <relativePath></relativePath>
     <!-- lookup parent from repository -->
   </parent>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.springframework.cloud</groupId>
     <artifactId>spring-cloud-starter-parent</artifactId>
-    <version>2022.0.5</version>
+    <version>2023.0.5</version>
     <relativePath></relativePath>
     <!-- lookup parent from repository -->
   </parent>
@@ -38,11 +38,6 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
-        <groupId>org.yaml</groupId>
-        <artifactId>snakeyaml</artifactId>
-        <version>2.2</version>
-      </dependency>
-      <dependency>
         <groupId>org.springframework.cloud</groupId>
         <artifactId>spring-cloud-dependencies</artifactId>
         <version>${spring-cloud.version}</version>
@@ -72,11 +67,6 @@
           }
           which causes issues.
       -->
-      <dependency>
-        <groupId>org.projectlombok</groupId>
-        <artifactId>lombok</artifactId>
-        <version>${lombok.version}</version>
-      </dependency>
     </dependencies>
   </dependencyManagement>
   <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,7 @@
     </repository>
   </distributionManagement>
   <properties>
+    <java.version>21</java.version>
     <revision>1.2-SNAPSHOT</revision>
     <georchestra.version>24.1-SNAPSHOT</georchestra.version>
     <spring-cloud.version>2021.0.9</spring-cloud.version>
@@ -35,7 +36,7 @@
     <pom.fmt.skip>${fmt.skip}</pom.fmt.skip>
     <imageTag>${project.version}</imageTag>
     <spring-boot.build-image.imageName>georchestra/gateway:${imageTag}</spring-boot.build-image.imageName>
-    <lombok.version>1.18.34</lombok.version>
+    <lombok.version>1.18.36</lombok.version>
     <logback.version>1.2.13</logback.version>
   </properties>
   <dependencyManagement>
@@ -166,7 +167,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.12.1</version>
+          <version>3.14.0</version>
         </plugin>
       </plugins>
     </pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -2,9 +2,9 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>org.springframework.boot</groupId>
-    <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.1.12</version>
+    <groupId>org.springframework.cloud</groupId>
+    <artifactId>spring-cloud-starter-parent</artifactId>
+    <version>2022.0.5</version>
     <relativePath></relativePath>
     <!-- lookup parent from repository -->
   </parent>
@@ -27,15 +27,12 @@
     <java.version>21</java.version>
     <revision>1.2-SNAPSHOT</revision>
     <georchestra.version>24.1-SNAPSHOT</georchestra.version>
-    <spring-cloud.version>2022.0.5</spring-cloud.version>
     <formatter-maven-plugin.version>2.10.0</formatter-maven-plugin.version>
     <fmt.skip>false</fmt.skip>
     <fmt.action>format</fmt.action>
     <!-- or -Dfmt.action=validate -Dpom.fmt.action=verify -->
     <pom.fmt.action>sort</pom.fmt.action>
     <pom.fmt.skip>${fmt.skip}</pom.fmt.skip>
-    <imageTag>${project.version}</imageTag>
-    <spring-boot.build-image.imageName>georchestra/gateway:${imageTag}</spring-boot.build-image.imageName>
     <lombok.version>1.18.36</lombok.version>
   </properties>
   <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.springframework.cloud</groupId>
     <artifactId>spring-cloud-starter-parent</artifactId>
-    <version>2023.0.5</version>
+    <version>2024.0.1</version>
     <relativePath></relativePath>
     <!-- lookup parent from repository -->
   </parent>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>2.7.18</version>
+    <version>3.0.13</version>
     <relativePath></relativePath>
     <!-- lookup parent from repository -->
   </parent>
@@ -27,7 +27,7 @@
     <java.version>21</java.version>
     <revision>1.2-SNAPSHOT</revision>
     <georchestra.version>24.1-SNAPSHOT</georchestra.version>
-    <spring-cloud.version>2021.0.9</spring-cloud.version>
+    <spring-cloud.version>2022.0.5</spring-cloud.version>
     <formatter-maven-plugin.version>2.10.0</formatter-maven-plugin.version>
     <fmt.skip>false</fmt.skip>
     <fmt.action>format</fmt.action>
@@ -45,16 +45,6 @@
         <groupId>org.yaml</groupId>
         <artifactId>snakeyaml</artifactId>
         <version>2.2</version>
-      </dependency>
-      <dependency>
-        <groupId>ch.qos.logback</groupId>
-        <artifactId>logback-core</artifactId>
-        <version>${logback.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>ch.qos.logback</groupId>
-        <artifactId>logback-classic</artifactId>
-        <version>${logback.version}</version>
       </dependency>
       <dependency>
         <groupId>org.springframework.cloud</groupId>
@@ -86,21 +76,6 @@
           }
           which causes issues.
       -->
-      <dependency>
-        <groupId>org.springframework.security</groupId>
-        <artifactId>spring-security-oauth2-client</artifactId>
-        <version>5.6.2</version>
-      </dependency>
-      <dependency>
-        <groupId>org.springframework.security</groupId>
-        <artifactId>spring-security-oauth2-core</artifactId>
-        <version>5.6.2</version>
-      </dependency>
-      <dependency>
-        <groupId>org.springframework.security</groupId>
-        <artifactId>spring-security-oauth2-jose</artifactId>
-        <version>5.6.2</version>
-      </dependency>
       <dependency>
         <groupId>org.projectlombok</groupId>
         <artifactId>lombok</artifactId>
@@ -171,5 +146,5 @@
         </plugin>
       </plugins>
     </pluginManagement>
-  </build>
+ </build>
 </project>


### PR DESCRIPTION
## Summary

- Upgrade to Java 21, Spring Boot 3.4.3, and Spring Cloud 2024.01
- Migrate through Spring Boot 3.0, 3.1, and finally 3.4.3
- Fix compilation errors and test failures during migration
- Support Spring Cloud 2022, 2023, and 2024 releases
- Fix Mockito and JSONObject warnings in tests

## Test plan

All unit and integration tests have been verified to pass with the updated framework versions. Verify gateway functionality in a deployed environment to ensure all routing, security, and integration features function as expected.

---
Supersedes #188