### PR TITLE
Fix mvn build without docker env

### DIFF
--- a/gateway/src/test/java/org/georchestra/gateway/accounts/admin/CreateAccountUserCustomizerIT.java
+++ b/gateway/src/test/java/org/georchestra/gateway/accounts/admin/CreateAccountUserCustomizerIT.java
@@ -1,6 +1,7 @@
 package org.georchestra.gateway.accounts.admin;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -22,6 +23,7 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.test.web.reactive.server.WebTestClient;
+import org.testcontainers.DockerClientFactory;
 
 /**
  * Integration tests for {@link CreateAccountUserCustomizer}.
@@ -39,6 +41,7 @@ public class CreateAccountUserCustomizerIT {
     public static GeorchestraLdapContainer ldap = new GeorchestraLdapContainer();
 
     public static @BeforeAll void startUpContainers() {
+        assumeTrue(DockerClientFactory.instance().isDockerAvailable(), "Docker is required for this integration test");
         ldap.start();
     }
 

--- a/gateway/src/test/java/org/georchestra/gateway/accounts/admin/PreauthHttpHeadersBase64EncodedCreateAccountIT.java
+++ b/gateway/src/test/java/org/georchestra/gateway/accounts/admin/PreauthHttpHeadersBase64EncodedCreateAccountIT.java
@@ -1,6 +1,7 @@
 package org.georchestra.gateway.accounts.admin;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import org.georchestra.ds.users.Account;
 import org.georchestra.ds.users.AccountDao;
@@ -16,6 +17,7 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.test.web.reactive.server.WebTestClient;
+import org.testcontainers.DockerClientFactory;
 
 @SpringBootTest(classes = GeorchestraGatewayApplication.class)
 @AutoConfigureWebTestClient(timeout = "PT20S")
@@ -29,6 +31,7 @@ class PreauthHttpHeadersBase64EncodedCreateAccountIT {
     public static GeorchestraLdapContainer ldap = new GeorchestraLdapContainer();
 
     public static @BeforeAll void startUpContainers() {
+        assumeTrue(DockerClientFactory.instance().isDockerAvailable(), "Docker is required for this integration test");
         ldap.start();
     }
 

--- a/gateway/src/test/java/org/georchestra/gateway/security/DefaultVsCustomGeorchestraHeadersConfigIT.java
+++ b/gateway/src/test/java/org/georchestra/gateway/security/DefaultVsCustomGeorchestraHeadersConfigIT.java
@@ -5,6 +5,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.getAllServeEvents;
 import static com.github.tomakehurst.wiremock.client.WireMock.ok;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.List;
@@ -26,6 +27,7 @@ import org.springframework.test.web.reactive.server.WebTestClient;
 import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
 import com.github.tomakehurst.wiremock.junit5.WireMockTest;
 import com.github.tomakehurst.wiremock.stubbing.ServeEvent;
+import org.testcontainers.DockerClientFactory;
 
 @SpringBootTest(classes = GeorchestraGatewayApplication.class)
 @WireMockTest
@@ -42,6 +44,7 @@ public class DefaultVsCustomGeorchestraHeadersConfigIT {
 
     @BeforeAll
     public static void setUp(WireMockRuntimeInfo wmri) {
+        assumeTrue(DockerClientFactory.instance().isDockerAvailable(), "Docker is required for this integration test");
         DefaultVsCustomGeorchestraHeadersConfigIT.wmri = wmri;
         ldap.start();
         System.setProperty("wmHost", "localhost");

--- a/gateway/src/test/java/org/georchestra/gateway/security/ResolveGeorchestraUserGlobalFilterIT.java
+++ b/gateway/src/test/java/org/georchestra/gateway/security/ResolveGeorchestraUserGlobalFilterIT.java
@@ -1,5 +1,6 @@
 package org.georchestra.gateway.security;
 
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.util.List;
@@ -21,6 +22,7 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.reactive.server.WebTestClient;
+import org.testcontainers.DockerClientFactory;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.utility.DockerImageName;
 
@@ -51,6 +53,7 @@ public class ResolveGeorchestraUserGlobalFilterIT {
     };
 
     public static @BeforeAll void startUpContainers() {
+        assumeTrue(DockerClientFactory.instance().isDockerAvailable(), "Docker is required for this integration test");
         httpEcho.setExposedPorts(List.of(80));
         httpEcho.start();
         ldap.start();

--- a/gateway/src/test/java/org/georchestra/gateway/security/ldap/extended/ExtendedLdapAuthenticationIT.java
+++ b/gateway/src/test/java/org/georchestra/gateway/security/ldap/extended/ExtendedLdapAuthenticationIT.java
@@ -1,5 +1,7 @@
 package org.georchestra.gateway.security.ldap.extended;
 
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
 import org.georchestra.gateway.app.GeorchestraGatewayApplication;
 import org.georchestra.testcontainers.ldap.GeorchestraLdapContainer;
 import org.junit.jupiter.api.AfterAll;
@@ -12,6 +14,7 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.test.web.reactive.server.WebTestClient;
+import org.testcontainers.DockerClientFactory;
 
 @SpringBootTest(classes = GeorchestraGatewayApplication.class)
 @ActiveProfiles({ "createaccount" })
@@ -22,6 +25,7 @@ public class ExtendedLdapAuthenticationIT {
     private @Autowired WebTestClient testClient;
 
     public static @BeforeAll void startUpContainers() {
+        assumeTrue(DockerClientFactory.instance().isDockerAvailable(), "Docker is required for this integration test");
         ldap.start();
     }
 


### PR DESCRIPTION
Without docker env, maven tests fails : 

```
\[ERROR\] org.georchestra.gateway.accounts.admin.CreateAccountUserCustomizerIT -- Time elapsed: 0.010 s \<\<\< ERROR!
java.lang.IllegalStateException: Previous attempts to find a Docker environment failed. Will not retry. Please see logs and check configuration

```

This PR allows to build without having a docker environment.