### PR TITLE
feat: Support organization MDC

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -33,25 +33,25 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         submodules: 'true'
 
     - name: "Setting up Java"
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v4
       with:
         distribution: 'adopt'
         java-version: '21'
         cache: 'maven'
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
 
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+      uses: github/codeql-action/autobuild@v3
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v3
 

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -8,12 +8,12 @@ jobs:
     timeout-minutes: 15
     steps:
     - name: "Checking out"
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         submodules: 'true'
 
     - name: "Setting up Java"
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v4
       with:
         distribution: 'adopt'
         java-version: '21'

--- a/datadir/gateway/logging.yaml
+++ b/datadir/gateway/logging.yaml
@@ -23,12 +23,15 @@ logging:
   # The following are default values. The MDC attributes will be automatically
   # included when using the json-logs profile. For the regular console output you could tweak the logback-spring.xml
   # config file to include the required MDC properties
+  # In any case, the activated MDC will be visible when using the OpenTelemetry protocol
   mdc:
     include:
       user:
         id: true
         roles: false
         org: true
+        extras: false
+        auth-method: false
       application:
         name: true
         version: true

--- a/datadir/gateway/logging.yaml
+++ b/datadir/gateway/logging.yaml
@@ -28,6 +28,7 @@ logging:
       user:
         id: true
         roles: false
+        org: true
       application:
         name: true
         version: true

--- a/docs/arc42/component_view.md
+++ b/docs/arc42/component_view.md
@@ -68,6 +68,7 @@ This diagram shows the detailed internal structure of the Gateway with component
 - **ResolveGeorchestraUserGlobalFilter**: Extracts authenticated user information
 - **ResolveTargetGlobalFilter**: Determines the target service configuration
 - **GlobalUriFilter**: Fixes URI encoding issues
+- **MdcUserAndOrgGlobalFilter**: Adds user and organization-related MDCs in the access logs
 
 #### Gateway Filter Factories
 - **ApplicationErrorGatewayFilterFactory**: Handles application errors and creates friendly responses

--- a/docs/user_guide/configuration.md
+++ b/docs/user_guide/configuration.md
@@ -157,9 +157,10 @@ logging:
   mdc:
     include:
       user:
-        id: true           # Include user ID in enduser.id
+        id: true           # Include user ID in enduser.id and enduser.uuid
         roles: true        # Include user roles in enduser.roles
-        org: true          # Include user's organization in enduser.org
+        org: true          # Include user's organization ID: enduser.org.id (shortname) and enduser.org.uuid 
+        extras: true       # include human-friendly labels enduser.firstname, enduser.lastname, enduser.org.fullname
         auth-method: true  # Include authentication method in enduser.auth-method
 ```
 

--- a/gateway/src/main/java/org/georchestra/gateway/autoconfigure/app/FiltersAutoConfiguration.java
+++ b/gateway/src/main/java/org/georchestra/gateway/autoconfigure/app/FiltersAutoConfiguration.java
@@ -19,14 +19,13 @@
 package org.georchestra.gateway.autoconfigure.app;
 
 import org.georchestra.gateway.filter.global.ApplicationErrorGatewayFilterFactory;
-import org.georchestra.gateway.filter.global.GeorchestraUserMdcGlobalFilter;
+import org.georchestra.gateway.filter.global.MdcUserAndOrgGlobalFilter;
 import org.georchestra.gateway.filter.global.LoginParamRedirectGatewayFilterFactory;
 import org.georchestra.gateway.filter.global.ResolveTargetGlobalFilter;
 import org.georchestra.gateway.filter.headers.HeaderFiltersConfiguration;
 import org.georchestra.gateway.logging.mdc.config.AuthenticationMdcConfigProperties;
 import org.georchestra.gateway.model.GatewayConfigProperties;
 import org.georchestra.gateway.model.GeorchestraTargetConfig;
-import org.georchestra.gateway.security.ResolveGeorchestraUserGlobalFilter;
 import org.geoserver.cloud.gateway.filter.RouteProfileGatewayFilterFactory;
 import org.geoserver.cloud.gateway.filter.StripBasePathGatewayFilterFactory;
 import org.geoserver.cloud.gateway.predicate.RegExpQueryRoutePredicateFactory;
@@ -85,11 +84,11 @@ public class FiltersAutoConfiguration {
      * <p>
      *
      * @param authConfig the logging auth configuration properties
-     * @return an instance of {@link GeorchestraUserMdcGlobalFilter}
+     * @return an instance of {@link MdcUserAndOrgGlobalFilter}
      */
     @Bean
-    GeorchestraUserMdcGlobalFilter resolveGeorchestraUserMdcWebFilter(AuthenticationMdcConfigProperties authConfig) {
-        return new GeorchestraUserMdcGlobalFilter(authConfig);
+    MdcUserAndOrgGlobalFilter resolveGeorchestraUserMdcWebFilter(AuthenticationMdcConfigProperties authConfig) {
+        return new MdcUserAndOrgGlobalFilter(authConfig);
     }
 
     /**

--- a/gateway/src/main/java/org/georchestra/gateway/autoconfigure/app/FiltersAutoConfiguration.java
+++ b/gateway/src/main/java/org/georchestra/gateway/autoconfigure/app/FiltersAutoConfiguration.java
@@ -19,11 +19,14 @@
 package org.georchestra.gateway.autoconfigure.app;
 
 import org.georchestra.gateway.filter.global.ApplicationErrorGatewayFilterFactory;
+import org.georchestra.gateway.filter.global.GeorchestraUserMdcGlobalFilter;
 import org.georchestra.gateway.filter.global.LoginParamRedirectGatewayFilterFactory;
 import org.georchestra.gateway.filter.global.ResolveTargetGlobalFilter;
 import org.georchestra.gateway.filter.headers.HeaderFiltersConfiguration;
+import org.georchestra.gateway.logging.mdc.config.AuthenticationMdcConfigProperties;
 import org.georchestra.gateway.model.GatewayConfigProperties;
 import org.georchestra.gateway.model.GeorchestraTargetConfig;
+import org.georchestra.gateway.security.ResolveGeorchestraUserGlobalFilter;
 import org.geoserver.cloud.gateway.filter.RouteProfileGatewayFilterFactory;
 import org.geoserver.cloud.gateway.filter.StripBasePathGatewayFilterFactory;
 import org.geoserver.cloud.gateway.predicate.RegExpQueryRoutePredicateFactory;
@@ -56,7 +59,7 @@ import org.springframework.context.annotation.Import;
 @AutoConfiguration
 @AutoConfigureBefore(GatewayAutoConfiguration.class)
 @Import(HeaderFiltersConfiguration.class)
-@EnableConfigurationProperties(GatewayConfigProperties.class)
+@EnableConfigurationProperties({ GatewayConfigProperties.class, AuthenticationMdcConfigProperties.class })
 public class FiltersAutoConfiguration {
 
     /**
@@ -73,6 +76,20 @@ public class FiltersAutoConfiguration {
     @Bean
     ResolveTargetGlobalFilter resolveTargetWebFilter(GatewayConfigProperties config) {
         return new ResolveTargetGlobalFilter(config);
+    }
+
+    /**
+     * Registers a {@link GlobalFilter} that adds user and org-related MDC (Mapping
+     * Diagnostic Context) if respectively logging.mdc.include.user.id = true and
+     * logging.mdc.include.user.org= true
+     * <p>
+     *
+     * @param authConfig the logging auth configuration properties
+     * @return an instance of {@link GeorchestraUserMdcGlobalFilter}
+     */
+    @Bean
+    GeorchestraUserMdcGlobalFilter resolveGeorchestraUserMdcWebFilter(AuthenticationMdcConfigProperties authConfig) {
+        return new GeorchestraUserMdcGlobalFilter(authConfig);
     }
 
     /**

--- a/gateway/src/main/java/org/georchestra/gateway/filter/global/GeorchestraUserMdcGlobalFilter.java
+++ b/gateway/src/main/java/org/georchestra/gateway/filter/global/GeorchestraUserMdcGlobalFilter.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (C) 2022 by the geOrchestra PSC
+ *
+ * This file is part of geOrchestra.
+ *
+ * geOrchestra is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * geOrchestra is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * geOrchestra. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.georchestra.gateway.filter.global;
+
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.georchestra.gateway.logging.mdc.config.AuthenticationMdcConfigProperties;
+import org.georchestra.gateway.logging.mdc.webflux.ReactorContextHolder;
+import org.georchestra.gateway.model.*;
+import org.georchestra.gateway.security.ResolveGeorchestraUserGlobalFilter;
+import org.georchestra.security.model.GeorchestraUser;
+import org.georchestra.security.model.Organization;
+import org.springframework.cloud.gateway.filter.GatewayFilterChain;
+import org.springframework.cloud.gateway.filter.GlobalFilter;
+import org.springframework.cloud.gateway.route.Route;
+import org.springframework.core.Ordered;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Mono;
+
+import java.util.*;
+
+/**
+ * A {@link GlobalFilter} that adds user and org-related MDC (Mapping Diagnostic
+ * Context) if respectively logging.mdc.include.user.id = true and
+ * logging.mdc.include.user.org= true
+ * <p>
+ * This filter executes after user and org resolution in
+ * {@link ResolveGeorchestraUserGlobalFilter}.
+ * </p>
+ */
+@RequiredArgsConstructor
+@Slf4j
+public class GeorchestraUserMdcGlobalFilter implements GlobalFilter, Ordered {
+
+    /**
+     * The execution order of this filter, ensuring it runs after user/org
+     * resolution
+     */
+    public static final int ORDER = ResolveGeorchestraUserGlobalFilter.ORDER + 2;
+
+    private final @NonNull AuthenticationMdcConfigProperties authConfig;
+
+    public static final String MDC_CONTEXT_KEY = "MDC";
+
+    /**
+     * Ensures that this filter runs after the matched {@link Route} has been set as
+     * an attribute in the {@link ServerWebExchange}.
+     *
+     * @return the execution order of this filter
+     */
+    @Override
+    public int getOrder() {
+        return GeorchestraUserMdcGlobalFilter.ORDER;
+    }
+
+    /**
+     * Adds some MDC related to user and org auth information, if enabled.
+     *
+     * @param exchange the current server exchange
+     * @param chain    the gateway filter chain
+     * @return a {@link Mono} that proceeds with the filter chain execution
+     */
+    @Override
+    public Mono<Void> filter(ServerWebExchange exchange, GatewayFilterChain chain) {
+        log.debug("Activated GeorchestraUserMdcGlobalFilter");
+        return chain.filter(exchange).contextWrite(context -> {
+            Map<String, String> mdcMap = context.getOrEmpty(ReactorContextHolder.MDC_CONTEXT_KEY)
+                    .map(map -> new HashMap<>((Map<String, String>) map)).orElseGet(HashMap::new);
+            if (authConfig.isOrg()) {
+                // Add custom MDC attributes
+                Optional<Organization> opt_org = GeorchestraOrganizations.resolve(exchange);
+                opt_org.ifPresent(org -> {
+                    mdcMap.put("enduser.org.id", org.getId());
+                    mdcMap.put("enduser.org.shortname", org.getShortName());
+                    mdcMap.put("enduser.org.fullname", org.getName());
+                });
+            }
+            if (authConfig.isId()) {
+                // Add custom MDC attributes
+                Optional<GeorchestraUser> opt_user = GeorchestraUsers.resolve(exchange);
+                opt_user.ifPresent(user -> {
+                    mdcMap.put("enduser.firstname", user.getFirstName());
+                    mdcMap.put("enduser.lastname", user.getLastName());
+                    mdcMap.put("enduser.uuid", user.getId());
+                });
+            }
+            return context.put(ReactorContextHolder.MDC_CONTEXT_KEY, mdcMap);
+        });
+    }
+}

--- a/gateway/src/main/java/org/georchestra/gateway/filter/global/GeorchestraUserMdcGlobalFilter.java
+++ b/gateway/src/main/java/org/georchestra/gateway/filter/global/GeorchestraUserMdcGlobalFilter.java
@@ -87,7 +87,7 @@ public class GeorchestraUserMdcGlobalFilter implements GlobalFilter, Ordered {
                 // Add custom MDC attributes
                 Optional<Organization> opt_org = GeorchestraOrganizations.resolve(exchange);
                 opt_org.ifPresent(org -> {
-                    mdcMap.put("enduser.org.id", org.getId());
+                    mdcMap.put("enduser.org.uuid", org.getId());
                     mdcMap.put("enduser.org.shortname", org.getShortName());
                     mdcMap.put("enduser.org.fullname", org.getName());
                 });

--- a/gateway/src/main/java/org/georchestra/gateway/filter/global/MdcUserAndOrgGlobalFilter.java
+++ b/gateway/src/main/java/org/georchestra/gateway/filter/global/MdcUserAndOrgGlobalFilter.java
@@ -37,8 +37,9 @@ import reactor.core.publisher.Mono;
 import java.util.*;
 
 /**
- * A {@link GlobalFilter} that adds user and org-related MDC (Mapping Diagnostic
- * Context) if respectively logging.mdc.include.user.id = true and
+ * A {@link GlobalFilter} that adds user and org-related MDC (Mapping Diagnostic Context) if respectively
+ * logging.mdc.include.user.id = true
+ * and
  * logging.mdc.include.user.org= true
  * <p>
  * This filter executes after user and org resolution in
@@ -47,7 +48,7 @@ import java.util.*;
  */
 @RequiredArgsConstructor
 @Slf4j
-public class GeorchestraUserMdcGlobalFilter implements GlobalFilter, Ordered {
+public class MdcUserAndOrgGlobalFilter implements GlobalFilter, Ordered {
 
     /**
      * The execution order of this filter, ensuring it runs after user/org
@@ -67,7 +68,7 @@ public class GeorchestraUserMdcGlobalFilter implements GlobalFilter, Ordered {
      */
     @Override
     public int getOrder() {
-        return GeorchestraUserMdcGlobalFilter.ORDER;
+        return MdcUserAndOrgGlobalFilter.ORDER;
     }
 
     /**
@@ -88,17 +89,21 @@ public class GeorchestraUserMdcGlobalFilter implements GlobalFilter, Ordered {
                 Optional<Organization> opt_org = GeorchestraOrganizations.resolve(exchange);
                 opt_org.ifPresent(org -> {
                     mdcMap.put("enduser.org.uuid", org.getId());
-                    mdcMap.put("enduser.org.shortname", org.getShortName());
-                    mdcMap.put("enduser.org.fullname", org.getName());
+                    mdcMap.put("enduser.org.id", org.getShortName());
+                    if (authConfig.isExtras()) {
+                        mdcMap.put("enduser.org.fullname", org.getName());
+                    }
                 });
             }
             if (authConfig.isId()) {
                 // Add custom MDC attributes
                 Optional<GeorchestraUser> opt_user = GeorchestraUsers.resolve(exchange);
                 opt_user.ifPresent(user -> {
-                    mdcMap.put("enduser.firstname", user.getFirstName());
-                    mdcMap.put("enduser.lastname", user.getLastName());
                     mdcMap.put("enduser.uuid", user.getId());
+                    if (authConfig.isExtras()) {
+                        mdcMap.put("enduser.firstname", user.getFirstName());
+                        mdcMap.put("enduser.lastname", user.getLastName());
+                    }
                 });
             }
             return context.put(ReactorContextHolder.MDC_CONTEXT_KEY, mdcMap);

--- a/modules/logging/src/main/java/org/georchestra/gateway/logging/mdc/config/AuthenticationMdcConfigProperties.java
+++ b/modules/logging/src/main/java/org/georchestra/gateway/logging/mdc/config/AuthenticationMdcConfigProperties.java
@@ -52,17 +52,23 @@ import lombok.Data;
 @ConfigurationProperties(prefix = "logging.mdc.include.user")
 public class AuthenticationMdcConfigProperties {
 
-    /** Whether to append the enduser.id MDC property for the authenticated user. */
+    /** Whether to append the enduser.id and enduser.uuid MDC properties for the authenticated user. */
     private boolean id = true;
 
     /** Whether to append the enduser.roles MDC property containing user roles. */
     private boolean roles = false;
 
     /**
-     * Whether to append the enduser.org MDC property representing the user's
+     * Whether to append the enduser.org.id and enduser.org.uuid MDC properties representing the user's
      * organization.
      */
     private boolean org = false;
+
+    /**
+     * Whether to append extra MDC properties for the authenticated user:
+     * enduser.firstname, enduser.lastname, enduser.org.fullname
+     */
+    private boolean extras = false;
 
     /**
      * Whether to append the enduser.auth-method MDC property for the authentication

--- a/modules/logging/src/main/java/org/georchestra/gateway/logging/mdc/webflux/MDCWebFilter.java
+++ b/modules/logging/src/main/java/org/georchestra/gateway/logging/mdc/webflux/MDCWebFilter.java
@@ -223,8 +223,8 @@ public class MDCWebFilter implements OrderedWebFilter {
         }
 
         // Note: Organization is not added here as it's specific to geOrchestra user
-        // objects
-        // and would need to be handled separately based on the actual user object type
+        // objects. It is handled in
+        // gateway/src/main/java/org/georchestra/gateway/filter/global/GeorchestraUserMdcGlobalFilter.java
     }
 
     /**


### PR DESCRIPTION
Solves https://github.com/georchestra/georchestra-gateway/issues/195

Resolving the user and organisation information requires to intervene at a late stage, much later than the logging MDCWebFilter class (after ResolveGeorchestraUserGlobalFilter). Resolving the objects would also imply a circular dependency if implemented in the logging module. So, it seems to make more sense to implement it in the main geOrchestra gateway code.