### PR TITLE
Add shells to debug images

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -37,7 +37,9 @@ jobs:
 
     - name: "Build docker image"
       if: github.repository == 'georchestra/georchestra-gateway'
-      run: make docker
+      run: |
+        make docker
+        make docker-debug
 
     - name: "Log in to docker.io"
       if: github.repository == 'georchestra/georchestra-gateway'
@@ -48,17 +50,16 @@ jobs:
 
     - name: "Push latest to docker.io"
       if: github.ref == 'refs/heads/main' && github.repository == 'georchestra/georchestra-gateway'
-      run: docker push georchestra/gateway:latest
+      run: |
+        docker push georchestra/gateway:latest
+        docker push georchestra/gateway:latest-debug
 
     - name: "Pushing release branch to docker.io"
-      if: endsWith(github.ref, '.x') && github.repository == 'georchestra/georchestra-gateway' && github.actor != 'dependabot[bot]' && github.event_name != 'pull_request'
+      if: (endsWith(github.ref, '.x') || github.ref_type == 'tag') && github.repository == 'georchestra/georchestra-gateway' && github.actor != 'dependabot[bot]' && github.event_name != 'pull_request'
       run: |
         docker tag georchestra/gateway:latest georchestra/gateway:${{ steps.version.outputs.VERSION }}
         docker push georchestra/gateway:${{ steps.version.outputs.VERSION }}
-
-    - name: "Push tagged image to docker.io"
-      if: github.ref_type == 'tag' && github.ref != 'refs/heads/main' && github.repository == 'georchestra/georchestra-gateway'
-      run: docker push georchestra/gateway:${{ steps.version.outputs.VERSION }}
+        docker push georchestra/gateway:${{ steps.version.outputs.VERSION }}-debug
 
     - name: "Update Gateway Docker Hub Description"
       if: github.ref == 'refs/heads/main' && github.repository == 'georchestra/georchestra-gateway' && github.actor != 'dependabot[bot]' && github.event_name != 'pull_request'

--- a/DOCKER_HUB.md
+++ b/DOCKER_HUB.md
@@ -9,6 +9,7 @@
 # Featured tags
 
 - `latest`, `2.0.x`, `1.1.2`
+- `latest-debug`, `2.0.x-debug`. It enables shell inside the container for debugging purposes.
 
 # Quick reference
 

--- a/Makefile
+++ b/Makefile
@@ -13,5 +13,10 @@ docker:
 	docker tag georchestra/gateway:$${TAG} georchestra/gateway:latest && \
 	docker images|grep "georchestra/gateway"|grep latest
 
+docker-debug:
+	@TAG=`./mvnw -f gateway/ help:evaluate -q -DforceStdout -Dexpression=imageTag` && \
+	./mvnw package -f gateway/ -Pdocker-debug -ntp -DskipTests && \
+	docker tag georchestra/gateway:$${TAG} georchestra/gateway:latest-debug
+
 deb: install
 	./mvnw package deb:package -f gateway/ -PdebianPackage

--- a/gateway/pom.xml
+++ b/gateway/pom.xml
@@ -253,6 +253,33 @@
       </build>
     </profile>
     <profile>
+        <id>docker-debug</id>
+        <build>
+            <plugins>
+                <plugin>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-maven-plugin</artifactId>
+                    <executions>
+                        <execution>
+                            <id>build-image</id>
+                            <goals>
+                                <goal>build-image</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                    <configuration>
+                        <image>
+                            <builder>paketobuildpacks/builder-jammy-base</builder>
+                            <name>georchestra/${project.artifactId}:${project.version}-debug</name>
+                            <pullPolicy>IF_NOT_PRESENT</pullPolicy>
+                        </image>
+                        <jvmOptions>-XX:MaxRAMPercentage=80 -XX:+UseParallelGC</jvmOptions>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </build>
+    </profile>
+    <profile>
       <id>debianPackage</id>
       <build>
         <finalName>${project.artifactId}</finalName>


### PR DESCRIPTION
Creates new docker images with appending `-debug` to images names on main, stable branch and tags.

Allows to use shell inside images