### PR TITLE
fix: oidc - some fixes related to users info mapping

### DIFF
--- a/gateway/src/main/java/org/georchestra/gateway/accounts/admin/ldap/LdapAccountsManager.java
+++ b/gateway/src/main/java/org/georchestra/gateway/accounts/admin/ldap/LdapAccountsManager.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.apache.commons.lang3.StringUtils;
 import org.georchestra.ds.DataServiceException;
 import org.georchestra.ds.DuplicatedCommonNameException;
@@ -251,16 +252,18 @@ class LdapAccountsManager extends AbstractAccountsManager {
     }
 
     /**
-     * Ensures the organization associated with a user exists in LDAP.
+     * Ensures the role exists in LDAP.
      *
-     * @param newAccount the account whose organization needs verification
+     * @param role The CN of the role LDAP-side as a string.
+     * @throws DataServiceException
      */
-    private void ensureRoleExists(String role) throws DataServiceException {
+    @VisibleForTesting
+    void ensureRoleExists(String role) throws DataServiceException {
         try {
             roleDao.findByCommonName(role);
         } catch (NameNotFoundException notFound) {
             try {
-                roleDao.insert(RoleFactory.create(role, null, null));
+                roleDao.insert(RoleFactory.create(role, null, false));
             } catch (DuplicatedCommonNameException e) {
                 throw new IllegalStateException(e);
             }

--- a/gateway/src/main/java/org/georchestra/gateway/security/oauth2/OAuth2Configuration.java
+++ b/gateway/src/main/java/org/georchestra/gateway/security/oauth2/OAuth2Configuration.java
@@ -18,19 +18,9 @@
  */
 package org.georchestra.gateway.security.oauth2;
 
-import static org.springframework.security.config.Customizer.withDefaults;
-
-import java.lang.reflect.Field;
-import java.net.URI;
-import java.nio.charset.StandardCharsets;
-import java.text.ParseException;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.Map;
-import java.util.stream.Collectors;
-
-import javax.crypto.spec.SecretKeySpec;
-
+import com.nimbusds.jwt.JWT;
+import com.nimbusds.jwt.JWTParser;
+import lombok.extern.slf4j.Slf4j;
 import org.georchestra.gateway.security.GeorchestraGatewaySecurityConfigProperties;
 import org.georchestra.gateway.security.ServerHttpSecurityCustomizer;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -49,6 +39,7 @@ import org.springframework.security.oauth2.client.oidc.web.server.logout.OidcCli
 import org.springframework.security.oauth2.client.registration.ClientRegistration;
 import org.springframework.security.oauth2.client.registration.InMemoryReactiveClientRegistrationRepository;
 import org.springframework.security.oauth2.client.userinfo.DefaultReactiveOAuth2UserService;
+import org.springframework.security.oauth2.core.AuthorizationGrantType;
 import org.springframework.security.oauth2.jose.jws.MacAlgorithm;
 import org.springframework.security.oauth2.jose.jws.SignatureAlgorithm;
 import org.springframework.security.oauth2.jwt.BadJwtException;
@@ -56,15 +47,24 @@ import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.jwt.NimbusReactiveJwtDecoder;
 import org.springframework.security.oauth2.jwt.ReactiveJwtDecoderFactory;
 import org.springframework.security.web.server.authentication.logout.ServerLogoutSuccessHandler;
+import org.springframework.util.CollectionUtils;
+import org.springframework.util.StringUtils;
 import org.springframework.web.reactive.function.client.ExchangeFilterFunction;
 import org.springframework.web.reactive.function.client.WebClient;
-
-import com.nimbusds.jwt.JWT;
-import com.nimbusds.jwt.JWTParser;
-
-import lombok.extern.slf4j.Slf4j;
 import reactor.netty.http.client.HttpClient;
 import reactor.netty.transport.ProxyProvider;
+
+import javax.crypto.spec.SecretKeySpec;
+import java.lang.reflect.Field;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.text.ParseException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.springframework.security.config.Customizer.withDefaults;
 
 /**
  * OAuth2 security configuration for geOrchestra's Gateway.
@@ -268,6 +268,26 @@ public class OAuth2Configuration {
     @Bean
     OidcReactiveOAuth2UserService oidcReactiveOAuth2UserService(DefaultReactiveOAuth2UserService oauth2Delegate) {
         OidcReactiveOAuth2UserService oidUserService = new OidcReactiveOAuth2UserService();
+        oidUserService.setRetrieveUserInfo(userRequest -> {
+            // This is basically the same implementation as the default one in OidcUserRequestUtils::shouldRetrieveUserInfo,
+            // but returning true also if the token does not carry any scopes.
+            //
+            // Since the spring upgrade (PR #190), the token does not carry the scopes anymore, leading to
+            // the default implementation of shouldRetrieveUserInfo returning false. We do need to retrieve
+            // the user infos, else the gateway will likely to be unable to create a LDAP user afterward.
+            ClientRegistration clientRegistration = userRequest.getClientRegistration();
+            if (!StringUtils.hasLength(clientRegistration.getProviderDetails().getUserInfoEndpoint().getUri())) {
+                return false;
+            }
+            if (AuthorizationGrantType.AUTHORIZATION_CODE.equals(clientRegistration.getAuthorizationGrantType())) {
+                if (userRequest.getAccessToken().getScopes().isEmpty()) {
+                    return true;
+                }
+                return CollectionUtils.containsAny(userRequest.getAccessToken().getScopes(),
+                        userRequest.getClientRegistration().getScopes());
+            }
+            return false;
+        });
         oidUserService.setOauth2UserService(oauth2Delegate);
         return oidUserService;
     }

--- a/gateway/src/main/java/org/georchestra/gateway/security/oauth2/OAuth2Configuration.java
+++ b/gateway/src/main/java/org/georchestra/gateway/security/oauth2/OAuth2Configuration.java
@@ -269,12 +269,14 @@ public class OAuth2Configuration {
     OidcReactiveOAuth2UserService oidcReactiveOAuth2UserService(DefaultReactiveOAuth2UserService oauth2Delegate) {
         OidcReactiveOAuth2UserService oidUserService = new OidcReactiveOAuth2UserService();
         oidUserService.setRetrieveUserInfo(userRequest -> {
-            // This is basically the same implementation as the default one in OidcUserRequestUtils::shouldRetrieveUserInfo,
-            // but returning true also if the token does not carry any scopes.
+            // This is basically the same implementation as the default one in
+            // OidcUserRequestUtils::shouldRetrieveUserInfo, but returning true also if the
+            // token does not carry any scopes.
             //
-            // Since the spring upgrade (PR #190), the token does not carry the scopes anymore, leading to
-            // the default implementation of shouldRetrieveUserInfo returning false. We do need to retrieve
-            // the user infos, else the gateway will likely to be unable to create a LDAP user afterward.
+            // Following the spring upgrade (PR #190), the token does not carry the scopes
+            // anymore, leading to the default implementation of shouldRetrieveUserInfo
+            // returning false. We do need to retrieve the user infos, else the gateway will
+            // likely to be unable to create a LDAP user afterward.
             ClientRegistration clientRegistration = userRequest.getClientRegistration();
             if (!StringUtils.hasLength(clientRegistration.getProviderDetails().getUserInfoEndpoint().getUri())) {
                 return false;

--- a/gateway/src/test/java/org/georchestra/gateway/accounts/admin/ldap/LdapAccountsManagerTest.java
+++ b/gateway/src/test/java/org/georchestra/gateway/accounts/admin/ldap/LdapAccountsManagerTest.java
@@ -1,0 +1,26 @@
+package org.georchestra.gateway.accounts.admin.ldap;
+
+import org.georchestra.ds.DataServiceException;
+import org.georchestra.ds.roles.RoleDao;
+import org.georchestra.ds.users.AccountDao;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.ldap.NameNotFoundException;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class LdapAccountsManagerTest {
+
+    public @Test void testEnsureRoleExist() throws DataServiceException {
+        RoleDao roleDao = mock(RoleDao.class);
+        when(roleDao.findByCommonName(anyString())).thenThrow(new NameNotFoundException("FAKE_ROLE"));
+
+        LdapAccountsManager toTest = new LdapAccountsManager(mock(ApplicationEventPublisher.class), null, roleDao, null,
+                null, null, null);
+
+        toTest.ensureRoleExists("FAKE_ROLE");
+        // No exception thrown
+    }
+}


### PR DESCRIPTION
This PR aims to bring some fixes related to OIDC external identity providers interactions.

# Force UserInfo retrieval

Since the spring upgrade (PR #190), the token does not carry the scopes anymore, leading to the default implementation of `shouldRetrieveUserInfo` returning false. We do need to retrieve the user infos, else the gateway will likely to fail creating a LDAP user afterward.

# Avoid exception when a role needs to be created

The following code will throw an exception:
```
RoleImpl r  = new RoleImpl();
r.setFavorite(null);
```
because the `favorite` flag is a scalar boolean: https://github.com/georchestra/georchestra/blob/master/ldap-account-management/src/main/java/org/georchestra/ds/roles/RoleImpl.java#L42, hence not accepting null as a value. Using false instead.

Also fixing the javadoc comment related to the `ensureRoleExists` method.
