### PR TITLE
Fix #231 - force username from ldap if possible

### DIFF
--- a/gateway/src/main/java/org/georchestra/gateway/accounts/admin/AbstractAccountsManager.java
+++ b/gateway/src/main/java/org/georchestra/gateway/accounts/admin/AbstractAccountsManager.java
@@ -159,6 +159,11 @@ public abstract class AbstractAccountsManager implements AccountManager {
             GeorchestraUser existing = findInternal(mapped).orElse(null);
             // verify if user org match between ldap and OAuth2 info
             if (!isSameOrgUniqueId(mapped, existing)) {
+                // force username from ldap instead unknown external username
+                // See issue #231 : https://github.com/georchestra/georchestra-gateway/issues/231
+                if (existing != null) {
+                    mapped.setUsername(existing.getUsername());
+                }
                 // we find or create org from this orgUniqueId and add user to this org
                 // unlink
                 unlinkUserOrg(existing);


### PR DESCRIPTION
> ref issue #231 

This PR will replace unknown external auth (oidc) username by ldap username if user exists.

This is usefull to retrieve correct user to insert into new org (if org doesn't exists).

This avoid as `500 error - user id does not exists` (see issue to get more details.)