### PR TITLE
fix: removing TokenRelay filter by default

### DIFF
--- a/gateway/src/main/resources/application.yml
+++ b/gateway/src/main/resources/application.yml
@@ -47,7 +47,6 @@ spring:
 
       default-filters:
       - SecureHeaders # add security-related HTTP headers to responses sent from the gateway to clients. See https://blog.appcanary.com/2017/http-security-headers.html
-      - TokenRelay # propagates OAuth2 access tokens from incoming requests to downstream services
       - RemoveSecurityHeaders # removing incoming sec-* headers to prevent impersonation
       - AddSecHeaders # append resolved sec-* headers to proxied requests based on the currently authenticated user
       - PreserveHostHeader # ensure that the original Host header from the incoming HTTP request is preserved and passed along to the downstream service


### PR DESCRIPTION
[TokenRelay](https://docs.spring.io/spring-cloud-gateway/reference/spring-cloud-gateway/gatewayfilter-factories/tokenrelay-factory.html) is responsible for adding a `Authorization` header in the proxified HTTP requests which can lead to weird behaviours with downstream webapps.

Considering that the geOrchestra applications will consume the `sec-*` HTTP headers for authnz, it does not really make sense to propagate the `Authorization: bearer <oauth2 token>` to proxified webapps IMHO.

In fact, this behaviour lead to weird behaviours with some proxified webapps, e.g. geocontrib replying to some HTTP requests with 403 because it was not able to extract any info from the header, not being aware of the oauth2 identity provider which had been used for connection anyway.

It is still possible to use it by defining a custom filter on the route which could be in the need for it, but it seems more reasonable to use it as an "opt in" fashion instead of forcing it by default on every targets.