### PR TITLE
#230 - Use static path to find provider button's img

### DIFF
--- a/gateway/src/main/java/org/georchestra/gateway/app/StaticResourcesUtils.java
+++ b/gateway/src/main/java/org/georchestra/gateway/app/StaticResourcesUtils.java
@@ -1,0 +1,89 @@
+package org.georchestra.gateway.app;
+
+import org.springframework.core.env.Environment;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.FileSystemResource;
+import org.springframework.core.io.Resource;
+import org.springframework.util.StringUtils;
+
+/**
+ * Utility methods for resolving and checking static resources, and for
+ * computing the web prefix used to serve static content.
+ */
+public class StaticResourcesUtils {
+    /**
+     * Resolves a resource path into a Spring {@link Resource} instance.
+     * <p>
+     * Supported prefixes:
+     * <ul>
+     * <li><b>classpath:</b> resolved as a {@link ClassPathResource}</li>
+     * <li><b>file:</b> resolved as a {@link FileSystemResource}</li>
+     * <li>otherwise</li>
+     * </ul>
+     * If no prefix is provided, the path is interpreted as a filesystem path.
+     *
+     * @param path fully qualified resource path
+     * @return the resolved {@link Resource}
+     */
+    public static Resource resolveResource(String path) {
+        if (path.startsWith("classpath:")) {
+            return new ClassPathResource(path.substring(10));
+        }
+        if (path.startsWith("file:")) {
+            return new FileSystemResource(path.substring(5));
+        }
+        return new FileSystemResource(path);
+    }
+
+    /**
+     * Checks whether a resource exists and is readable.
+     * <p>
+     * Resolution is delegated to {@link #resolveResource(String)}.
+     *
+     * @param path fully qualified resource path
+     * @return {@code true} if the resource exists and can be read
+     */
+    public static boolean resourceExists(String path) {
+        return resolveResource(path).isReadable();
+    }
+
+    /**
+     * Computes the web prefix used for serving static resources, based on Spring
+     * MVC or WebFlux configuration.
+     * <p>
+     * Reads:
+     * <ul>
+     * <li>{@code spring.webflux.static-path-pattern}</li>
+     * <li>{@code spring.mvc.static-path-pattern}</li>
+     * </ul>
+     * If no pattern is defined, "/" is returned. The resulting prefix is normalized
+     * to start and end with a slash, and the terminal "/**" pattern is removed if
+     * present.
+     *
+     * @param environment the Spring {@link Environment}
+     * @return the normalized static web prefix (for example "/static/")
+     */
+    public static String computeStaticResourceWebPrefix(Environment environment) {
+        String pattern = environment.getProperty("spring.webflux.static-path-pattern");
+        if (!StringUtils.hasText(pattern)) {
+            pattern = environment.getProperty("spring.mvc.static-path-pattern");
+        }
+        if (!StringUtils.hasText(pattern)) {
+            return "/";
+        }
+        pattern = pattern.trim();
+        if (!pattern.startsWith("/")) {
+            pattern = "/" + pattern;
+        }
+        if (pattern.endsWith("/**")) {
+            pattern = pattern.substring(0, pattern.length() - 2);
+        }
+        if (pattern.isEmpty() || "/".equals(pattern)) {
+            return "/";
+        }
+        if (!pattern.endsWith("/")) {
+            pattern = pattern + "/";
+        }
+        return pattern;
+    }
+}


### PR DESCRIPTION
> ref. issue  #230 

### Description

This PR Introduced ProviderLogoResolver to centralize OAuth logo lookups according to datadir static directory (overrides) :

https://docs.georchestra.org/gateway/en/latest/user_guide/ui_customization/?h=thym#static-resources


- [x] Java doc
- [x] Tests


Here an example to use a custom png with franceconnect (boat) : 

<img width="406" height="144" alt="image" src="https://github.com/user-attachments/assets/486f2cd7-aa35-4111-a575-5acf0cafe8e9" />

### How to test ?

1. Fetch branch
2. Copy [/templates](https://github.com/jdev-org/georchestra-gateway/tree/main/gateway/src/main/resources/templates) into [gateway's datadir](https://github.com/georchestra/georchestra-gateway/tree/main/datadir/gateway)
3. Copy [/static](https://github.com/jdev-org/georchestra-gateway/tree/main/gateway/src/main/resources/static) into previous datadir/gateway/templates
4. Change [datadir/gateway/application.yaml](https://github.com/georchestra/georchestra-gateway/blob/main/datadir/gateway/application.yaml) to use static ([doc](https://docs.georchestra.org/gateway/en/latest/user_guide/ui_customization/?h=thym#static-resources)) ressources and templates ([doc](https://docs.georchestra.org/gateway/en/latest/user_guide/ui_customization/?h=thym#main-principles)) :

in application.yaml, replace : 

```
spring:
  cloud:

```
By : 

```
spring:
  thymeleaf:
    prefix: file:${georchestra.datadir}/gateway/templates/
  web:
    resources:
      static-locations: file:${georchestra.datadir}/gateway/templates/static/
  webflux:
    static-path-pattern: /static/**
  cloud:
```
  
5. Play with PNG located in `datadir/gateway/templates/static/img`

Example, if you set a `franceconnect` provider, use a png names `franceconnect.png` in `templates/static` directory.
  
