### PR TITLE
fix: bump GH actions on docker and docs

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -14,12 +14,12 @@ jobs:
     timeout-minutes: 15
     steps:
     - name: "Checking out"
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         submodules: 'true'
 
     - name: "Setting up Java"
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v4
       with:
         distribution: 'adopt'
         java-version: '21'
@@ -41,7 +41,7 @@ jobs:
 
     - name: "Log in to docker.io"
       if: github.repository == 'georchestra/georchestra-gateway'
-      uses: azure/docker-login@v1
+      uses: docker/login-action@v3
       with:
         username: '${{ secrets.DOCKER_HUB_USERNAME }}'
         password: '${{ secrets.DOCKER_HUB_PASSWORD }}'
@@ -62,7 +62,7 @@ jobs:
 
     - name: "Update Gateway Docker Hub Description"
       if: github.ref == 'refs/heads/main' && github.repository == 'georchestra/georchestra-gateway' && github.actor != 'dependabot[bot]' && github.event_name != 'pull_request'
-      uses: peter-evans/dockerhub-description@v3
+      uses: peter-evans/dockerhub-description@v4
       with:
         username: ${{ secrets.DOCKER_HUB_USERNAME }}
         password: ${{ secrets.DOCKER_HUB_PASSWORD }}
@@ -72,7 +72,7 @@ jobs:
 
     - name: Login to GitHub Container Registry
       if: github.ref == 'refs/heads/main' && github.repository == 'georchestra/georchestra-gateway'
-      uses: docker/login-action@v1
+      uses: docker/login-action@v3
       with:
         registry: ghcr.io
         username: ${{ github.actor }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -28,14 +28,14 @@ jobs:
         
       # Step 1: Set up dependencies
       - name: Setup Java
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: '21'
           cache: 'maven'
           
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.10'
           cache: 'pip'


### PR DESCRIPTION
Docker action was failing due to the old `actions/setup-java@v2`. Was fixed on other actions by #f77e6c3 but forgot to fix in here.
Replaced the `azure/docker-login@v1` action since this one is deprecated (see https://github.com/Azure/docker-login)