### PR TITLE
feat: adding micrometer-registry-prometheus as dependency

### DIFF
--- a/gateway/pom.xml
+++ b/gateway/pom.xml
@@ -126,6 +126,10 @@
       </exclusions>
     </dependency>
     <dependency>
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-registry-prometheus</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.wiremock.integrations</groupId>
       <artifactId>wiremock-spring-boot</artifactId>
       <scope>test</scope>


### PR DESCRIPTION
This allows to have a `/prometheus` on the actuator endpoint (default configuration have them onto the `8090` port).

The metrics being published on the endpoint are quite similar to the ones we had before with Jetty + jmx + collectd, the main benefit here is that the setup is less complex.

Tests: runtime tested onto the new-app's sample docker composition.