### PR TITLE
Implement an organization name resolver and add Sirene 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ test:
 	./mvnw verify -ntp
 
 docker:
+	./mvnw install -ntp -DskipTests -pl modules/org-resolvers,modules/sirene,modules/logging -am
 	@TAG=`./mvnw -f gateway/ help:evaluate -q -DforceStdout -Dexpression=imageTag` && \
 	./mvnw package -f gateway/ -Pdocker -ntp -DskipTests && \
 	echo tagging georchestra/gateway:$${TAG} as georchestra/gateway:latest && \
@@ -14,6 +15,7 @@ docker:
 	docker images|grep "georchestra/gateway"|grep latest
 
 docker-debug:
+	./mvnw install -ntp -DskipTests -pl modules/org-resolvers,modules/sirene,modules/logging -am
 	@TAG=`./mvnw -f gateway/ help:evaluate -q -DforceStdout -Dexpression=imageTag` && \
 	./mvnw package -f gateway/ -Pdocker,docker-debug -ntp -DskipTests && \
 	docker tag georchestra/gateway:$${TAG}-debug georchestra/gateway:latest-debug

--- a/datadir/gateway/security.yaml
+++ b/datadir/gateway/security.yaml
@@ -10,11 +10,20 @@ georchestra:
       # You can disable UID transformation for an IDP by its identifier
       # This lead to not prefixing or sanitize the UID from this IDP
       #disableUidTransformation: 'icu'
+
       #events:
       #  accountcreated:
       #    # Set this url to console's endpoint to be able to receive an email when a new user logs in
       #    #  for the first time with an IDP and is created in LDAP.
       #    url: "http://console:8080/console/internal/events/accountcreated"
+      #
+
+      # Used to enable sirene API calls to resolve organization names from SIRET codes.
+      # If enabled, make sure to set the SIRENE_API_KEY env variable with a valid API key from https://portail-api.insee.fr/.
+      #sirene:
+      #  enabled: true
+      #  api-key: ${SIRENE_API_KEY}
+
       oauth2:
         # if enabled, make sure to have at least one OAuth2 client
         # set up at spring.security.oauth2.client below 
@@ -65,6 +74,29 @@ georchestra:
             searchFilter: (&(objectClass=user)(userPrincipalName={0}))
           adminDn: uid=gdi-admin,ou=myorg,ou=Applications
           adminPassword: s3cr3t
+
+      #oidc:
+      #  config:
+      #    provider:
+      #      icu:
+      #        searchEmail: true # Determines if the user will be searched by email (false by default).
+      #        moderatedSignup: true # if true, users logging in with this provider for the first time will be created in LDAP but disabled, waiting for an admin to validate them. If false, they will be created as enabled.
+      #        useSireneApi: true  # enable SIRENE resolution on this provider
+      #        overrideExistingOrgName: false # don't update existing orgs
+      #        orgNameResolvers: # fallback chain
+      #          - sirene # try to resolve org name from SIRENE API using the siret from the token: need to be configured above (enabled + token)
+      #          - identifier # use the identifier from the token (e.g. "siret:12345678901234")
+      #          - static:NO_ORG # fallback to this static name if the previous resolvers fail. MATCH the shortname of an existing org or it will be created as a new one with this name.
+      #  # Claims mapping from the OIDC provider's token to the user details used by the gateway and downstream services.
+      #  claims:
+      #    provider:
+      #      icu:
+      #        id.path: "$.sub"
+      #        email.path: "$.email"
+      #        familyName.path: "$.usual_name"
+      #        givenName.path: "$.given_name"
+      #        organization.path: "$.siret"
+      #        organizationUid.path: "$.siret"
 
 # If georchestra.gateway.security.oauth2.enabled == true above, set up
 # the OAuth2/OpenID Connect registrations here.

--- a/datadir/gateway/security.yaml
+++ b/datadir/gateway/security.yaml
@@ -81,12 +81,11 @@ georchestra:
       #      icu:
       #        searchEmail: true # Determines if the user will be searched by email (false by default).
       #        moderatedSignup: true # if true, users logging in with this provider for the first time will be created in LDAP but disabled, waiting for an admin to validate them. If false, they will be created as enabled.
-      #        useSireneApi: true  # enable SIRENE resolution on this provider
       #        overrideExistingOrgName: false # don't update existing orgs
       #        orgNameResolvers: # fallback chain
       #          - sirene # try to resolve org name from SIRENE API using the siret from the token: need to be configured above (enabled + token)
       #          - identifier # use the identifier from the token (e.g. "siret:12345678901234")
-      #          - static:NO_ORG # fallback to this static name if the previous resolvers fail. MATCH the shortname of an existing org or it will be created as a new one with this name.
+      #          - NO_ORG # fallback to this static short name if the previous resolvers fail. MATCH the shortname of an existing org, or it will be created as a new one with this name.
       #  # Claims mapping from the OIDC provider's token to the user details used by the gateway and downstream services.
       #  claims:
       #    provider:

--- a/docs/user_guide/authentication.md
+++ b/docs/user_guide/authentication.md
@@ -219,6 +219,38 @@ georchestra:
 
 For more information on available ProConnect claims, see the [ProConnect documentation](https://github.com/numerique-gouv/proconnect-documentation/blob/main/doc_fs/scope-claims.md#correspondance-entre-scope-et-claims-sur-proconnect).
 
+## Organization fallback strategy
+
+OIDC and Oauth2 providers supports a fallback strategy to resolve the organization of a user when the organization claim is missing or empty. This is useful for providers that don't provide a specific claim for organization, or when the claim is not consistently filled.
+
+```yaml
+georchestra:
+  security:
+    oauth2:
+      oidc:
+        config:
+          provider:
+            proconnect:
+              orgNameResolvers: # fallback chain
+                - sirene # try to resolve org name from SIRENE API using the siret from the token: need to be configured (enabled + token)
+                - identifier # use the identifier from the token (e.g. "siret:12345678901234" if set to organizationUid.path: "$.siret", see above)
+                - NO_ORG # fallback to this static short name if the previous resolvers fail. MATCH the shortname of an existing org, or it will be created as a new one with this name.
+```
+
+In order to enable the `sirene` resolver, you need to configure the SIRENE API client. 
+
+You can get a token for the SIRENE API by creating an account on [https://portail-api.insee.fr/](https://portail-api.insee.fr/), subscribing to the SIRENE API, and generating a token. Then, add the following configuration:
+
+```yaml
+
+georchestra:
+  gateway:
+    security:
+      sirene:
+        enabled: true
+        token: <sirenetoken>
+```
+
 ## Custom Claims Mapping
 
 For OpenID Connect providers, you can customize how claims are mapped to geOrchestra user properties:

--- a/gateway/pom.xml
+++ b/gateway/pom.xml
@@ -44,6 +44,10 @@
     </dependency>
     <dependency>
       <groupId>org.georchestra</groupId>
+      <artifactId>georchestra-gateway-sirene</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.georchestra</groupId>
       <artifactId>georchestra-ldap-account-management</artifactId>
       <exclusions>
         <exclusion>

--- a/gateway/pom.xml
+++ b/gateway/pom.xml
@@ -49,6 +49,7 @@
     <dependency>
       <groupId>org.georchestra</groupId>
       <artifactId>georchestra-gateway-sirene</artifactId>
+      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.georchestra</groupId>

--- a/gateway/pom.xml
+++ b/gateway/pom.xml
@@ -40,6 +40,10 @@
   <dependencies>
     <dependency>
       <groupId>org.georchestra</groupId>
+      <artifactId>georchestra-gateway-org-resolvers</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.georchestra</groupId>
       <artifactId>georchestra-gateway-logging</artifactId>
     </dependency>
     <dependency>

--- a/gateway/src/main/java/org/georchestra/gateway/accounts/admin/ldap/GeorchestraLdapAccountManagementConfiguration.java
+++ b/gateway/src/main/java/org/georchestra/gateway/accounts/admin/ldap/GeorchestraLdapAccountManagementConfiguration.java
@@ -34,6 +34,7 @@ import org.georchestra.gateway.security.GeorchestraGatewaySecurityConfigProperti
 import org.georchestra.gateway.security.ldap.extended.DemultiplexingUsersApi;
 import org.georchestra.gateway.security.ldap.extended.ExtendedLdapConfig;
 import org.georchestra.gateway.security.oauth2.OpenIdConnectCustomConfig;
+import org.georchestra.gateway.orgresolvers.OrganizationNameResolver;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.annotation.Bean;
@@ -42,6 +43,8 @@ import org.springframework.ldap.core.LdapTemplate;
 import org.springframework.ldap.core.support.LdapContextSource;
 import org.springframework.ldap.pool.factory.PoolingContextSource;
 import org.springframework.ldap.pool.validation.DefaultDirContextValidator;
+
+import java.util.Optional;
 
 /**
  * Spring Boot configuration class for geOrchestra's LDAP-based account
@@ -79,10 +82,11 @@ public class GeorchestraLdapAccountManagementConfiguration {
             OrgsDao orgsDao, //
             DemultiplexingUsersApi demultiplexingUsersApi, //
             GeorchestraGatewaySecurityConfigProperties configProperties, //
-            OpenIdConnectCustomConfig providerConfig) {
+            OpenIdConnectCustomConfig providerConfig, //
+            Optional<OrganizationNameResolver> orgNameResolver) {
 
         return new LdapAccountsManager(eventPublisher::publishEvent, accountDao, roleDao, orgsDao,
-                demultiplexingUsersApi, configProperties, providerConfig);
+                demultiplexingUsersApi, configProperties, providerConfig, orgNameResolver);
     }
 
     /**

--- a/gateway/src/main/java/org/georchestra/gateway/accounts/admin/ldap/LdapAccountsManager.java
+++ b/gateway/src/main/java/org/georchestra/gateway/accounts/admin/ldap/LdapAccountsManager.java
@@ -45,6 +45,8 @@ import org.georchestra.gateway.security.exceptions.DuplicatedEmailFoundException
 import org.georchestra.gateway.security.exceptions.DuplicatedUsernameFoundException;
 import org.georchestra.gateway.security.ldap.extended.DemultiplexingUsersApi;
 import org.georchestra.gateway.security.oauth2.OpenIdConnectCustomConfig;
+import org.georchestra.gateway.orgresolvers.OrganizationNameResolver;
+import org.georchestra.gateway.orgresolvers.ResolvedOrganization;
 import org.georchestra.security.model.GeorchestraUser;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.ldap.NameNotFoundException;
@@ -93,6 +95,9 @@ class LdapAccountsManager extends AbstractAccountsManager {
     private final @NonNull DemultiplexingUsersApi demultiplexingUsersApi;
     private final @NonNull OpenIdConnectCustomConfig providersConfig;
 
+    /** Optional organization name resolver (e.g. SIRENE API). */
+    private final @NonNull Optional<OrganizationNameResolver> orgNameResolver;
+
     /**
      * Constructs an instance of {@code LdapAccountsManager}.
      *
@@ -112,11 +117,14 @@ class LdapAccountsManager extends AbstractAccountsManager {
      *                                                   users by OAuth2 credentials
      * @param georchestraGatewaySecurityConfigProperties configuration properties
      *                                                   for security settings
+     * @param providersConfig                            the providers configuration
+     * @param orgNameResolver                            optional organization name
+     *                                                   resolver (e.g. SIRENE API)
      */
     public LdapAccountsManager(ApplicationEventPublisher eventPublisher, AccountDao accountDao, RoleDao roleDao,
             OrgsDao orgsDao, DemultiplexingUsersApi demultiplexingUsersApi,
             GeorchestraGatewaySecurityConfigProperties georchestraGatewaySecurityConfigProperties,
-            OpenIdConnectCustomConfig providersConfig) {
+            OpenIdConnectCustomConfig providersConfig, Optional<OrganizationNameResolver> orgNameResolver) {
         super(eventPublisher, providersConfig);
         this.accountDao = accountDao;
         this.roleDao = roleDao;
@@ -124,6 +132,7 @@ class LdapAccountsManager extends AbstractAccountsManager {
         this.demultiplexingUsersApi = demultiplexingUsersApi;
         this.georchestraGatewaySecurityConfigProperties = georchestraGatewaySecurityConfigProperties;
         this.providersConfig = providersConfig;
+        this.orgNameResolver = orgNameResolver;
     }
 
     /**
@@ -221,7 +230,7 @@ class LdapAccountsManager extends AbstractAccountsManager {
         }
 
         try {
-            ensureOrgExists(newAccount);
+            ensureOrgExists(newAccount, mapped.getOAuth2Provider());
         } catch (IllegalStateException orgError) {
             log.error("Error when trying to create / update the organisation {}, reverting the account creation",
                     newAccount.getOrg(), orgError);
@@ -347,15 +356,17 @@ class LdapAccountsManager extends AbstractAccountsManager {
     @Override
     protected void ensureOrgExists(@NonNull GeorchestraUser mappedUser) {
         Account newAccount = mapToAccountBrief(mappedUser);
-        ensureOrgExists(newAccount);
+        ensureOrgExists(newAccount, mappedUser.getOAuth2Provider());
     }
 
     /**
      * Retrieve LDAP organization from org value
      * 
+     * @param oAuth2Provider the OAuth2 provider name (may be null for non-OAuth2
+     *                       users)
      * @throws IllegalStateException if the org can't be created/updated
      */
-    private void ensureOrgExists(@NonNull Account newAccount) {
+    private void ensureOrgExists(@NonNull Account newAccount, @Nullable String oAuth2Provider) {
         final String orgId = newAccount.getOrg();
         String orgUniqueId = Optional.ofNullable(newAccount.getOAuth2OrgId()).orElse("");
 
@@ -364,53 +375,71 @@ class LdapAccountsManager extends AbstractAccountsManager {
             Optional<Org> existingOrg = StringUtils.isNotEmpty(orgUniqueId) ? findOrgById(orgId, orgUniqueId)
                     : findOrg(orgId);
 
-            existingOrg.ifPresentOrElse(org -> addAccountToOrg(newAccount, org),
-                    () -> createOrgAndAddAccount(newAccount, orgId, orgUniqueId));
+            existingOrg.ifPresentOrElse(org -> addAccountToOrg(newAccount, org, oAuth2Provider),
+                    () -> createOrgAndAddAccount(newAccount, orgId, orgUniqueId, oAuth2Provider));
         }
     }
 
     /**
-     * Creates an organization and assigns the user to it.
-     *
-     * @param newAccount the user account to add to the new organization
-     * @param orgId      the identifier of the organization
+     * Creates an organization and assigns the user to it. If an
+     * {@link OrganizationNameResolver} is available and enabled for the provider,
+     * the resolved name is used instead of the raw orgId.
      */
-    private void createOrgAndAddAccount(Account newAccount, final String orgId, final String orgUniqueId) {
+    private void createOrgAndAddAccount(Account newAccount, final String orgId, final String orgUniqueId,
+            @Nullable String oAuth2Provider) {
         try {
             log.info("Org {} does not exist, trying to create it", orgId);
-            Org org = newOrg(orgId, orgUniqueId);
+            Org org = newOrg(orgId, orgUniqueId, oAuth2Provider);
             org.getMembers().add(newAccount.getUid());
             orgsDao.insert(org);
-            verifySingleOrgMembership(newAccount, org.getId());
+            verifySingleOrgMembership(newAccount, org);
         } catch (Exception orgError) {
             throw new IllegalStateException(orgError);
         }
     }
 
-    private void addAccountToOrg(Account newAccount, Org org) {
+    /**
+     * Adds an account to an existing organization. If
+     * {@code overrideExistingOrgName} is enabled for the provider, the organization
+     * name is updated from the resolver.
+     */
+    private void addAccountToOrg(Account newAccount, Org org, @Nullable String oAuth2Provider) {
         // org already in the LDAP, add the newly created account to it
         org.getMembers().add(newAccount.getUid());
+
+        // Optionally update existing org name if override is enabled
+        if (oAuth2Provider != null && providersConfig.overrideExistingOrgName(oAuth2Provider)) {
+            String orgUniqueId = Optional.ofNullable(newAccount.getOAuth2OrgId()).orElse("");
+            String identifier = StringUtils.isNotEmpty(orgUniqueId) ? orgUniqueId : org.getId();
+            resolveOrgNameFromChain(identifier, oAuth2Provider).ifPresent(resolved -> {
+                log.info("Overriding existing org '{}' name from '{}' to '{}'", org.getId(), org.getName(),
+                        resolved.name());
+                org.setName(resolved.name());
+                org.setShortName(resolved.shortName());
+            });
+        }
+
         orgsDao.update(org);
-        verifySingleOrgMembership(newAccount, org.getId());
+        verifySingleOrgMembership(newAccount, org);
     }
 
     @VisibleForTesting
-    void verifySingleOrgMembership(@NonNull Account account, @Nullable String expectedOrgId) {
+    void verifySingleOrgMembership(@NonNull Account account, Org org) {
         try {
             final String uid = account.getUid();
             if (StringUtils.isBlank(uid)) {
                 throw new IllegalStateException("Cannot verify org membership for account with blank uid");
             }
 
-            long memberships = orgsDao.findAll().stream().filter(Objects::nonNull)
-                    .filter(org -> org.getMembers() != null).filter(org -> org.getMembers().contains(uid)).count();
+            long memberships = orgsDao.findAll().stream().filter(Objects::nonNull).filter(o -> o.getMembers() != null)
+                    .filter(o -> o.getMembers().contains(uid)).count();
 
             if (memberships > 1) {
                 throw new IllegalStateException(
                         String.format("User %s is linked to %d organizations; expected at most one", uid, memberships));
             }
 
-            if (expectedOrgId == null) {
+            if (org == null || org.getId() == null) {
                 if (memberships != 0) {
                     throw new IllegalStateException(
                             String.format("User %s is still linked to an organization after unlink", uid));
@@ -423,10 +452,11 @@ class LdapAccountsManager extends AbstractAccountsManager {
                         .format("User %s membership count is %d after link; expected exactly one", uid, memberships));
             }
 
-            Org linkedOrg = orgsDao.findByUser(account);
-            if (linkedOrg == null || !expectedOrgId.equals(linkedOrg.getId())) {
+            Org linkedOrg = StringUtils.isEmpty(org.getOrgUniqueId()) ? orgsDao.findByUser(account)
+                    : orgsDao.findByOrgUniqueId(org.getOrgUniqueId());
+            if (linkedOrg == null || !org.getId().equals(linkedOrg.getId())) {
                 throw new IllegalStateException(String.format("User %s linked org mismatch, expected '%s', got '%s'",
-                        uid, expectedOrgId, linkedOrg == null ? null : linkedOrg.getId()));
+                        uid, org.getId(), linkedOrg == null ? null : linkedOrg.getId()));
             }
         } catch (Exception e) {
             if (e instanceof IllegalStateException) {
@@ -476,31 +506,100 @@ class LdapAccountsManager extends AbstractAccountsManager {
     }
 
     /**
-     * Factory method to create a new org with the given id. Will set orgUniqueId if
-     * not null.
-     * 
-     * @param orgId       organization ID to create (cn)
-     * @param orgUniqueId uniqueOrgId field value
+     * Factory method to create a new org with the given id. When an
+     * {@link OrganizationNameResolver} is available and the provider has SIRENE API
+     * enabled, the resolved name is used for the org name and shortName.
+     *
+     * @param orgId          organization ID to create (cn)
+     * @param orgUniqueId    uniqueOrgId field value
+     * @param oAuth2Provider the OAuth2 provider name (may be null)
      * @return {@link Org} created organization
      */
-    private Org newOrg(final String orgId, final String orgUniqueId) {
-        Org org = newOrg(orgId);
+    private Org newOrg(final String orgId, final String orgUniqueId, @Nullable String oAuth2Provider) {
+        Org org = new Org();
+        org.setId(orgId);
         org.setOrgUniqueId(Optional.ofNullable(orgUniqueId).orElse(""));
+        org.setOrgType("Other");
+
+        // Resolve the org name via the fallback chain
+        String identifier = StringUtils.isNotEmpty(orgUniqueId) ? orgUniqueId : orgId;
+        Optional<ResolvedOrganization> resolved = (oAuth2Provider != null)
+                ? resolveOrgNameFromChain(identifier, oAuth2Provider)
+                : Optional.empty();
+
+        if (resolved.isPresent()) {
+            org.setName(resolved.get().name());
+            org.setShortName(resolved.get().shortName());
+        } else {
+            org.setName(orgId);
+            org.setShortName(orgId);
+        }
+
         return org;
     }
 
     /**
-     * Factory method to create a new org with the given id.
-     * 
-     * @param orgId organization ID to create (cn)
-     * @return {@link Org} created organization
+     * Resolves an organization name by trying each entry in the configured
+     * {@code orgNameResolvers} list for the given provider. The first non-empty
+     * result wins.
+     * <p>
+     * Supported resolver types:
+     * <ul>
+     * <li>{@code sirene} — delegates to the registered
+     * {@link OrganizationNameResolver}</li>
+     * <li>{@code identifier} — returns the raw identifier (e.g. SIRET number) as
+     * the org name</li>
+     * <li>{@code static:<value>} — returns the literal value</li>
+     * </ul>
+     * </p>
+     *
+     * @param identifier     the organization identifier (e.g. SIRET number)
+     * @param oAuth2Provider the OAuth2 provider name
+     * @return an {@link Optional} containing the resolved organization, or empty
      */
-    private Org newOrg(final String orgId) {
-        Org org = new Org();
-        org.setId(orgId);
-        org.setName(orgId);
-        org.setShortName(orgId);
-        org.setOrgType("Other");
-        return org;
+    private Optional<ResolvedOrganization> resolveOrgNameFromChain(String identifier, @NonNull String oAuth2Provider) {
+        List<String> resolvers = providersConfig.orgNameResolvers(oAuth2Provider);
+        if (resolvers.isEmpty()) {
+            return Optional.empty();
+        }
+
+        for (String resolverEntry : resolvers) {
+            Optional<ResolvedOrganization> result = tryResolver(resolverEntry, identifier);
+            if (result.isPresent()) {
+                return result;
+            }
+        }
+
+        log.debug("No organization name resolver returned a result for identifier '{}' (provider: {})", identifier,
+                oAuth2Provider);
+        return Optional.empty();
+    }
+
+    /**
+     * Tries a single resolver entry from the fallback chain.
+     */
+    private Optional<ResolvedOrganization> tryResolver(String resolverEntry, String identifier) {
+        if ("sirene".equalsIgnoreCase(resolverEntry)) {
+            return orgNameResolver.flatMap(resolver -> resolver.resolve(identifier));
+        }
+
+        if ("identifier".equalsIgnoreCase(resolverEntry)) {
+            if (StringUtils.isNotEmpty(identifier)) {
+                String shortName = identifier.length() > 32 ? identifier.substring(0, 32) : identifier;
+                return Optional.of(new ResolvedOrganization(identifier, shortName));
+            }
+            return Optional.empty();
+        }
+
+        if (resolverEntry.toLowerCase().startsWith("static:")) {
+            String staticValue = resolverEntry.substring("static:".length()).trim();
+            if (!staticValue.isEmpty()) {
+                String shortName = staticValue.length() > 32 ? staticValue.substring(0, 32) : staticValue;
+                return Optional.of(new ResolvedOrganization(staticValue, shortName));
+            }
+        }
+
+        log.warn("Unknown organization name resolver type: '{}'", resolverEntry);
+        return Optional.empty();
     }
 }

--- a/gateway/src/main/java/org/georchestra/gateway/accounts/admin/ldap/LdapAccountsManager.java
+++ b/gateway/src/main/java/org/georchestra/gateway/accounts/admin/ldap/LdapAccountsManager.java
@@ -95,7 +95,7 @@ class LdapAccountsManager extends AbstractAccountsManager {
     private final @NonNull DemultiplexingUsersApi demultiplexingUsersApi;
     private final @NonNull OpenIdConnectCustomConfig providersConfig;
 
-    /** Optional organization name resolver (e.g. SIRENE API). */
+    /** Optional organization name resolver. */
     private final @NonNull Optional<OrganizationNameResolver> orgNameResolver;
 
     /**
@@ -119,7 +119,7 @@ class LdapAccountsManager extends AbstractAccountsManager {
      *                                                   for security settings
      * @param providersConfig                            the providers configuration
      * @param orgNameResolver                            optional organization name
-     *                                                   resolver (e.g. SIRENE API)
+     *                                                   resolver
      */
     public LdapAccountsManager(ApplicationEventPublisher eventPublisher, AccountDao accountDao, RoleDao roleDao,
             OrgsDao orgsDao, DemultiplexingUsersApi demultiplexingUsersApi,
@@ -575,11 +575,9 @@ class LdapAccountsManager extends AbstractAccountsManager {
         return Optional.empty();
     }
 
-    /**
-     * Tries a single resolver entry from the fallback chain.
-     */
     private Optional<ResolvedOrganization> tryResolver(String resolverEntry, String identifier) {
-        if ("sirene".equalsIgnoreCase(resolverEntry)) {
+        if (orgNameResolver.isPresent()
+                && orgNameResolver.get().getOrgNameResolverEntry().equalsIgnoreCase(resolverEntry)) {
             return orgNameResolver.flatMap(resolver -> resolver.resolve(identifier));
         }
 

--- a/gateway/src/main/java/org/georchestra/gateway/accounts/admin/ldap/LdapAccountsManager.java
+++ b/gateway/src/main/java/org/georchestra/gateway/accounts/admin/ldap/LdapAccountsManager.java
@@ -424,7 +424,7 @@ class LdapAccountsManager extends AbstractAccountsManager {
     }
 
     @VisibleForTesting
-    void verifySingleOrgMembership(@NonNull Account account, Org org) {
+    void verifySingleOrgMembership(@NonNull Account account, @Nullable  Org org) {
         try {
             final String uid = account.getUid();
             if (StringUtils.isBlank(uid)) {
@@ -549,7 +549,7 @@ class LdapAccountsManager extends AbstractAccountsManager {
      * {@link OrganizationNameResolver}</li>
      * <li>{@code identifier} — returns the raw identifier (e.g. SIRET number) as
      * the org name</li>
-     * <li>{@code static:<value>} — returns the literal value</li>
+     * <li>{@code <value>} — returns the literal value</li>
      * </ul>
      * </p>
      *
@@ -588,12 +588,9 @@ class LdapAccountsManager extends AbstractAccountsManager {
             }
             return Optional.empty();
         }
-
-        if (resolverEntry.toLowerCase().startsWith("static:")) {
-            String staticValue = resolverEntry.substring("static:".length()).trim();
-            if (!staticValue.isEmpty()) {
-                return Optional.of(new ResolvedOrganization(staticValue, staticValue));
-            }
+        else if (!resolverEntry.isEmpty()) {
+            String shortName = resolverEntry.length() > 32 ? resolverEntry.substring(0, 32) : resolverEntry;
+            return Optional.of(new ResolvedOrganization(resolverEntry, shortName));
         }
 
         log.warn("Unknown organization name resolver type: '{}'", resolverEntry);

--- a/gateway/src/main/java/org/georchestra/gateway/accounts/admin/ldap/LdapAccountsManager.java
+++ b/gateway/src/main/java/org/georchestra/gateway/accounts/admin/ldap/LdapAccountsManager.java
@@ -594,8 +594,7 @@ class LdapAccountsManager extends AbstractAccountsManager {
         if (resolverEntry.toLowerCase().startsWith("static:")) {
             String staticValue = resolverEntry.substring("static:".length()).trim();
             if (!staticValue.isEmpty()) {
-                String shortName = staticValue.length() > 32 ? staticValue.substring(0, 32) : staticValue;
-                return Optional.of(new ResolvedOrganization(staticValue, shortName));
+                return Optional.of(new ResolvedOrganization(staticValue, staticValue));
             }
         }
 

--- a/gateway/src/main/java/org/georchestra/gateway/accounts/admin/ldap/LdapAccountsManager.java
+++ b/gateway/src/main/java/org/georchestra/gateway/accounts/admin/ldap/LdapAccountsManager.java
@@ -439,7 +439,7 @@ class LdapAccountsManager extends AbstractAccountsManager {
     }
 
     @VisibleForTesting
-    void verifySingleOrgMembership(@NonNull Account account, @Nullable  Org org) {
+    void verifySingleOrgMembership(@NonNull Account account, @Nullable Org org) {
         try {
             final String uid = account.getUid();
             if (StringUtils.isBlank(uid)) {
@@ -602,8 +602,7 @@ class LdapAccountsManager extends AbstractAccountsManager {
                 return Optional.of(new ResolvedOrganization(identifier, shortName));
             }
             return Optional.empty();
-        }
-        else if (!resolverEntry.isEmpty()) {
+        } else if (!resolverEntry.isEmpty()) {
             String shortName = resolverEntry.length() > 32 ? resolverEntry.substring(0, 32) : resolverEntry;
             return Optional.of(new ResolvedOrganization(resolverEntry, shortName));
         }

--- a/gateway/src/main/java/org/georchestra/gateway/accounts/admin/ldap/LdapAccountsManager.java
+++ b/gateway/src/main/java/org/georchestra/gateway/accounts/admin/ldap/LdapAccountsManager.java
@@ -96,7 +96,7 @@ class LdapAccountsManager extends AbstractAccountsManager {
     private final @NonNull OpenIdConnectCustomConfig providersConfig;
 
     /** Optional organization name resolver. */
-    private final @NonNull Optional<OrganizationNameResolver> orgNameResolver;
+    private final Optional<OrganizationNameResolver> orgNameResolver;
 
     /**
      * Constructs an instance of {@code LdapAccountsManager}.

--- a/gateway/src/main/java/org/georchestra/gateway/accounts/admin/ldap/LdapAccountsManager.java
+++ b/gateway/src/main/java/org/georchestra/gateway/accounts/admin/ldap/LdapAccountsManager.java
@@ -45,6 +45,8 @@ import org.georchestra.gateway.security.exceptions.DuplicatedEmailFoundException
 import org.georchestra.gateway.security.exceptions.DuplicatedUsernameFoundException;
 import org.georchestra.gateway.security.ldap.extended.DemultiplexingUsersApi;
 import org.georchestra.gateway.security.oauth2.OpenIdConnectCustomConfig;
+import org.georchestra.gateway.orgresolvers.OrganizationNameResolver;
+import org.georchestra.gateway.orgresolvers.ResolvedOrganization;
 import org.georchestra.security.model.GeorchestraUser;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.ldap.NameNotFoundException;
@@ -93,6 +95,9 @@ class LdapAccountsManager extends AbstractAccountsManager {
     private final @NonNull DemultiplexingUsersApi demultiplexingUsersApi;
     private final @NonNull OpenIdConnectCustomConfig providersConfig;
 
+    /** Optional organization name resolver (e.g. SIRENE API). */
+    private final @NonNull Optional<OrganizationNameResolver> orgNameResolver;
+
     /**
      * Constructs an instance of {@code LdapAccountsManager}.
      *
@@ -112,11 +117,14 @@ class LdapAccountsManager extends AbstractAccountsManager {
      *                                                   users by OAuth2 credentials
      * @param georchestraGatewaySecurityConfigProperties configuration properties
      *                                                   for security settings
+     * @param providersConfig                            the providers configuration
+     * @param orgNameResolver                            optional organization name
+     *                                                   resolver (e.g. SIRENE API)
      */
     public LdapAccountsManager(ApplicationEventPublisher eventPublisher, AccountDao accountDao, RoleDao roleDao,
             OrgsDao orgsDao, DemultiplexingUsersApi demultiplexingUsersApi,
             GeorchestraGatewaySecurityConfigProperties georchestraGatewaySecurityConfigProperties,
-            OpenIdConnectCustomConfig providersConfig) {
+            OpenIdConnectCustomConfig providersConfig, Optional<OrganizationNameResolver> orgNameResolver) {
         super(eventPublisher, providersConfig);
         this.accountDao = accountDao;
         this.roleDao = roleDao;
@@ -124,6 +132,7 @@ class LdapAccountsManager extends AbstractAccountsManager {
         this.demultiplexingUsersApi = demultiplexingUsersApi;
         this.georchestraGatewaySecurityConfigProperties = georchestraGatewaySecurityConfigProperties;
         this.providersConfig = providersConfig;
+        this.orgNameResolver = orgNameResolver;
     }
 
     /**
@@ -221,7 +230,7 @@ class LdapAccountsManager extends AbstractAccountsManager {
         }
 
         try {
-            ensureOrgExists(newAccount);
+            ensureOrgExists(newAccount, mapped.getOAuth2Provider());
         } catch (IllegalStateException orgError) {
             log.error("Error when trying to create / update the organisation {}, reverting the account creation",
                     newAccount.getOrg(), orgError);
@@ -362,15 +371,17 @@ class LdapAccountsManager extends AbstractAccountsManager {
         String effectiveUid = findInternal(mappedUser).map(GeorchestraUser::getUsername).filter(StringUtils::isNotBlank)
                 .orElse(mappedUser.getUsername());
         Account newAccount = mapToAccountBrief(mappedUser, effectiveUid);
-        ensureOrgExists(newAccount);
+        ensureOrgExists(newAccount, mappedUser.getOAuth2Provider());
     }
 
     /**
      * Retrieve LDAP organization from org value
      * 
+     * @param oAuth2Provider the OAuth2 provider name (may be null for non-OAuth2
+     *                       users)
      * @throws IllegalStateException if the org can't be created/updated
      */
-    private void ensureOrgExists(@NonNull Account newAccount) {
+    private void ensureOrgExists(@NonNull Account newAccount, @Nullable String oAuth2Provider) {
         final String orgId = newAccount.getOrg();
         String orgUniqueId = Optional.ofNullable(newAccount.getOAuth2OrgId()).orElse("");
 
@@ -379,53 +390,71 @@ class LdapAccountsManager extends AbstractAccountsManager {
             Optional<Org> existingOrg = StringUtils.isNotEmpty(orgUniqueId) ? findOrgById(orgId, orgUniqueId)
                     : findOrg(orgId);
 
-            existingOrg.ifPresentOrElse(org -> addAccountToOrg(newAccount, org),
-                    () -> createOrgAndAddAccount(newAccount, orgId, orgUniqueId));
+            existingOrg.ifPresentOrElse(org -> addAccountToOrg(newAccount, org, oAuth2Provider),
+                    () -> createOrgAndAddAccount(newAccount, orgId, orgUniqueId, oAuth2Provider));
         }
     }
 
     /**
-     * Creates an organization and assigns the user to it.
-     *
-     * @param newAccount the user account to add to the new organization
-     * @param orgId      the identifier of the organization
+     * Creates an organization and assigns the user to it. If an
+     * {@link OrganizationNameResolver} is available and enabled for the provider,
+     * the resolved name is used instead of the raw orgId.
      */
-    private void createOrgAndAddAccount(Account newAccount, final String orgId, final String orgUniqueId) {
+    private void createOrgAndAddAccount(Account newAccount, final String orgId, final String orgUniqueId,
+            @Nullable String oAuth2Provider) {
         try {
             log.info("Org {} does not exist, trying to create it", orgId);
-            Org org = newOrg(orgId, orgUniqueId);
+            Org org = newOrg(orgId, orgUniqueId, oAuth2Provider);
             org.getMembers().add(newAccount.getUid());
             orgsDao.insert(org);
-            verifySingleOrgMembership(newAccount, org.getId());
+            verifySingleOrgMembership(newAccount, org);
         } catch (Exception orgError) {
             throw new IllegalStateException(orgError);
         }
     }
 
-    private void addAccountToOrg(Account newAccount, Org org) {
+    /**
+     * Adds an account to an existing organization. If
+     * {@code overrideExistingOrgName} is enabled for the provider, the organization
+     * name is updated from the resolver.
+     */
+    private void addAccountToOrg(Account newAccount, Org org, @Nullable String oAuth2Provider) {
         // org already in the LDAP, add the newly created account to it
         org.getMembers().add(newAccount.getUid());
+
+        // Optionally update existing org name if override is enabled
+        if (oAuth2Provider != null && providersConfig.overrideExistingOrgName(oAuth2Provider)) {
+            String orgUniqueId = Optional.ofNullable(newAccount.getOAuth2OrgId()).orElse("");
+            String identifier = StringUtils.isNotEmpty(orgUniqueId) ? orgUniqueId : org.getId();
+            resolveOrgNameFromChain(identifier, oAuth2Provider).ifPresent(resolved -> {
+                log.info("Overriding existing org '{}' name from '{}' to '{}'", org.getId(), org.getName(),
+                        resolved.name());
+                org.setName(resolved.name());
+                org.setShortName(resolved.shortName());
+            });
+        }
+
         orgsDao.update(org);
-        verifySingleOrgMembership(newAccount, org.getId());
+        verifySingleOrgMembership(newAccount, org);
     }
 
     @VisibleForTesting
-    void verifySingleOrgMembership(@NonNull Account account, @Nullable String expectedOrgId) {
+    void verifySingleOrgMembership(@NonNull Account account, Org org) {
         try {
             final String uid = account.getUid();
             if (StringUtils.isBlank(uid)) {
                 throw new IllegalStateException("Cannot verify org membership for account with blank uid");
             }
 
-            long memberships = orgsDao.findAll().stream().filter(Objects::nonNull)
-                    .filter(org -> org.getMembers() != null).filter(org -> org.getMembers().contains(uid)).count();
+            long memberships = orgsDao.findAll().stream().filter(Objects::nonNull).filter(o -> o.getMembers() != null)
+                    .filter(o -> o.getMembers().contains(uid)).count();
 
             if (memberships > 1) {
                 throw new IllegalStateException(
                         String.format("User %s is linked to %d organizations; expected at most one", uid, memberships));
             }
 
-            if (expectedOrgId == null) {
+            if (org == null || org.getId() == null) {
                 if (memberships != 0) {
                     throw new IllegalStateException(
                             String.format("User %s is still linked to an organization after unlink", uid));
@@ -438,10 +467,11 @@ class LdapAccountsManager extends AbstractAccountsManager {
                         .format("User %s membership count is %d after link; expected exactly one", uid, memberships));
             }
 
-            Org linkedOrg = orgsDao.findByUser(account);
-            if (linkedOrg == null || !expectedOrgId.equals(linkedOrg.getId())) {
+            Org linkedOrg = StringUtils.isEmpty(org.getOrgUniqueId()) ? orgsDao.findByUser(account)
+                    : orgsDao.findByOrgUniqueId(org.getOrgUniqueId());
+            if (linkedOrg == null || !org.getId().equals(linkedOrg.getId())) {
                 throw new IllegalStateException(String.format("User %s linked org mismatch, expected '%s', got '%s'",
-                        uid, expectedOrgId, linkedOrg == null ? null : linkedOrg.getId()));
+                        uid, org.getId(), linkedOrg == null ? null : linkedOrg.getId()));
             }
         } catch (Exception e) {
             if (e instanceof IllegalStateException) {
@@ -491,31 +521,100 @@ class LdapAccountsManager extends AbstractAccountsManager {
     }
 
     /**
-     * Factory method to create a new org with the given id. Will set orgUniqueId if
-     * not null.
-     * 
-     * @param orgId       organization ID to create (cn)
-     * @param orgUniqueId uniqueOrgId field value
+     * Factory method to create a new org with the given id. When an
+     * {@link OrganizationNameResolver} is available and the provider has SIRENE API
+     * enabled, the resolved name is used for the org name and shortName.
+     *
+     * @param orgId          organization ID to create (cn)
+     * @param orgUniqueId    uniqueOrgId field value
+     * @param oAuth2Provider the OAuth2 provider name (may be null)
      * @return {@link Org} created organization
      */
-    private Org newOrg(final String orgId, final String orgUniqueId) {
-        Org org = newOrg(orgId);
+    private Org newOrg(final String orgId, final String orgUniqueId, @Nullable String oAuth2Provider) {
+        Org org = new Org();
+        org.setId(orgId);
         org.setOrgUniqueId(Optional.ofNullable(orgUniqueId).orElse(""));
+        org.setOrgType("Other");
+
+        // Resolve the org name via the fallback chain
+        String identifier = StringUtils.isNotEmpty(orgUniqueId) ? orgUniqueId : orgId;
+        Optional<ResolvedOrganization> resolved = (oAuth2Provider != null)
+                ? resolveOrgNameFromChain(identifier, oAuth2Provider)
+                : Optional.empty();
+
+        if (resolved.isPresent()) {
+            org.setName(resolved.get().name());
+            org.setShortName(resolved.get().shortName());
+        } else {
+            org.setName(orgId);
+            org.setShortName(orgId);
+        }
+
         return org;
     }
 
     /**
-     * Factory method to create a new org with the given id.
-     * 
-     * @param orgId organization ID to create (cn)
-     * @return {@link Org} created organization
+     * Resolves an organization name by trying each entry in the configured
+     * {@code orgNameResolvers} list for the given provider. The first non-empty
+     * result wins.
+     * <p>
+     * Supported resolver types:
+     * <ul>
+     * <li>{@code sirene} — delegates to the registered
+     * {@link OrganizationNameResolver}</li>
+     * <li>{@code identifier} — returns the raw identifier (e.g. SIRET number) as
+     * the org name</li>
+     * <li>{@code static:<value>} — returns the literal value</li>
+     * </ul>
+     * </p>
+     *
+     * @param identifier     the organization identifier (e.g. SIRET number)
+     * @param oAuth2Provider the OAuth2 provider name
+     * @return an {@link Optional} containing the resolved organization, or empty
      */
-    private Org newOrg(final String orgId) {
-        Org org = new Org();
-        org.setId(orgId);
-        org.setName(orgId);
-        org.setShortName(orgId);
-        org.setOrgType("Other");
-        return org;
+    private Optional<ResolvedOrganization> resolveOrgNameFromChain(String identifier, @NonNull String oAuth2Provider) {
+        List<String> resolvers = providersConfig.orgNameResolvers(oAuth2Provider);
+        if (resolvers.isEmpty()) {
+            return Optional.empty();
+        }
+
+        for (String resolverEntry : resolvers) {
+            Optional<ResolvedOrganization> result = tryResolver(resolverEntry, identifier);
+            if (result.isPresent()) {
+                return result;
+            }
+        }
+
+        log.debug("No organization name resolver returned a result for identifier '{}' (provider: {})", identifier,
+                oAuth2Provider);
+        return Optional.empty();
+    }
+
+    /**
+     * Tries a single resolver entry from the fallback chain.
+     */
+    private Optional<ResolvedOrganization> tryResolver(String resolverEntry, String identifier) {
+        if ("sirene".equalsIgnoreCase(resolverEntry)) {
+            return orgNameResolver.flatMap(resolver -> resolver.resolve(identifier));
+        }
+
+        if ("identifier".equalsIgnoreCase(resolverEntry)) {
+            if (StringUtils.isNotEmpty(identifier)) {
+                String shortName = identifier.length() > 32 ? identifier.substring(0, 32) : identifier;
+                return Optional.of(new ResolvedOrganization(identifier, shortName));
+            }
+            return Optional.empty();
+        }
+
+        if (resolverEntry.toLowerCase().startsWith("static:")) {
+            String staticValue = resolverEntry.substring("static:".length()).trim();
+            if (!staticValue.isEmpty()) {
+                String shortName = staticValue.length() > 32 ? staticValue.substring(0, 32) : staticValue;
+                return Optional.of(new ResolvedOrganization(staticValue, shortName));
+            }
+        }
+
+        log.warn("Unknown organization name resolver type: '{}'", resolverEntry);
+        return Optional.empty();
     }
 }

--- a/gateway/src/main/java/org/georchestra/gateway/accounts/admin/ldap/LdapAccountsManager.java
+++ b/gateway/src/main/java/org/georchestra/gateway/accounts/admin/ldap/LdapAccountsManager.java
@@ -439,7 +439,7 @@ class LdapAccountsManager extends AbstractAccountsManager {
     }
 
     @VisibleForTesting
-    void verifySingleOrgMembership(@NonNull Account account, Org org) {
+    void verifySingleOrgMembership(@NonNull Account account, @Nullable  Org org) {
         try {
             final String uid = account.getUid();
             if (StringUtils.isBlank(uid)) {
@@ -564,7 +564,7 @@ class LdapAccountsManager extends AbstractAccountsManager {
      * {@link OrganizationNameResolver}</li>
      * <li>{@code identifier} — returns the raw identifier (e.g. SIRET number) as
      * the org name</li>
-     * <li>{@code static:<value>} — returns the literal value</li>
+     * <li>{@code <value>} — returns the literal value</li>
      * </ul>
      * </p>
      *
@@ -603,12 +603,9 @@ class LdapAccountsManager extends AbstractAccountsManager {
             }
             return Optional.empty();
         }
-
-        if (resolverEntry.toLowerCase().startsWith("static:")) {
-            String staticValue = resolverEntry.substring("static:".length()).trim();
-            if (!staticValue.isEmpty()) {
-                return Optional.of(new ResolvedOrganization(staticValue, staticValue));
-            }
+        else if (!resolverEntry.isEmpty()) {
+            String shortName = resolverEntry.length() > 32 ? resolverEntry.substring(0, 32) : resolverEntry;
+            return Optional.of(new ResolvedOrganization(resolverEntry, shortName));
         }
 
         log.warn("Unknown organization name resolver type: '{}'", resolverEntry);

--- a/gateway/src/main/java/org/georchestra/gateway/accounts/admin/ldap/LdapAccountsManager.java
+++ b/gateway/src/main/java/org/georchestra/gateway/accounts/admin/ldap/LdapAccountsManager.java
@@ -609,8 +609,7 @@ class LdapAccountsManager extends AbstractAccountsManager {
         if (resolverEntry.toLowerCase().startsWith("static:")) {
             String staticValue = resolverEntry.substring("static:".length()).trim();
             if (!staticValue.isEmpty()) {
-                String shortName = staticValue.length() > 32 ? staticValue.substring(0, 32) : staticValue;
-                return Optional.of(new ResolvedOrganization(staticValue, shortName));
+                return Optional.of(new ResolvedOrganization(staticValue, staticValue));
             }
         }
 

--- a/gateway/src/main/java/org/georchestra/gateway/accounts/admin/ldap/LdapAccountsManager.java
+++ b/gateway/src/main/java/org/georchestra/gateway/accounts/admin/ldap/LdapAccountsManager.java
@@ -95,7 +95,7 @@ class LdapAccountsManager extends AbstractAccountsManager {
     private final @NonNull DemultiplexingUsersApi demultiplexingUsersApi;
     private final @NonNull OpenIdConnectCustomConfig providersConfig;
 
-    /** Optional organization name resolver (e.g. SIRENE API). */
+    /** Optional organization name resolver. */
     private final @NonNull Optional<OrganizationNameResolver> orgNameResolver;
 
     /**
@@ -119,7 +119,7 @@ class LdapAccountsManager extends AbstractAccountsManager {
      *                                                   for security settings
      * @param providersConfig                            the providers configuration
      * @param orgNameResolver                            optional organization name
-     *                                                   resolver (e.g. SIRENE API)
+     *                                                   resolver
      */
     public LdapAccountsManager(ApplicationEventPublisher eventPublisher, AccountDao accountDao, RoleDao roleDao,
             OrgsDao orgsDao, DemultiplexingUsersApi demultiplexingUsersApi,
@@ -590,11 +590,9 @@ class LdapAccountsManager extends AbstractAccountsManager {
         return Optional.empty();
     }
 
-    /**
-     * Tries a single resolver entry from the fallback chain.
-     */
     private Optional<ResolvedOrganization> tryResolver(String resolverEntry, String identifier) {
-        if ("sirene".equalsIgnoreCase(resolverEntry)) {
+        if (orgNameResolver.isPresent()
+                && orgNameResolver.get().getOrgNameResolverEntry().equalsIgnoreCase(resolverEntry)) {
             return orgNameResolver.flatMap(resolver -> resolver.resolve(identifier));
         }
 

--- a/gateway/src/main/java/org/georchestra/gateway/security/oauth2/OpenIdConnectCustomConfig.java
+++ b/gateway/src/main/java/org/georchestra/gateway/security/oauth2/OpenIdConnectCustomConfig.java
@@ -19,6 +19,7 @@
 package org.georchestra.gateway.security.oauth2;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -44,7 +45,7 @@ import lombok.NonNull;
  * :
  * georchestra.gateway.security.oidc.config.provider.[provider].moderatedSignup
  * 
- * Note that moderatedSignup can be configured either in the datadir’s
+ * Note that moderatedSignup can be configured either in the datadir's
  * default.properties file or in the gateway configuration.
  * 
  * </p>
@@ -65,6 +66,11 @@ import lombok.NonNull;
  *              proconnect:
  *                  searchEmail: true
  *                  moderatedSignup: true
+ *                  useSireneApi: true
+ *                  orgNameResolvers:
+ *                    - sirene
+ *                    - identifier
+ *                    - static:Unknown Organization
  *              google:
  *                  searchEmail: false
  *                  moderatedSignup: false
@@ -78,6 +84,36 @@ public class OpenIdConnectCustomConfig {
     private Boolean searchEmail;
 
     private Boolean moderatedSignup;
+
+    /**
+     * Whether to use the SIRENE API (or any registered
+     * {@code OrganizationNameResolver}) to resolve organization names from
+     * identifiers such as SIRET numbers. Defaults to {@code false}.
+     */
+    private Boolean useSireneApi;
+
+    /**
+     * Whether to override the name of an existing organization when a user logs in.
+     * When {@code false} (the default), only newly created organizations get their
+     * name resolved via the API. When {@code true}, the organization name is
+     * updated on every login if the resolver returns a result.
+     */
+    private Boolean overrideExistingOrgName;
+
+    /**
+     * Ordered list of organization name resolvers to try when creating or updating
+     * an organization. Each entry is a string of the form:
+     * <ul>
+     * <li>{@code sirene} — calls the registered
+     * {@code OrganizationNameResolver}</li>
+     * <li>{@code identifier} — uses the raw identifier (e.g. SIRET number) as the
+     * org name</li>
+     * <li>{@code static:<value>} — uses the literal value as the org name</li>
+     * </ul>
+     * The first resolver returning a non-empty result wins. If not configured and
+     * {@code useSireneApi} is {@code true}, defaults to {@code ["sirene"]}.
+     */
+    private List<String> orgNameResolvers;
 
     private Map<String, OpenIdConnectCustomConfig> provider = new HashMap<>();
 
@@ -103,7 +139,7 @@ public class OpenIdConnectCustomConfig {
         return getProviderConfig(providerName)
                 // provider config
                 .map(OpenIdConnectCustomConfig::getSearchEmail)
-                // orf fallback general config
+                // or fallback general config
                 .orElse(searchEmail != null ? searchEmail : false);
     }
 
@@ -117,7 +153,51 @@ public class OpenIdConnectCustomConfig {
         return getProviderConfig(providerName)
                 // provider config
                 .map(OpenIdConnectCustomConfig::getModeratedSignup)
-                // orf fallback general config
+                // or fallback general config
                 .orElse(moderatedSignup != null ? moderatedSignup : false);
+    }
+
+    /**
+     * Determines if the SIRENE API (or any {@code OrganizationNameResolver}) should
+     * be used to resolve organization names for this provider.
+     * 
+     * @param providerName provider id in use
+     * @return {@code true} if the organization name resolver should be used
+     */
+    public boolean useSireneApi(@NonNull String providerName) {
+        return getProviderConfig(providerName).map(OpenIdConnectCustomConfig::getUseSireneApi)
+                .orElse(useSireneApi != null ? useSireneApi : false);
+    }
+
+    /**
+     * Determines whether existing organization names should be overridden on login.
+     * 
+     * @param providerName provider id in use
+     * @return {@code true} if existing org names should be updated
+     */
+    public boolean overrideExistingOrgName(@NonNull String providerName) {
+        return getProviderConfig(providerName).map(OpenIdConnectCustomConfig::getOverrideExistingOrgName)
+                .orElse(overrideExistingOrgName != null ? overrideExistingOrgName : false);
+    }
+
+    /**
+     * Returns the ordered list of organization name resolvers for this provider. If
+     * not explicitly configured and {@code useSireneApi} is {@code true}, defaults
+     * to {@code ["sirene"]}.
+     * 
+     * @param providerName provider id in use
+     * @return a list of resolver identifiers, or an empty list if none configured
+     */
+    public List<String> orgNameResolvers(@NonNull String providerName) {
+        List<String> resolvers = getProviderConfig(providerName).map(OpenIdConnectCustomConfig::getOrgNameResolvers)
+                .orElse(orgNameResolvers);
+        if (resolvers != null && !resolvers.isEmpty()) {
+            return resolvers;
+        }
+        // Default: if useSireneApi is enabled, use ["sirene"] as fallback
+        if (useSireneApi(providerName)) {
+            return List.of("sirene");
+        }
+        return List.of();
     }
 }

--- a/gateway/src/main/java/org/georchestra/gateway/security/oauth2/OpenIdConnectCustomConfig.java
+++ b/gateway/src/main/java/org/georchestra/gateway/security/oauth2/OpenIdConnectCustomConfig.java
@@ -69,7 +69,7 @@ import lombok.NonNull;
  *                  orgNameResolvers:
  *                    - sirene
  *                    - identifier
- *                    - static:Unknown Organization
+ *                    - NO_ORG
  *              google:
  *                  searchEmail: false
  *                  moderatedSignup: false
@@ -100,7 +100,7 @@ public class OpenIdConnectCustomConfig {
      * {@code OrganizationNameResolver}</li>
      * <li>{@code identifier} — uses the raw identifier (e.g. SIRET number) as the
      * org name</li>
-     * <li>{@code static:<value>} — uses the literal value as the org name</li>
+     * <li>{@code <value>} — uses the literal value as the org short name</li>
      * </ul>
      * The first resolver returning a non-empty result wins.
      */

--- a/gateway/src/main/java/org/georchestra/gateway/security/oauth2/OpenIdConnectCustomConfig.java
+++ b/gateway/src/main/java/org/georchestra/gateway/security/oauth2/OpenIdConnectCustomConfig.java
@@ -66,7 +66,6 @@ import lombok.NonNull;
  *              proconnect:
  *                  searchEmail: true
  *                  moderatedSignup: true
- *                  useSireneApi: true
  *                  orgNameResolvers:
  *                    - sirene
  *                    - identifier
@@ -86,13 +85,6 @@ public class OpenIdConnectCustomConfig {
     private Boolean moderatedSignup;
 
     /**
-     * Whether to use the SIRENE API (or any registered
-     * {@code OrganizationNameResolver}) to resolve organization names from
-     * identifiers such as SIRET numbers. Defaults to {@code false}.
-     */
-    private Boolean useSireneApi;
-
-    /**
      * Whether to override the name of an existing organization when a user logs in.
      * When {@code false} (the default), only newly created organizations get their
      * name resolved via the API. When {@code true}, the organization name is
@@ -110,8 +102,7 @@ public class OpenIdConnectCustomConfig {
      * org name</li>
      * <li>{@code static:<value>} — uses the literal value as the org name</li>
      * </ul>
-     * The first resolver returning a non-empty result wins. If not configured and
-     * {@code useSireneApi} is {@code true}, defaults to {@code ["sirene"]}.
+     * The first resolver returning a non-empty result wins.
      */
     private List<String> orgNameResolvers;
 
@@ -158,18 +149,6 @@ public class OpenIdConnectCustomConfig {
     }
 
     /**
-     * Determines if the SIRENE API (or any {@code OrganizationNameResolver}) should
-     * be used to resolve organization names for this provider.
-     * 
-     * @param providerName provider id in use
-     * @return {@code true} if the organization name resolver should be used
-     */
-    public boolean useSireneApi(@NonNull String providerName) {
-        return getProviderConfig(providerName).map(OpenIdConnectCustomConfig::getUseSireneApi)
-                .orElse(useSireneApi != null ? useSireneApi : false);
-    }
-
-    /**
      * Determines whether existing organization names should be overridden on login.
      * 
      * @param providerName provider id in use
@@ -181,9 +160,7 @@ public class OpenIdConnectCustomConfig {
     }
 
     /**
-     * Returns the ordered list of organization name resolvers for this provider. If
-     * not explicitly configured and {@code useSireneApi} is {@code true}, defaults
-     * to {@code ["sirene"]}.
+     * Returns the ordered list of organization name resolvers for this provider.
      * 
      * @param providerName provider id in use
      * @return a list of resolver identifiers, or an empty list if none configured
@@ -193,10 +170,6 @@ public class OpenIdConnectCustomConfig {
                 .orElse(orgNameResolvers);
         if (resolvers != null && !resolvers.isEmpty()) {
             return resolvers;
-        }
-        // Default: if useSireneApi is enabled, use ["sirene"] as fallback
-        if (useSireneApi(providerName)) {
-            return List.of("sirene");
         }
         return List.of();
     }

--- a/gateway/src/test/java/org/georchestra/gateway/accounts/admin/ldap/LdapAccountsManagerTest.java
+++ b/gateway/src/test/java/org/georchestra/gateway/accounts/admin/ldap/LdapAccountsManagerTest.java
@@ -12,6 +12,7 @@ import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.ldap.NameNotFoundException;
 
 import java.util.List;
+import java.util.Optional;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -25,7 +26,7 @@ public class LdapAccountsManagerTest {
         when(roleDao.findByCommonName(anyString())).thenThrow(new NameNotFoundException("FAKE_ROLE"));
 
         LdapAccountsManager toTest = new LdapAccountsManager(mock(ApplicationEventPublisher.class), null, roleDao, null,
-                null, null, null);
+                null, null, null, Optional.empty());
 
         toTest.ensureRoleExists("FAKE_ROLE");
         // No exception thrown
@@ -37,7 +38,7 @@ public class LdapAccountsManagerTest {
         when(orgsDao.findAll()).thenReturn(List.of());
 
         LdapAccountsManager toTest = new LdapAccountsManager(mock(ApplicationEventPublisher.class),
-                mock(AccountDao.class), mock(RoleDao.class), orgsDao, null, null, null);
+                mock(AccountDao.class), mock(RoleDao.class), orgsDao, null, null, null, Optional.empty());
 
         Account account = mock(Account.class);
         when(account.getUid()).thenReturn("uid-1");
@@ -55,12 +56,12 @@ public class LdapAccountsManagerTest {
         when(orgsDao.findByUser(any(Account.class))).thenReturn(org);
 
         LdapAccountsManager toTest = new LdapAccountsManager(mock(ApplicationEventPublisher.class),
-                mock(AccountDao.class), mock(RoleDao.class), orgsDao, null, null, null);
+                mock(AccountDao.class), mock(RoleDao.class), orgsDao, null, null, null, Optional.empty());
 
         Account account = mock(Account.class);
         when(account.getUid()).thenReturn("uid-1");
 
-        toTest.verifySingleOrgMembership(account, "ORG_A");
+        toTest.verifySingleOrgMembership(account, org);
     }
 
     @Test
@@ -75,11 +76,11 @@ public class LdapAccountsManagerTest {
         when(orgsDao.findAll()).thenReturn(List.of(org1, org2));
 
         LdapAccountsManager toTest = new LdapAccountsManager(mock(ApplicationEventPublisher.class),
-                mock(AccountDao.class), mock(RoleDao.class), orgsDao, null, null, null);
+                mock(AccountDao.class), mock(RoleDao.class), orgsDao, null, null, null, Optional.empty());
 
         Account account = mock(Account.class);
         when(account.getUid()).thenReturn("uid-1");
 
-        assertThrows(IllegalStateException.class, () -> toTest.verifySingleOrgMembership(account, "ORG_A"));
+        assertThrows(IllegalStateException.class, () -> toTest.verifySingleOrgMembership(account, org1));
     }
 }

--- a/gateway/src/test/java/org/georchestra/gateway/accounts/admin/ldap/LdapAccountsManagerTest.java
+++ b/gateway/src/test/java/org/georchestra/gateway/accounts/admin/ldap/LdapAccountsManagerTest.java
@@ -124,7 +124,7 @@ public class LdapAccountsManagerTest {
         when(usersApi.findByEmail("user@example.org", false)).thenReturn(Optional.of(existingLdapUser));
 
         LdapAccountsManager toTest = new LdapAccountsManager(mock(ApplicationEventPublisher.class), accountDao, roleDao,
-                orgsDao, usersApi, securityConfig, providersConfig);
+                orgsDao, usersApi, securityConfig, providersConfig, Optional.empty());
 
         GeorchestraUser mappedUser = new GeorchestraUser();
         mappedUser.setUsername("proconnect_uid");
@@ -173,7 +173,7 @@ public class LdapAccountsManagerTest {
         when(usersApi.findByEmail("user@example.org", false)).thenReturn(Optional.of(existingLdapUser));
 
         LdapAccountsManager toTest = new LdapAccountsManager(mock(ApplicationEventPublisher.class), accountDao, roleDao,
-                orgsDao, usersApi, securityConfig, providersConfig);
+                orgsDao, usersApi, securityConfig, providersConfig, Optional.empty());
 
         GeorchestraUser mappedUser = new GeorchestraUser();
         mappedUser.setUsername("fake_uid");

--- a/gateway/src/test/java/org/georchestra/gateway/accounts/admin/ldap/LdapAccountsManagerTest.java
+++ b/gateway/src/test/java/org/georchestra/gateway/accounts/admin/ldap/LdapAccountsManagerTest.java
@@ -35,7 +35,7 @@ public class LdapAccountsManagerTest {
         when(roleDao.findByCommonName(anyString())).thenThrow(new NameNotFoundException("FAKE_ROLE"));
 
         LdapAccountsManager toTest = new LdapAccountsManager(mock(ApplicationEventPublisher.class), null, roleDao, null,
-                null, null, null);
+                null, null, null, Optional.empty());
 
         toTest.ensureRoleExists("FAKE_ROLE");
         // No exception thrown
@@ -47,7 +47,7 @@ public class LdapAccountsManagerTest {
         when(orgsDao.findAll()).thenReturn(List.of());
 
         LdapAccountsManager toTest = new LdapAccountsManager(mock(ApplicationEventPublisher.class),
-                mock(AccountDao.class), mock(RoleDao.class), orgsDao, null, null, null);
+                mock(AccountDao.class), mock(RoleDao.class), orgsDao, null, null, null, Optional.empty());
 
         Account account = mock(Account.class);
         when(account.getUid()).thenReturn("uid-1");
@@ -65,12 +65,12 @@ public class LdapAccountsManagerTest {
         when(orgsDao.findByUser(any(Account.class))).thenReturn(org);
 
         LdapAccountsManager toTest = new LdapAccountsManager(mock(ApplicationEventPublisher.class),
-                mock(AccountDao.class), mock(RoleDao.class), orgsDao, null, null, null);
+                mock(AccountDao.class), mock(RoleDao.class), orgsDao, null, null, null, Optional.empty());
 
         Account account = mock(Account.class);
         when(account.getUid()).thenReturn("uid-1");
 
-        toTest.verifySingleOrgMembership(account, "ORG_A");
+        toTest.verifySingleOrgMembership(account, org);
     }
 
     @Test
@@ -85,12 +85,12 @@ public class LdapAccountsManagerTest {
         when(orgsDao.findAll()).thenReturn(List.of(org1, org2));
 
         LdapAccountsManager toTest = new LdapAccountsManager(mock(ApplicationEventPublisher.class),
-                mock(AccountDao.class), mock(RoleDao.class), orgsDao, null, null, null);
+                mock(AccountDao.class), mock(RoleDao.class), orgsDao, null, null, null, Optional.empty());
 
         Account account = mock(Account.class);
         when(account.getUid()).thenReturn("uid-1");
 
-        assertThrows(IllegalStateException.class, () -> toTest.verifySingleOrgMembership(account, "ORG_A"));
+        assertThrows(IllegalStateException.class, () -> toTest.verifySingleOrgMembership(account, org1));
     }
 
     @Test

--- a/modules/org-resolvers/pom.xml
+++ b/modules/org-resolvers/pom.xml
@@ -3,19 +3,12 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.georchestra</groupId>
-    <artifactId>georchestra-gateway-parent</artifactId>
+    <artifactId>georchestra-gateway-modules</artifactId>
     <version>${revision}</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
-  <artifactId>georchestra-gateway-modules</artifactId>
-  <packaging>pom</packaging>
-  <name>geOrchestra Gateway - Modules</name>
-  <description>Parent POM for geOrchestra Gateway modules</description>
-
-  <modules>
-    <module>logging</module>
-    <module>org-resolvers</module>
-    <module>sirene</module>
-  </modules>
+  <artifactId>georchestra-gateway-org-resolvers</artifactId>
+  <name>geOrchestra Gateway - Organization Resolvers API</name>
+  <description>SPI for pluggable organization name resolvers (e.g. SIRENE, national registries)</description>
 
 </project>

--- a/modules/org-resolvers/src/main/java/org/georchestra/gateway/orgresolvers/OrganizationNameResolver.java
+++ b/modules/org-resolvers/src/main/java/org/georchestra/gateway/orgresolvers/OrganizationNameResolver.java
@@ -1,0 +1,43 @@
+
+/*
+ * Copyright (C) 2024 by the geOrchestra PSC
+ *
+ * This file is part of geOrchestra.
+ *
+ * geOrchestra is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * geOrchestra is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * geOrchestra. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.georchestra.gateway.orgresolvers;
+
+import java.util.Optional;
+
+/**
+ * SPI interface for resolving an organization name from an identifier (e.g. a
+ * SIRET number).
+ * <p>
+ * This is designed to be API-agnostic: the SIRENE (INSEE) implementation is the
+ * first adapter, but any country or system could provide its own implementation
+ * to resolve organization names from national registries.
+ * </p>
+ */
+public interface OrganizationNameResolver {
+
+    /**
+     * Attempts to resolve the organization name from the given identifier.
+     *
+     * @param organizationIdentifier the identifier to look up (e.g. a SIRET number)
+     * @return an {@link Optional} containing the resolved organization details, or
+     *         {@link Optional#empty()} if the identifier could not be resolved
+     */
+    Optional<ResolvedOrganization> resolve(String organizationIdentifier);
+}

--- a/modules/org-resolvers/src/main/java/org/georchestra/gateway/orgresolvers/OrganizationNameResolver.java
+++ b/modules/org-resolvers/src/main/java/org/georchestra/gateway/orgresolvers/OrganizationNameResolver.java
@@ -32,6 +32,8 @@ import java.util.Optional;
  */
 public interface OrganizationNameResolver {
 
+    String getOrgNameResolverEntry();
+
     /**
      * Attempts to resolve the organization name from the given identifier.
      *

--- a/modules/org-resolvers/src/main/java/org/georchestra/gateway/orgresolvers/ResolvedOrganization.java
+++ b/modules/org-resolvers/src/main/java/org/georchestra/gateway/orgresolvers/ResolvedOrganization.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2024 by the geOrchestra PSC
+ *
+ * This file is part of geOrchestra.
+ *
+ * geOrchestra is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * geOrchestra is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * geOrchestra. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.georchestra.gateway.orgresolvers;
+
+/**
+ * Holds the resolved organization name and short name.
+ *
+ * @param name      the full organization name (e.g. "Ministère de
+ *                  l'Environnement")
+ * @param shortName a shortened/normalized version of the name (max 32
+ *                  characters)
+ */
+public record ResolvedOrganization(String name, String shortName) {
+}

--- a/modules/pom.xml
+++ b/modules/pom.xml
@@ -14,6 +14,7 @@
 
   <modules>
     <module>logging</module>
+    <module>sirene</module>
   </modules>
 
 </project>

--- a/modules/sirene/pom.xml
+++ b/modules/sirene/pom.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.georchestra</groupId>
+    <artifactId>georchestra-gateway-modules</artifactId>
+    <version>${revision}</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+  <artifactId>georchestra-gateway-sirene</artifactId>
+  <name>geOrchestra Gateway - SIRENE API</name>
+  <description>Provides organization name resolution via the French SIRENE API (INSEE) or other pluggable organization resolvers</description>
+
+  <dependencies>
+    <!-- Organization Resolver SPI -->
+    <dependency>
+      <groupId>org.georchestra</groupId>
+      <artifactId>georchestra-gateway-org-resolver-api</artifactId>
+    </dependency>
+
+    <!-- Spring Boot Dependencies -->
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-webflux</artifactId>
+    </dependency>
+
+    <!-- Lombok for boilerplate reduction -->
+    <dependency>
+      <groupId>org.projectlombok</groupId>
+      <artifactId>lombok</artifactId>
+      <optional>true</optional>
+    </dependency>
+
+    <!-- Spring Boot Configuration Processor -->
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-configuration-processor</artifactId>
+      <optional>true</optional>
+    </dependency>
+
+    <!-- Test Dependencies -->
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.projectreactor</groupId>
+      <artifactId>reactor-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/modules/sirene/pom.xml
+++ b/modules/sirene/pom.xml
@@ -12,10 +12,10 @@
   <description>Provides organization name resolution via the French SIRENE API (INSEE) or other pluggable organization resolvers</description>
 
   <dependencies>
-    <!-- Organization Resolver SPI -->
+    <!-- Organization Resolvers API -->
     <dependency>
       <groupId>org.georchestra</groupId>
-      <artifactId>georchestra-gateway-org-resolver-api</artifactId>
+      <artifactId>georchestra-gateway-org-resolvers</artifactId>
     </dependency>
 
     <!-- Spring Boot Dependencies -->

--- a/modules/sirene/src/main/java/org/georchestra/gateway/autoconfigure/sirene/SireneAutoConfiguration.java
+++ b/modules/sirene/src/main/java/org/georchestra/gateway/autoconfigure/sirene/SireneAutoConfiguration.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2024 by the geOrchestra PSC
+ *
+ * This file is part of geOrchestra.
+ *
+ * geOrchestra is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * geOrchestra is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * geOrchestra. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.georchestra.gateway.autoconfigure.sirene;
+
+import org.georchestra.gateway.orgresolvers.OrganizationNameResolver;
+import org.georchestra.gateway.security.sirene.SireneApiConfigProperties;
+import org.georchestra.gateway.security.sirene.SireneOrganizationNameResolver;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.http.client.JdkClientHttpRequestFactory;
+import org.springframework.web.client.RestClient;
+
+import jakarta.annotation.PostConstruct;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Auto-configuration for the SIRENE API organization name resolver.
+ * <p>
+ * This configuration is only active when
+ * {@code georchestra.gateway.security.sirene.enabled=true}.
+ * </p>
+ * <p>
+ * It registers a {@link SireneOrganizationNameResolver} bean backed by a
+ * {@link RestClient} configured with the SIRENE API base URL and authentication
+ * key.
+ * </p>
+ *
+ * @see SireneApiConfigProperties
+ * @see SireneOrganizationNameResolver
+ */
+@AutoConfiguration
+@ConditionalOnProperty(name = "georchestra.gateway.security.sirene.enabled", havingValue = "true", matchIfMissing = false)
+@EnableConfigurationProperties(SireneApiConfigProperties.class)
+@Slf4j(topic = "org.georchestra.gateway.autoconfigure.sirene")
+public class SireneAutoConfiguration {
+
+    @PostConstruct
+    public void log() {
+        log.info("SIRENE API organization name resolver enabled");
+    }
+
+    /**
+     * Creates a {@link RestClient} pre-configured for the INSEE SIRENE API.
+     *
+     * @param properties the SIRENE API configuration properties
+     * @return a configured {@link RestClient} instance
+     */
+    @Bean("sireneRestClient")
+    RestClient sireneRestClient(SireneApiConfigProperties properties) {
+        log.info("Configuring SIRENE API RestClient with base URL: {}", properties.getBaseUrl());
+//        Using JdkClientHttpRequestFactory as RestClient doesn't support blocking requests
+        return RestClient.builder().requestFactory(new JdkClientHttpRequestFactory()).baseUrl(properties.getBaseUrl())
+                .defaultHeader("X-INSEE-Api-Key-Integration", properties.getApiKey())
+                .defaultHeader("Accept", "application/json").build();
+    }
+
+    /**
+     * Creates the {@link OrganizationNameResolver} backed by the SIRENE API.
+     *
+     * @param restClient the RestClient configured for the SIRENE API
+     * @return an {@link OrganizationNameResolver} instance
+     */
+    @Bean
+    OrganizationNameResolver sireneOrganizationNameResolver(RestClient restClient) {
+        return new SireneOrganizationNameResolver(restClient);
+    }
+}

--- a/modules/sirene/src/main/java/org/georchestra/gateway/autoconfigure/sirene/SireneAutoConfiguration.java
+++ b/modules/sirene/src/main/java/org/georchestra/gateway/autoconfigure/sirene/SireneAutoConfiguration.java
@@ -21,6 +21,7 @@ package org.georchestra.gateway.autoconfigure.sirene;
 import org.georchestra.gateway.orgresolvers.OrganizationNameResolver;
 import org.georchestra.gateway.security.sirene.SireneApiConfigProperties;
 import org.georchestra.gateway.security.sirene.SireneOrganizationNameResolver;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -66,7 +67,7 @@ public class SireneAutoConfiguration {
     @Bean("sireneRestClient")
     RestClient sireneRestClient(SireneApiConfigProperties properties) {
         log.info("Configuring SIRENE API RestClient with base URL: {}", properties.getBaseUrl());
-//        Using JdkClientHttpRequestFactory as RestClient doesn't support blocking requests
+        // Using JdkClientHttpRequestFactory as reactive Webclient doesn't support blocking requests
         return RestClient.builder().requestFactory(new JdkClientHttpRequestFactory()).baseUrl(properties.getBaseUrl())
                 .defaultHeader("X-INSEE-Api-Key-Integration", properties.getApiKey())
                 .defaultHeader("Accept", "application/json").build();
@@ -79,7 +80,7 @@ public class SireneAutoConfiguration {
      * @return an {@link OrganizationNameResolver} instance
      */
     @Bean
-    OrganizationNameResolver sireneOrganizationNameResolver(RestClient restClient) {
+    OrganizationNameResolver sireneOrganizationNameResolver(@Qualifier("sireneRestClient") RestClient restClient) {
         return new SireneOrganizationNameResolver(restClient);
     }
 }

--- a/modules/sirene/src/main/java/org/georchestra/gateway/autoconfigure/sirene/SireneAutoConfiguration.java
+++ b/modules/sirene/src/main/java/org/georchestra/gateway/autoconfigure/sirene/SireneAutoConfiguration.java
@@ -67,7 +67,8 @@ public class SireneAutoConfiguration {
     @Bean("sireneRestClient")
     RestClient sireneRestClient(SireneApiConfigProperties properties) {
         log.info("Configuring SIRENE API RestClient with base URL: {}", properties.getBaseUrl());
-        // Using JdkClientHttpRequestFactory as reactive Webclient doesn't support blocking requests
+        // Using JdkClientHttpRequestFactory as reactive Webclient doesn't support
+        // blocking requests
         return RestClient.builder().requestFactory(new JdkClientHttpRequestFactory()).baseUrl(properties.getBaseUrl())
                 .defaultHeader("X-INSEE-Api-Key-Integration", properties.getApiKey())
                 .defaultHeader("Accept", "application/json").build();

--- a/modules/sirene/src/main/java/org/georchestra/gateway/security/sirene/SireneApiConfigProperties.java
+++ b/modules/sirene/src/main/java/org/georchestra/gateway/security/sirene/SireneApiConfigProperties.java
@@ -37,7 +37,7 @@ import lombok.Data;
  *       sirene:
  *         enabled: true
  *         api-key: ${SIRENE_API_KEY}
- *         base-url: https://api.insee.fr/entreprises/sirene/V3.11
+ *         base-url: https://api.insee.fr/api-sirene/3.11
  * }
  * </pre>
  */

--- a/modules/sirene/src/main/java/org/georchestra/gateway/security/sirene/SireneApiConfigProperties.java
+++ b/modules/sirene/src/main/java/org/georchestra/gateway/security/sirene/SireneApiConfigProperties.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2024 by the geOrchestra PSC
+ *
+ * This file is part of geOrchestra.
+ *
+ * geOrchestra is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * geOrchestra is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * geOrchestra. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.georchestra.gateway.security.sirene;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import lombok.Data;
+
+/**
+ * Configuration properties for the SIRENE API integration.
+ *
+ * <p>
+ * Example configuration in {@code application.yml}:
+ * </p>
+ *
+ * <pre>
+ * {@code
+ * georchestra:
+ *   gateway:
+ *     security:
+ *       sirene:
+ *         enabled: true
+ *         api-key: ${SIRENE_API_KEY}
+ *         base-url: https://api.insee.fr/entreprises/sirene/V3.11
+ * }
+ * </pre>
+ */
+@ConfigurationProperties(prefix = "georchestra.gateway.security.sirene")
+@Data
+public class SireneApiConfigProperties {
+
+    /**
+     * Whether the SIRENE API integration is enabled.
+     */
+    private boolean enabled = false;
+
+    /**
+     * The API key (Bearer token) for authenticating with the INSEE SIRENE API. Free
+     * keys can be obtained from https://portail-api.insee.fr/.
+     */
+    private String apiKey;
+
+    /**
+     * The base URL for the SIRENE API.
+     */
+    private String baseUrl = "https://api.insee.fr/api-sirene/3.11";
+}

--- a/modules/sirene/src/main/java/org/georchestra/gateway/security/sirene/SireneOrganizationNameResolver.java
+++ b/modules/sirene/src/main/java/org/georchestra/gateway/security/sirene/SireneOrganizationNameResolver.java
@@ -28,7 +28,6 @@ import org.georchestra.gateway.orgresolvers.ResolvedOrganization;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestClient;
-import org.springframework.web.reactive.function.client.WebClientResponseException;
 
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;

--- a/modules/sirene/src/main/java/org/georchestra/gateway/security/sirene/SireneOrganizationNameResolver.java
+++ b/modules/sirene/src/main/java/org/georchestra/gateway/security/sirene/SireneOrganizationNameResolver.java
@@ -1,0 +1,200 @@
+/*
+ * Copyright (C) 2024 by the geOrchestra PSC
+ *
+ * This file is part of geOrchestra.
+ *
+ * geOrchestra is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * geOrchestra is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * geOrchestra. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.georchestra.gateway.security.sirene;
+
+import java.text.Normalizer;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.georchestra.gateway.orgresolvers.OrganizationNameResolver;
+import org.georchestra.gateway.orgresolvers.ResolvedOrganization;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * {@link OrganizationNameResolver} implementation that calls the French INSEE
+ * SIRENE API to resolve organization names from SIRET numbers.
+ * <p>
+ * The API endpoint used is {@code GET {baseUrl}/siret/{siret}} with a Bearer
+ * token for authentication.
+ * </p>
+ * <p>
+ * Results are cached in-memory (keyed by SIRET) to avoid hitting the API rate
+ * limit (30 requests/min on the free tier).
+ * </p>
+ *
+ * <p>
+ * The organization name is extracted from the JSON response field
+ * {@code etablissement.uniteLegale.denominationUniteLegale}. For individual
+ * enterprises where this field is null,
+ * {@code prenomUsuelUniteLegale + " " + nomUsuelUniteLegale} is used instead.
+ * </p>
+ *
+ * @see SireneApiConfigProperties
+ */
+@Slf4j(topic = "org.georchestra.gateway.security.sirene")
+public class SireneOrganizationNameResolver implements OrganizationNameResolver {
+
+    private static final int SHORT_NAME_MAX_LENGTH = 32;
+
+    private final RestClient restClient;
+
+    /**
+     * Simple in-memory cache to avoid redundant API calls for the same SIRET. An
+     * empty Optional means a previous lookup returned no result; the key's absence
+     * means it has never been looked up.
+     */
+    private final ConcurrentHashMap<String, Optional<ResolvedOrganization>> cache = new ConcurrentHashMap<>();
+
+    /**
+     * Constructs a new resolver.
+     *
+     * @param restClient a pre-configured {@link RestClient} pointing at the SIRENE
+     *                   API base URL, with authentication headers set
+     */
+    public SireneOrganizationNameResolver(@NonNull RestClient restClient) {
+        this.restClient = restClient;
+    }
+
+    @Override
+    public Optional<ResolvedOrganization> resolve(String organizationIdentifier) {
+        if (organizationIdentifier == null || organizationIdentifier.isBlank()) {
+            return Optional.empty();
+        }
+
+        return cache.computeIfAbsent(organizationIdentifier, this::doResolve);
+    }
+
+    @SuppressWarnings("unchecked")
+    private Optional<ResolvedOrganization> doResolve(String siret) {
+        try {
+            log.info("Resolving organization name from SIRENE API for SIRET: {}", siret);
+
+            Map<String, Object> response = restClient.get().uri("/siret/{siret}", siret).retrieve()
+                    .onStatus(HttpStatusCode::is4xxClientError, (request, res) -> {
+                        throw new HttpClientErrorException(res.getStatusCode(), res.getStatusText());
+                    }).body(Map.class);
+
+            if (response == null) {
+                log.warn("SIRENE API returned null response for SIRET: {}", siret);
+                return Optional.empty();
+            }
+
+            Map<String, Object> etablissement = (Map<String, Object>) response.get("etablissement");
+            if (etablissement == null) {
+                log.warn("SIRENE API response missing 'etablissement' for SIRET: {}", siret);
+                return Optional.empty();
+            }
+
+            Map<String, Object> uniteLegale = (Map<String, Object>) etablissement.get("uniteLegale");
+            if (uniteLegale == null) {
+                log.warn("SIRENE API response missing 'uniteLegale' for SIRET: {}", siret);
+                return Optional.empty();
+            }
+
+            String orgName = extractOrgName(uniteLegale);
+            if (orgName == null || orgName.isBlank()) {
+                log.warn("Could not extract organization name from SIRENE API response for SIRET: {}", siret);
+                return Optional.empty();
+            }
+
+            String shortName = deriveShortName(orgName);
+            log.info("Resolved SIRET {} to organization: '{}' (short: '{}')", siret, orgName, shortName);
+            return Optional.of(new ResolvedOrganization(orgName, shortName));
+
+        } catch (HttpClientErrorException.NotFound e) {
+            log.warn("SIRET {} not found in SIRENE API (404)", siret);
+            return Optional.empty();
+        } catch (HttpClientErrorException.TooManyRequests e) {
+            log.warn("SIRENE API rate limit exceeded while resolving SIRET: {}", siret);
+            return Optional.empty();
+        } catch (Exception e) {
+            log.error("Error calling SIRENE API for SIRET: {}", siret, e);
+            return Optional.empty();
+        }
+    }
+
+    /**
+     * Extracts the organization name from the {@code uniteLegale} JSON object.
+     * <p>
+     * Uses {@code denominationUniteLegale} for legal entities. For individual
+     * enterprises, falls back to
+     * {@code prenomUsuelUniteLegale + " " + nomUsuelUniteLegale}.
+     * </p>
+     */
+    private String extractOrgName(Map<String, Object> uniteLegale) {
+        String denomination = (String) uniteLegale.get("denominationUniteLegale");
+        if (denomination != null && !denomination.isBlank()) {
+            return denomination.trim();
+        }
+
+        // Individual enterprise fallback
+        String prenom = (String) uniteLegale.get("prenomUsuelUniteLegale");
+        String nom = (String) uniteLegale.get("nomUsuelUniteLegale");
+        if (nom != null && !nom.isBlank()) {
+            StringBuilder sb = new StringBuilder();
+            if (prenom != null && !prenom.isBlank()) {
+                sb.append(prenom.trim()).append(" ");
+            }
+            sb.append(nom.trim());
+            return sb.toString();
+        }
+
+        return null;
+    }
+
+    /**
+     * Derives a short name from the full organization name.
+     * <p>
+     * The short name is:
+     * <ul>
+     * <li>Uppercased</li>
+     * <li>Unicode-normalized and stripped of diacritical marks</li>
+     * <li>Whitespace and special characters removed</li>
+     * <li>Truncated to 32 characters</li>
+     * </ul>
+     * </p>
+     *
+     * @param orgName the full organization name
+     * @return the derived short name
+     */
+    static String deriveShortName(String orgName) {
+        String upper = orgName.toUpperCase();
+
+        // Normalize Unicode and remove diacritical marks
+        String normalized = Normalizer.normalize(upper, Normalizer.Form.NFD);
+        normalized = normalized.replaceAll("\\p{InCombiningDiacriticalMarks}+", "");
+
+        // Remove all non-alphanumeric characters
+        normalized = normalized.replaceAll("[^A-Z0-9]", "");
+
+        // Truncate to max length
+        if (normalized.length() > SHORT_NAME_MAX_LENGTH) {
+            normalized = normalized.substring(0, SHORT_NAME_MAX_LENGTH);
+        }
+
+        return normalized;
+    }
+}

--- a/modules/sirene/src/main/java/org/georchestra/gateway/security/sirene/SireneOrganizationNameResolver.java
+++ b/modules/sirene/src/main/java/org/georchestra/gateway/security/sirene/SireneOrganizationNameResolver.java
@@ -78,6 +78,11 @@ public class SireneOrganizationNameResolver implements OrganizationNameResolver 
     }
 
     @Override
+    public String getOrgNameResolverEntry() {
+        return "sirene";
+    }
+
+    @Override
     public Optional<ResolvedOrganization> resolve(String organizationIdentifier) {
         if (organizationIdentifier == null || organizationIdentifier.isBlank()) {
             return Optional.empty();

--- a/modules/sirene/src/main/java/org/georchestra/gateway/security/sirene/SireneOrganizationNameResolver.java
+++ b/modules/sirene/src/main/java/org/georchestra/gateway/security/sirene/SireneOrganizationNameResolver.java
@@ -65,7 +65,8 @@ public class SireneOrganizationNameResolver implements OrganizationNameResolver 
      * empty Optional means a previous lookup returned no result; the key's absence
      * means it has never been looked up.
      */
-    private final ConcurrentHashMap<String, Optional<ResolvedOrganization>> cache = new ConcurrentHashMap<>();
+     // Uncomment to enable cache for Sirene API, may be useful if users from same organization connects in a short time frame.
+     // private final ConcurrentHashMap<String, Optional<ResolvedOrganization>> cache = new ConcurrentHashMap<>();
 
     /**
      * Constructs a new resolver.
@@ -88,7 +89,9 @@ public class SireneOrganizationNameResolver implements OrganizationNameResolver 
             return Optional.empty();
         }
 
-        return cache.computeIfAbsent(organizationIdentifier, this::doResolve);
+        // Uncomment to enable cache for Sirene API, may be useful if users from same organization connects in a short time frame.
+        // return cache.computeIfAbsent(organizationIdentifier, this::doResolve);
+        return doResolve(organizationIdentifier);
     }
 
     @SuppressWarnings("unchecked")
@@ -98,7 +101,8 @@ public class SireneOrganizationNameResolver implements OrganizationNameResolver 
 
             Map<String, Object> response = restClient.get().uri("/siret/{siret}", siret).retrieve()
                     .onStatus(HttpStatusCode::is4xxClientError, (request, res) -> {
-                        throw new HttpClientErrorException(res.getStatusCode(), res.getStatusText());
+                        throw HttpClientErrorException.create(res.getStatusCode(),
+                                res.getStatusText(), res.getHeaders(), null, null);
                     }).body(Map.class);
 
             if (response == null) {

--- a/modules/sirene/src/main/java/org/georchestra/gateway/security/sirene/SireneOrganizationNameResolver.java
+++ b/modules/sirene/src/main/java/org/georchestra/gateway/security/sirene/SireneOrganizationNameResolver.java
@@ -26,6 +26,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import org.georchestra.gateway.orgresolvers.OrganizationNameResolver;
 import org.georchestra.gateway.orgresolvers.ResolvedOrganization;
 import org.springframework.http.HttpStatusCode;
+import org.springframework.util.StringUtils;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestClient;
 
@@ -97,7 +98,7 @@ public class SireneOrganizationNameResolver implements OrganizationNameResolver 
     @SuppressWarnings("unchecked")
     private Optional<ResolvedOrganization> doResolve(String siret) {
         try {
-            log.info("Resolving organization name from SIRENE API for SIRET: {}", siret);
+            log.debug("Resolving organization name from SIRENE API for SIRET: {}", siret);
 
             Map<String, Object> response = restClient.get().uri("/siret/{siret}", siret).retrieve()
                     .onStatus(HttpStatusCode::is4xxClientError, (request, res) -> {
@@ -123,13 +124,13 @@ public class SireneOrganizationNameResolver implements OrganizationNameResolver 
             }
 
             String orgName = extractOrgName(uniteLegale);
-            if (orgName == null || orgName.isBlank()) {
+            if (!StringUtils.hasText(orgName)) {
                 log.warn("Could not extract organization name from SIRENE API response for SIRET: {}", siret);
                 return Optional.empty();
             }
 
             String shortName = deriveShortName(orgName);
-            log.info("Resolved SIRET {} to organization: '{}' (short: '{}')", siret, orgName, shortName);
+            log.debug("Resolved SIRET {} to organization: '{}' (short: '{}')", siret, orgName, shortName);
             return Optional.of(new ResolvedOrganization(orgName, shortName));
 
         } catch (HttpClientErrorException.NotFound e) {

--- a/modules/sirene/src/main/java/org/georchestra/gateway/security/sirene/SireneOrganizationNameResolver.java
+++ b/modules/sirene/src/main/java/org/georchestra/gateway/security/sirene/SireneOrganizationNameResolver.java
@@ -66,8 +66,10 @@ public class SireneOrganizationNameResolver implements OrganizationNameResolver 
      * empty Optional means a previous lookup returned no result; the key's absence
      * means it has never been looked up.
      */
-     // Uncomment to enable cache for Sirene API, may be useful if users from same organization connects in a short time frame.
-     // private final ConcurrentHashMap<String, Optional<ResolvedOrganization>> cache = new ConcurrentHashMap<>();
+    // Uncomment to enable cache for Sirene API, may be useful if users from same
+    // organization connects in a short time frame.
+    // private final ConcurrentHashMap<String, Optional<ResolvedOrganization>> cache
+    // = new ConcurrentHashMap<>();
 
     /**
      * Constructs a new resolver.
@@ -90,7 +92,8 @@ public class SireneOrganizationNameResolver implements OrganizationNameResolver 
             return Optional.empty();
         }
 
-        // Uncomment to enable cache for Sirene API, may be useful if users from same organization connects in a short time frame.
+        // Uncomment to enable cache for Sirene API, may be useful if users from same
+        // organization connects in a short time frame.
         // return cache.computeIfAbsent(organizationIdentifier, this::doResolve);
         return doResolve(organizationIdentifier);
     }
@@ -102,8 +105,8 @@ public class SireneOrganizationNameResolver implements OrganizationNameResolver 
 
             Map<String, Object> response = restClient.get().uri("/siret/{siret}", siret).retrieve()
                     .onStatus(HttpStatusCode::is4xxClientError, (request, res) -> {
-                        throw HttpClientErrorException.create(res.getStatusCode(),
-                                res.getStatusText(), res.getHeaders(), null, null);
+                        throw HttpClientErrorException.create(res.getStatusCode(), res.getStatusText(),
+                                res.getHeaders(), null, null);
                     }).body(Map.class);
 
             if (response == null) {

--- a/modules/sirene/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/modules/sirene/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,2 @@
+org.georchestra.gateway.autoconfigure.sirene.SireneAutoConfiguration
+

--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
       </dependency>
       <dependency>
         <groupId>org.georchestra</groupId>
-        <artifactId>georchestra-gateway-org-resolver-api</artifactId>
+        <artifactId>georchestra-gateway-org-resolvers</artifactId>
         <version>${revision}</version>
       </dependency>
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.springframework.cloud</groupId>
     <artifactId>spring-cloud-starter-parent</artifactId>
-    <version>2025.0.1</version>
+    <version>2025.0.2</version>
     <relativePath></relativePath>
     <!-- lookup parent from repository -->
   </parent>
@@ -69,6 +69,16 @@
       <dependency>
         <groupId>org.georchestra</groupId>
         <artifactId>georchestra-gateway-logging</artifactId>
+        <version>${revision}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.georchestra</groupId>
+        <artifactId>georchestra-gateway-org-resolver-api</artifactId>
+        <version>${revision}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.georchestra</groupId>
+        <artifactId>georchestra-gateway-sirene</artifactId>
         <version>${revision}</version>
       </dependency>
       <!--spring-security-oauth2 dependencies version forced to 5.6.2


### PR DESCRIPTION
Adds a new pluggable “organization name resolver” SPI and integrates a SIRENE (INSEE) implementation to resolve organization names (and short names) from identifiers (e.g., SIRET) during OIDC/LDAP account provisioning.

Changes:

Introduces georchestra-gateway-org-resolvers (SPI) and georchestra-gateway-sirene (SIRENE resolver + auto-configuration) modules.
Extends OIDC provider config and LDAP account management to optionally resolve/override organization names via a configurable resolver chain.
Updates build/dependency wiring (parent, modules list, gateway deps, Makefile docker targets) and adds example configuration.