### PR TITLE
Allow disabling LDAP form login while keeping HTTP Basic enabled

### DIFF
--- a/datadir/gateway/security.yaml
+++ b/datadir/gateway/security.yaml
@@ -35,6 +35,11 @@ georchestra:
           port: 8000
           username: jack
           password: insecure
+
+      # Disable LDAP form login while keeping LDAP HTTP Basic authentication enabled.
+      # Useful when LDAP must remain available for technical clients, while browser
+      # users should authenticate only through OAuth2/OIDC.
+      disableLdapFormLogin: false
       ldap:
         # Multiple LDAP data sources are supported. The first key defines a simple
         # name for them. The `default` one here, disabled by default, is pre-configured

--- a/gateway/src/main/java/org/georchestra/gateway/app/LoginLogoutController.java
+++ b/gateway/src/main/java/org/georchestra/gateway/app/LoginLogoutController.java
@@ -73,8 +73,8 @@ public class LoginLogoutController {
     /** Configuration properties for gateway security, including LDAP settings. */
     private @Autowired(required = false) GeorchestraGatewaySecurityConfigProperties georchestraGatewaySecurityConfigProperties;
 
-    /** Whether LDAP authentication is enabled. */
-    private boolean ldapEnabled;
+    /** Whether LDAP form login is enabled. */
+    private boolean ldapFormLoginEnabled;
 
     /** OAuth2 client configuration, if available. */
     private @Autowired(required = false) OAuth2ClientProperties oauth2ClientConfig;
@@ -118,8 +118,10 @@ public class LoginLogoutController {
     @PostConstruct
     void initialize() {
         if (georchestraGatewaySecurityConfigProperties != null) {
-            ldapEnabled = georchestraGatewaySecurityConfigProperties.getLdap().values().stream()
+            boolean ldapEnabled = georchestraGatewaySecurityConfigProperties.getLdap().values().stream()
                     .anyMatch(Server::isEnabled);
+
+            ldapFormLoginEnabled = ldapEnabled && !georchestraGatewaySecurityConfigProperties.isDisableLdapFormLogin();
         }
     }
 
@@ -181,14 +183,15 @@ public class LoginLogoutController {
             });
         }
 
-        // Auto-redirect if only one OAuth2 provider is available and LDAP is disabled
-        if (oauth2LoginLinks.size() == 1 && !ldapEnabled) {
+        // Auto-redirect if only one OAuth2 provider is available and LDAP form login is
+        // disabled
+        if (oauth2LoginLinks.size() == 1 && !ldapFormLoginEnabled) {
             return "redirect:" + oauth2LoginLinks.keySet().stream().findFirst().orElseThrow();
         }
 
         // Set model attributes for login page rendering
         setHeaderAttributes(model);
-        model.addAttribute("ldapEnabled", ldapEnabled);
+        model.addAttribute("ldapFormLoginEnabled", ldapFormLoginEnabled);
         model.addAttribute("oauth2LoginLinks", oauth2LoginLinks);
 
         // Handle authentication error messages

--- a/gateway/src/main/java/org/georchestra/gateway/security/GeorchestraGatewaySecurityConfigProperties.java
+++ b/gateway/src/main/java/org/georchestra/gateway/security/GeorchestraGatewaySecurityConfigProperties.java
@@ -71,6 +71,11 @@ public class GeorchestraGatewaySecurityConfigProperties implements Validator {
     private boolean createNonExistingUsersInLDAP = true;
 
     /**
+     * Disable LDAP form login while keeping LDAP HTTP Basic authentication enabled.
+     */
+    private boolean disableLdapFormLogin = false;
+
+    /**
      * Flag indicating whether the user should be redirected to a page causing a
      * configureable delay after a successful login. Defaults to 0, which
      * deactivates the feature.

--- a/gateway/src/main/java/org/georchestra/gateway/security/ldap/LdapAuthenticationConfiguration.java
+++ b/gateway/src/main/java/org/georchestra/gateway/security/ldap/LdapAuthenticationConfiguration.java
@@ -91,6 +91,12 @@ public class LdapAuthenticationConfiguration {
      * Enables HTTP Basic authentication and form login for LDAP authentication.
      */
     public static final class LDAPAuthenticationCustomizer implements ServerHttpSecurityCustomizer {
+        private final GeorchestraGatewaySecurityConfigProperties securityConfig;
+
+        public LDAPAuthenticationCustomizer(GeorchestraGatewaySecurityConfigProperties securityConfig) {
+            this.securityConfig = securityConfig;
+        }
+
         /**
          * Configures HTTP Basic authentication and form login.
          *
@@ -98,7 +104,14 @@ public class LdapAuthenticationConfiguration {
          */
         public @Override void customize(ServerHttpSecurity http) {
             log.info("Enabling HTTP Basic authentication support for LDAP");
-            http.httpBasic(withDefaults()).formLogin(withDefaults());
+            http.httpBasic(withDefaults());
+
+            if (!securityConfig.isDisableLdapFormLogin()) {
+                log.info("Enabling form login support for LDAP");
+                http.formLogin(withDefaults());
+            } else {
+                log.info("LDAP form login support is disabled");
+            }
         }
     }
 
@@ -109,8 +122,9 @@ public class LdapAuthenticationConfiguration {
      * @return a {@link ServerHttpSecurityCustomizer} for LDAP authentication
      */
     @Bean
-    ServerHttpSecurityCustomizer ldapHttpBasicLoginFormEnablerExtension() {
-        return new LDAPAuthenticationCustomizer();
+    ServerHttpSecurityCustomizer ldapHttpBasicLoginFormEnablerExtension(
+            GeorchestraGatewaySecurityConfigProperties securityConfig) {
+        return new LDAPAuthenticationCustomizer(securityConfig);
     }
 
     /**

--- a/gateway/src/main/resources/templates/login.html
+++ b/gateway/src/main/resources/templates/login.html
@@ -30,7 +30,7 @@
                 <a href="/" class="d-flex align-items-center justify-content-center" th:if="${not headerEnabled}">
                     <img th:src="${logoUrl}" alt="" width="200" height="72">
                 </a>
-                <form class="form-signin" method="post" action="/login" th:if="${ldapEnabled}">
+                <form class="form-signin" method="post" action="/login" th:if="${ldapFormLoginEnabled}">
                     <h2 class="form-signin-heading"><span th:text="#{login_message_title}"/></h2>
                     <h4 class="fs-6 fw-light"><span th:text="#{login_message_subtitle}"/></h4>
                     <div class="my-4 text-danger text-center"


### PR DESCRIPTION
## Context

LDAP authentication currently enables both HTTP Basic and form login.

This makes it difficult to keep LDAP Basic Auth available for technical clients while avoiding an extra LDAP login option for browser users.

## Changes

This PR adds a new `disableLdapFormLogin` option under `georchestra.gateway.security`.

Default behavior is unchanged.

```yaml
georchestra:
  gateway:
    security:
      disableLdapFormLogin: true
      ldap:
        default:
          enabled: true
```

When `disableLdapFormLogin` is set to `true`:

* LDAP HTTP Basic remains enabled;
* LDAP form login is not enabled;
* the login page no longer displays the LDAP form;
* when only one OAuth2/OIDC provider is configured, browser users can still be redirected directly to that provider.

## Backward compatibility

The default value is `false`, so existing configurations keep the current behavior:

```text
LDAP enabled -> HTTP Basic + form login
```

## Testing note

I was able to validate the code-level behavior locally, but I have not yet been able to run a full deployment/integration test in real conditions.

I am currently away and will only be able to perform deployment-level testing next week. Feedback on the approach is welcome in the meantime.